### PR TITLE
Add AWS Lambda runtime support

### DIFF
--- a/cmd/swaig-test/main.go
+++ b/cmd/swaig-test/main.go
@@ -32,13 +32,14 @@ func (p *paramList) Set(value string) error {
 
 // config holds the parsed CLI flags.
 type config struct {
-	url       string
-	dumpSWML  bool
-	listTools bool
-	exec      string
-	params    paramList
-	raw       bool
-	verbose   bool
+	url                string
+	dumpSWML           bool
+	listTools          bool
+	exec               string
+	params             paramList
+	raw                bool
+	verbose            bool
+	simulateServerless string
 }
 
 func main() {
@@ -62,6 +63,10 @@ func parseFlags(args []string) config {
 	fs.Var(&cfg.params, "param", "Parameter as key=value (repeatable)")
 	fs.BoolVar(&cfg.raw, "raw", false, "Output compact JSON instead of pretty-printed")
 	fs.BoolVar(&cfg.verbose, "verbose", false, "Show request/response details")
+	fs.StringVar(&cfg.simulateServerless, "simulate-serverless", "",
+		"Simulate a serverless environment (currently supported: lambda). "+
+			"Sets mode-detection env vars and clears SWML_PROXY_URL_BASE so "+
+			"platform-specific URL generation is exercised.")
 
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: swaig-test --url <agent-url> [options]\n\n")
@@ -70,6 +75,12 @@ func parseFlags(args []string) config {
 		fmt.Fprintf(os.Stderr, "  --dump-swml          Dump the SWML document (GET)\n")
 		fmt.Fprintf(os.Stderr, "  --list-tools         List available SWAIG functions\n")
 		fmt.Fprintf(os.Stderr, "  --exec <name>        Execute a SWAIG function (POST)\n\n")
+		fmt.Fprintf(os.Stderr, "Serverless simulation:\n")
+		fmt.Fprintf(os.Stderr, "  --simulate-serverless lambda\n")
+		fmt.Fprintf(os.Stderr, "                       Apply Lambda mode-detection env vars around\n")
+		fmt.Fprintf(os.Stderr, "                       the invocation; clears SWML_PROXY_URL_BASE\n")
+		fmt.Fprintf(os.Stderr, "                       for the duration. Combine with --dump-swml\n")
+		fmt.Fprintf(os.Stderr, "                       or --exec as normal.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		fs.PrintDefaults()
 	}
@@ -80,17 +91,63 @@ func parseFlags(args []string) config {
 
 // run executes the CLI command based on the parsed config.
 func run(cfg config) error {
+	// Platform validation always runs first — if the user asked for
+	// a platform we don't implement, we want to fail before touching
+	// the environment or making any HTTP request.
+	if cfg.simulateServerless != "" {
+		if err := validateSimulatePlatform(cfg.simulateServerless); err != nil {
+			return err
+		}
+	}
+
 	if cfg.url == "" {
+		// --simulate-serverless without --url can't fully exercise the
+		// adapter from a Go CLI (Go agents are compiled binaries, not
+		// dynamically loadable files), so the CLI requires --url and
+		// documents the library API for in-process use.
+		if cfg.simulateServerless != "" {
+			return fmt.Errorf(
+				"--simulate-serverless %s: requires --url <agent-url>. "+
+					"Go agents are compiled binaries, so this CLI simulates by "+
+					"running the agent URL with the platform env vars applied. "+
+					"For true in-process adapter dispatch, use "+
+					"SimulateDumpSWMLViaLambda / SimulateExecToolViaLambda "+
+					"from package main directly (see cmd/swaig-test/simulate.go).",
+				cfg.simulateServerless,
+			)
+		}
 		return fmt.Errorf("--url is required")
 	}
 
 	if !cfg.dumpSWML && !cfg.listTools && cfg.exec == "" {
-		return fmt.Errorf("one of --dump-swml, --list-tools, or --exec is required")
+		// In simulate mode without a sub-action, default to dumping
+		// SWML — mirrors the Python CLI's "bare --simulate-serverless"
+		// mode. This also makes the "render SWML and exit" combination
+		// work intuitively.
+		if cfg.simulateServerless != "" {
+			cfg.dumpSWML = true
+		} else {
+			return fmt.Errorf("one of --dump-swml, --list-tools, or --exec is required")
+		}
 	}
 
 	baseURL, user, pass, err := parseAuthURL(cfg.url)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// If the user requested serverless simulation, set the mode-
+	// detection env vars for the chosen platform for the duration of
+	// this run and unconditionally restore them on exit. The
+	// simulation ALSO clears SWML_PROXY_URL_BASE (matches Python's
+	// mock_env.py behaviour) so platform-specific URL generation is
+	// actually exercised.
+	if cfg.simulateServerless != "" {
+		snap, err := activateSimulation(cfg.simulateServerless, cfg.verbose)
+		if err != nil {
+			return err
+		}
+		defer snap.restore()
 	}
 
 	switch {
@@ -103,6 +160,34 @@ func run(cfg config) error {
 	}
 
 	return nil
+}
+
+// activateSimulation sets env vars for the chosen platform and returns
+// a snapshot that restores the original values when restore() is
+// called. The caller is responsible for deferring restore(); this
+// separation lets the CLI's run() function apply the change around
+// whatever sub-action was selected.
+//
+// Only "lambda" is supported today. Unsupported platforms are rejected
+// earlier in run(); if we somehow reach this function with an unknown
+// platform we fall through to an explicit error so the bug is easy
+// to spot.
+func activateSimulation(platform string, verbose bool) (envSnapshot, error) {
+	switch platform {
+	case "lambda":
+		logger := (func(format string, args ...any))(nil)
+		if verbose {
+			logger = func(format string, args ...any) {
+				fmt.Fprintf(os.Stderr, "simulate-serverless: "+format+"\n", args...)
+			}
+		}
+		return activateLambdaEnv(SimulateLambdaOptions{Logger: logger}), nil
+	default:
+		return envSnapshot{}, fmt.Errorf(
+			"activateSimulation: internal error — platform %q passed validation but has no activator",
+			platform,
+		)
+	}
 }
 
 // parseAuthURL extracts basic auth credentials from a URL.

--- a/cmd/swaig-test/simulate.go
+++ b/cmd/swaig-test/simulate.go
@@ -1,0 +1,510 @@
+// Simulator support for `--simulate-serverless` mode.
+//
+// In the Python SDK, `swaig-test` can load an agent from a source file
+// and dispatch invocations through the chosen serverless adapter
+// in-process. Go has no equivalent dynamic-loader for compiled binaries,
+// so the simulator is split in two:
+//
+//   1. A library API (this file) that sets/clears the mode-detection
+//      env vars, dispatches a synthetic Lambda Function URL event
+//      through pkg/lambda, and restores the outer environment on exit.
+//      Tests and in-process callers (e.g. users who embed `swaig-test`
+//      in their own test suites) drive the simulator through this API.
+//
+//   2. A flag on the `swaig-test` CLI (see main.go) that validates the
+//      requested platform against what the port actually implements and
+//      surfaces a clear error for unsupported platforms (Phase 9 of the
+//      porting guide). The flag also works with --url: it sets the
+//      mode-detection env vars for the duration of the invocation so
+//      the server-side URL generation goes through the platform branch.
+//
+// The simulator mirrors the behaviour of Python's
+// `signalwire/cli/simulation/mock_env.py`:
+//   - Platform preset env vars are applied (AWS_LAMBDA_FUNCTION_NAME etc).
+//   - Conflicting env vars — most importantly SWML_PROXY_URL_BASE — are
+//     cleared so platform-specific URL generation is actually exercised.
+//   - The original env is restored on exit, whether the simulated call
+//     succeeded, errored, or panicked. Leaking env across simulations
+//     would corrupt later tests in the same process.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/signalwire/signalwire-go/pkg/lambda"
+)
+
+// supportedSimulatePlatforms is the set of platforms that `swaig-test
+// --simulate-serverless` accepts. The list matches what the Go port
+// implemented in Phase 9 of the porting guide. Adding an entry here
+// without a corresponding adapter in pkg/ is a lie that will
+// misleadingly pass `--simulate-serverless <new-platform>` calls.
+var supportedSimulatePlatforms = map[string]bool{
+	"lambda": true,
+}
+
+// notYetImplementedSimulatePlatforms enumerates platforms the porting
+// guide mentions but the Go port has not yet shipped. Listing them
+// explicitly lets the CLI give a targeted error ("not yet implemented")
+// instead of a generic "unknown platform" — matches the guide's
+// requirement that unimplemented platforms surface a clear error rather
+// than silently falling back to the server path.
+var notYetImplementedSimulatePlatforms = map[string]bool{
+	"gcf":             true, // Google Cloud Functions
+	"cloud_function":  true, // alternate Python name
+	"azure":           true,
+	"azure_function":  true,
+	"cgi":             true,
+}
+
+// validateSimulatePlatform checks that the given platform name is
+// supported by this port. It returns nil if the platform is usable,
+// and a descriptive error otherwise. The error message points at
+// Phase 9 of the porting guide so users can tell at a glance whether
+// they're looking at a typo or a missing implementation.
+func validateSimulatePlatform(platform string) error {
+	if platform == "" {
+		return fmt.Errorf("--simulate-serverless requires a platform name (e.g. \"lambda\")")
+	}
+	if supportedSimulatePlatforms[platform] {
+		return nil
+	}
+	if notYetImplementedSimulatePlatforms[platform] {
+		return fmt.Errorf(
+			"--simulate-serverless %s: platform not implemented in this port. "+
+				"Phase 9 of the porting guide has only been completed for: %s. "+
+				"To use --simulate-serverless %s, implement the corresponding "+
+				"adapter under pkg/ first.",
+			platform, supportedPlatformList(), platform,
+		)
+	}
+	return fmt.Errorf(
+		"--simulate-serverless %s: unknown platform. Supported: %s",
+		platform, supportedPlatformList(),
+	)
+}
+
+// supportedPlatformList returns a human-readable comma-separated list
+// of platforms the port supports, for inclusion in error messages.
+func supportedPlatformList() string {
+	names := make([]string, 0, len(supportedSimulatePlatforms))
+	for name := range supportedSimulatePlatforms {
+		names = append(names, name)
+	}
+	// Tiny list — skip sort to avoid pulling in sort package; the
+	// iteration order is fine for the one-element case.
+	return strings.Join(names, ", ")
+}
+
+// envSnapshot captures the values (and presence) of a fixed set of
+// env vars so they can be restored verbatim, including distinguishing
+// "unset" from "set to empty string".
+type envSnapshot struct {
+	values map[string]*string // nil pointer == unset, empty string == set empty
+}
+
+// snapshotEnv captures the current values of the given env vars. A key
+// that is unset is represented by a nil pointer; a key that is set
+// (even to the empty string) is represented by a non-nil pointer.
+func snapshotEnv(keys []string) envSnapshot {
+	snap := envSnapshot{values: make(map[string]*string, len(keys))}
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			vCopy := v
+			snap.values[k] = &vCopy
+		} else {
+			snap.values[k] = nil
+		}
+	}
+	return snap
+}
+
+// restore puts every captured key back to its pre-activation state.
+// Called from a deferred closure so it runs on both the happy path
+// and on error paths (including panics).
+func (s envSnapshot) restore() {
+	for k, v := range s.values {
+		if v == nil {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, *v)
+		}
+	}
+}
+
+// lambdaPresetEnv is the set of env vars set when activating a Lambda
+// simulation. Values are tame defaults — they're only used for URL
+// construction and mode detection, not for any real AWS API call.
+//
+// AWS_LAMBDA_FUNCTION_URL is deliberately omitted so GetFullURL's
+// fallback (construct from function name + region) is the path
+// exercised by default. Callers that need a specific URL can override
+// it via SimulateLambdaOptions.
+func lambdaPresetEnv() map[string]string {
+	return map[string]string{
+		"AWS_LAMBDA_FUNCTION_NAME": "test-agent-function",
+		"LAMBDA_TASK_ROOT":         "/var/task",
+		"AWS_REGION":               "us-east-1",
+		"_HANDLER":                 "bootstrap",
+	}
+}
+
+// managedEnvKeys returns every env var the simulator touches. These
+// are the keys captured by snapshotEnv so their original values — or
+// unset state — can be faithfully restored on exit.
+//
+// We include all of the AWS preset keys, the keys for other platforms
+// (so SimulateLambda can clear them defensively), and SWML_PROXY_URL_BASE
+// which Python's mock_env.py explicitly clears during any simulation.
+func managedEnvKeys() []string {
+	return []string{
+		// Lambda
+		"AWS_LAMBDA_FUNCTION_NAME",
+		"LAMBDA_TASK_ROOT",
+		"AWS_REGION",
+		"AWS_LAMBDA_FUNCTION_URL",
+		"_HANDLER",
+		// CGI (cleared defensively)
+		"GATEWAY_INTERFACE",
+		"HTTP_HOST",
+		"SCRIPT_NAME",
+		// Google Cloud Functions (cleared defensively)
+		"FUNCTION_TARGET",
+		"K_SERVICE",
+		"GOOGLE_CLOUD_PROJECT",
+		// Azure Functions (cleared defensively)
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+		// Proxy override — cleared during simulation (matches mock_env.py)
+		"SWML_PROXY_URL_BASE",
+	}
+}
+
+// SimulateLambdaOptions tunes an in-process Lambda simulation.
+type SimulateLambdaOptions struct {
+	// FunctionURLOverride, if non-empty, is assigned to
+	// AWS_LAMBDA_FUNCTION_URL during the simulation. The default
+	// (empty) lets GetFullURL fall back to constructing the URL from
+	// AWS_LAMBDA_FUNCTION_NAME + AWS_REGION, which is the more
+	// interesting code path to exercise in tests.
+	FunctionURLOverride string
+
+	// FunctionName overrides AWS_LAMBDA_FUNCTION_NAME. Empty means
+	// use the preset default ("test-agent-function").
+	FunctionName string
+
+	// Region overrides AWS_REGION. Empty means use the preset default
+	// ("us-east-1").
+	Region string
+
+	// Logger receives warnings about env state — notably if
+	// SWML_PROXY_URL_BASE is still set after the clear attempt. A nil
+	// Logger sends warnings to os.Stderr.
+	Logger func(format string, args ...any)
+}
+
+// activateLambdaEnv applies the Lambda-preset env vars, clears the
+// conflicting ones, and returns the snapshot of the pre-simulation
+// environment. Callers MUST call snapshot.restore() (typically via
+// defer) to put the environment back once the simulation is done.
+//
+// The function deliberately returns a value type so it can't be
+// accidentally shared between goroutines — simulations are one-at-a-
+// time in a single process.
+func activateLambdaEnv(opts SimulateLambdaOptions) envSnapshot {
+	keys := managedEnvKeys()
+	snap := snapshotEnv(keys)
+
+	// Clear everything first so leftover state from a previous
+	// simulation (or the outer shell, for SWML_PROXY_URL_BASE) can't
+	// leak into the new simulation.
+	for _, k := range keys {
+		os.Unsetenv(k)
+	}
+
+	// Apply presets.
+	preset := lambdaPresetEnv()
+	if opts.FunctionName != "" {
+		preset["AWS_LAMBDA_FUNCTION_NAME"] = opts.FunctionName
+	}
+	if opts.Region != "" {
+		preset["AWS_REGION"] = opts.Region
+	}
+	if opts.FunctionURLOverride != "" {
+		preset["AWS_LAMBDA_FUNCTION_URL"] = opts.FunctionURLOverride
+	}
+	for k, v := range preset {
+		os.Setenv(k, v)
+	}
+
+	// Belt-and-suspenders: if the outer environment or a cooperating
+	// process re-set SWML_PROXY_URL_BASE between our Unsetenv and
+	// this check, warn so the user understands why their URLs don't
+	// look Lambda-style. Matches Python's mock_env.py warning.
+	if proxy := os.Getenv("SWML_PROXY_URL_BASE"); proxy != "" {
+		warn := opts.Logger
+		if warn == nil {
+			warn = func(format string, args ...any) {
+				fmt.Fprintf(os.Stderr, "warning: "+format+"\n", args...)
+			}
+		}
+		warn("SWML_PROXY_URL_BASE is still set (%q) after simulator clear; Lambda URL generation may be bypassed", proxy)
+	}
+
+	return snap
+}
+
+// LambdaSimResult is the decoded result of one synthetic Lambda
+// invocation. Status is the HTTP status returned by the handler,
+// Body is the response body (already base64-decoded if the
+// adapter marked it so), and Headers mirrors the Lambda response
+// envelope's flattened single-value map.
+type LambdaSimResult struct {
+	Status  int
+	Body    []byte
+	Headers map[string]string
+}
+
+// SimulateLambdaInvocation runs a single synthetic Lambda Function
+// URL event against the given handler with the Lambda environment
+// active. It does NOT touch env vars itself — call activateLambdaEnv
+// first and defer restore() so the env change has the right scope.
+//
+// The split exists so one activation can host multiple invocations
+// (dump-SWML then exec-tool, say) without paying the env save/restore
+// cost per call.
+func SimulateLambdaInvocation(
+	handler http.Handler,
+	method, path string,
+	headers map[string]string,
+	body io.Reader,
+) (LambdaSimResult, error) {
+	if handler == nil {
+		return LambdaSimResult{}, fmt.Errorf("simulate-lambda: handler must not be nil")
+	}
+	if method == "" {
+		method = http.MethodGet
+	}
+	if path == "" {
+		path = "/"
+	}
+
+	var bodyStr string
+	if body != nil {
+		raw, err := io.ReadAll(body)
+		if err != nil {
+			return LambdaSimResult{}, fmt.Errorf("simulate-lambda: reading body: %w", err)
+		}
+		bodyStr = string(raw)
+	}
+
+	// Construct a synthetic Function URL event. We only populate the
+	// fields the adapter actually reads; Lambda injects many more
+	// in real invocations, none of which the SDK looks at.
+	evt := events.LambdaFunctionURLRequest{
+		RawPath: path,
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: method},
+		},
+		Headers: headers,
+		Body:    bodyStr,
+	}
+
+	adapter := lambda.NewHandler(handler)
+	resp, err := adapter.HandleFunctionURL(context.Background(), evt)
+	if err != nil {
+		return LambdaSimResult{}, fmt.Errorf("simulate-lambda: adapter returned error: %w", err)
+	}
+
+	// The adapter base64-encodes non-UTF-8 bodies; in this simulator
+	// we don't care about the distinction for display, so decode into
+	// raw bytes unconditionally.
+	bodyBytes := []byte(resp.Body)
+	if resp.IsBase64Encoded {
+		// Fail loudly on malformed base64 — if the adapter emitted
+		// base64 but it doesn't decode, something is broken in the
+		// handler's response pipeline and hiding the error would
+		// waste user time.
+		decoded, err := base64Decode(resp.Body)
+		if err != nil {
+			return LambdaSimResult{}, fmt.Errorf("simulate-lambda: base64-decode response body: %w", err)
+		}
+		bodyBytes = decoded
+	}
+
+	return LambdaSimResult{
+		Status:  resp.StatusCode,
+		Body:    bodyBytes,
+		Headers: resp.Headers,
+	}, nil
+}
+
+// base64Decode is a thin wrapper around encoding/base64.StdEncoding
+// kept exclusively to centralise error wrapping in one place.
+func base64Decode(s string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(s)
+}
+
+// basicAuthHeader constructs a Basic auth header value for the given
+// credentials. Centralised so tests and CLI code agree on the format.
+func basicAuthHeader(user, pass string) string {
+	cred := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	return "Basic " + cred
+}
+
+// HandlerFactory is a zero-arg function that constructs the
+// http.Handler under test. The factory is called AFTER the simulator
+// has activated the platform env vars, so any env-var-driven state
+// the agent captures at construction (notably SWML_PROXY_URL_BASE,
+// which pkg/swml.Service reads in its constructor) reflects the
+// simulated environment rather than the outer shell.
+//
+// This mirrors the Python SDK's mock_env.py flow: env vars are set
+// first, then the agent module is imported/loaded, then invocations
+// run against that freshly-loaded agent.
+type HandlerFactory func() http.Handler
+
+// SimulateDumpSWMLViaLambda activates the Lambda environment, calls
+// the factory to construct the agent (so any env-captured state
+// reflects the simulated Lambda environment), issues a POST to the
+// agent's route through the Lambda adapter, and returns the response
+// body (the SWML document JSON). It's the library-side equivalent of
+// `swaig-test --simulate-serverless lambda --dump-swml`, usable from
+// in-process tests.
+//
+// The factory-based API is load-bearing: constructing the agent
+// BEFORE activation would let SWML_PROXY_URL_BASE from the outer
+// shell leak into the agent's own proxyURLBase field, and the
+// rendered webhook URLs would point at the outer proxy instead of
+// the simulated Lambda function. Use SimulateDumpSWMLViaLambdaHandler
+// only when you've already verified the handler doesn't capture
+// env state — it skips the activation-ordering guarantee.
+//
+// basicAuth, if non-empty in both fields, adds a basic-auth header
+// to the synthetic event so authed agents don't 401.
+func SimulateDumpSWMLViaLambda(
+	factory HandlerFactory,
+	agentRoute string,
+	opts SimulateLambdaOptions,
+	basicAuth BasicAuth,
+) ([]byte, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("simulate-lambda dump-swml: factory must not be nil")
+	}
+	if agentRoute == "" {
+		agentRoute = "/"
+	}
+
+	snap := activateLambdaEnv(opts)
+	defer snap.restore()
+
+	// Build the handler AFTER env activation so any env-var-driven
+	// state (e.g. agent.proxyURLBase, which is captured from
+	// SWML_PROXY_URL_BASE at construction time) reflects the
+	// simulated environment.
+	handler := factory()
+	if handler == nil {
+		return nil, fmt.Errorf("simulate-lambda dump-swml: factory returned nil handler")
+	}
+
+	headers := map[string]string{
+		"content-type": "application/json",
+	}
+	if basicAuth.User != "" || basicAuth.Password != "" {
+		headers["authorization"] = basicAuthHeader(basicAuth.User, basicAuth.Password)
+	}
+
+	result, err := SimulateLambdaInvocation(
+		handler, http.MethodPost, agentRoute, headers, strings.NewReader("{}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if result.Status < 200 || result.Status >= 300 {
+		return nil, fmt.Errorf("simulate-lambda dump-swml: HTTP %d: %s", result.Status, string(result.Body))
+	}
+	return result.Body, nil
+}
+
+// SimulateExecToolViaLambda activates the Lambda environment, calls
+// the factory to construct the agent (so any env-captured state
+// reflects the simulated Lambda environment), and dispatches a SWAIG
+// tool invocation through the Lambda adapter at `<agentRoute>/swaig`.
+// Returns the raw response body.
+func SimulateExecToolViaLambda(
+	factory HandlerFactory,
+	agentRoute, toolName string,
+	args map[string]any,
+	opts SimulateLambdaOptions,
+	basicAuth BasicAuth,
+) ([]byte, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("simulate-lambda exec: factory must not be nil")
+	}
+	if agentRoute == "" {
+		agentRoute = "/"
+	}
+	if toolName == "" {
+		return nil, fmt.Errorf("simulate-lambda exec: tool name is required")
+	}
+
+	snap := activateLambdaEnv(opts)
+	defer snap.restore()
+
+	// See SimulateDumpSWMLViaLambda for why the handler is built
+	// after env activation.
+	handler := factory()
+	if handler == nil {
+		return nil, fmt.Errorf("simulate-lambda exec: factory returned nil handler")
+	}
+
+	payload := map[string]any{
+		"function": toolName,
+		"argument": args,
+		"call_id":  "simulate-call-id",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("simulate-lambda exec: marshal payload: %w", err)
+	}
+
+	headers := map[string]string{
+		"content-type": "application/json",
+	}
+	if basicAuth.User != "" || basicAuth.Password != "" {
+		headers["authorization"] = basicAuthHeader(basicAuth.User, basicAuth.Password)
+	}
+
+	swaigPath := strings.TrimRight(agentRoute, "/") + "/swaig"
+	if agentRoute == "/" {
+		swaigPath = "/swaig"
+	}
+
+	result, err := SimulateLambdaInvocation(
+		handler, http.MethodPost, swaigPath, headers, bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if result.Status < 200 || result.Status >= 300 {
+		return nil, fmt.Errorf("simulate-lambda exec: HTTP %d: %s", result.Status, string(result.Body))
+	}
+	return result.Body, nil
+}
+
+// BasicAuth bundles a username/password pair for convenience.
+type BasicAuth struct {
+	User     string
+	Password string
+}

--- a/cmd/swaig-test/simulate_test.go
+++ b/cmd/swaig-test/simulate_test.go
@@ -1,0 +1,768 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/signalwire/signalwire-go/pkg/agent"
+	"github.com/signalwire/signalwire-go/pkg/lambda"
+	"github.com/signalwire/signalwire-go/pkg/swaig"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers shared across simulate tests
+// ---------------------------------------------------------------------------
+
+// simulateManagedKeys mirrors managedEnvKeys() — duplicated here so the
+// tests don't depend on the private list becoming a test-visible export.
+// Kept in sync by the test "TestManagedEnvKeysCoversAllKnownVars".
+func simulateManagedKeys() []string {
+	return []string{
+		"AWS_LAMBDA_FUNCTION_NAME",
+		"LAMBDA_TASK_ROOT",
+		"AWS_REGION",
+		"AWS_LAMBDA_FUNCTION_URL",
+		"_HANDLER",
+		"GATEWAY_INTERFACE",
+		"HTTP_HOST",
+		"SCRIPT_NAME",
+		"FUNCTION_TARGET",
+		"K_SERVICE",
+		"GOOGLE_CLOUD_PROJECT",
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+		"SWML_PROXY_URL_BASE",
+	}
+}
+
+// clearSimulatorEnv zeroes every env var the simulator manages. Use
+// this at the top of any test that asserts on env state so an outer
+// shell or leaked state from a previous test doesn't poison the
+// result. t.Setenv is preferred over os.Setenv because Go's testing
+// framework auto-restores those on t.Cleanup.
+func clearSimulatorEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range simulateManagedKeys() {
+		t.Setenv(k, "")
+		os.Unsetenv(k) // t.Setenv uses Setenv("", "") which keeps the key, so follow up with Unsetenv
+	}
+}
+
+// newTestAgent returns a small agent configured for simulator tests.
+// The agent has a single tool ("ping") that echoes back so tests can
+// verify SWAIG dispatch too.
+func newTestAgent(route, user, pass string) *agent.AgentBase {
+	a := agent.NewAgentBase(
+		agent.WithName("SimTestAgent"),
+		agent.WithRoute(route),
+		agent.WithBasicAuth(user, pass),
+	)
+	a.DefineTool(agent.ToolDefinition{
+		Name:        "ping",
+		Description: "ping",
+		Parameters:  map[string]any{"msg": map[string]any{"type": "string"}},
+		Handler: func(args, raw map[string]any) *swaig.FunctionResult {
+			return swaig.NewFunctionResult(fmt.Sprintf("pong: %v", args["msg"]))
+		},
+	})
+	return a
+}
+
+// ---------------------------------------------------------------------------
+// Platform validation
+// ---------------------------------------------------------------------------
+
+func TestValidateSimulatePlatform_LambdaAccepted(t *testing.T) {
+	if err := validateSimulatePlatform("lambda"); err != nil {
+		t.Fatalf("expected lambda to be accepted, got error: %v", err)
+	}
+}
+
+func TestValidateSimulatePlatform_UnimplementedPlatformsRejected(t *testing.T) {
+	for _, platform := range []string{"gcf", "cloud_function", "azure", "azure_function", "cgi"} {
+		t.Run(platform, func(t *testing.T) {
+			err := validateSimulatePlatform(platform)
+			if err == nil {
+				t.Fatalf("expected error for unimplemented platform %q", platform)
+			}
+			if !strings.Contains(err.Error(), "not implemented") {
+				t.Errorf("error for %q should say 'not implemented'; got: %v", platform, err)
+			}
+			if !strings.Contains(err.Error(), "Phase 9") {
+				t.Errorf("error for %q should reference Phase 9; got: %v", platform, err)
+			}
+		})
+	}
+}
+
+func TestValidateSimulatePlatform_UnknownPlatformRejected(t *testing.T) {
+	err := validateSimulatePlatform("not-a-real-platform")
+	if err == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+	if !strings.Contains(err.Error(), "unknown platform") {
+		t.Errorf("error should say 'unknown platform'; got: %v", err)
+	}
+}
+
+func TestValidateSimulatePlatform_EmptyRejected(t *testing.T) {
+	err := validateSimulatePlatform("")
+	if err == nil {
+		t.Fatal("expected error for empty platform")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Env save/restore lifecycle
+// ---------------------------------------------------------------------------
+
+// TestActivateLambdaEnv_SetsExpectedVars confirms the happy path:
+// activation sets the preset variables so GetExecutionMode returns
+// ModeLambda and the Lambda URL branch engages.
+func TestActivateLambdaEnv_SetsExpectedVars(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	defer snap.restore()
+
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "test-agent-function" {
+		t.Errorf("AWS_LAMBDA_FUNCTION_NAME = %q, want %q", got, "test-agent-function")
+	}
+	if got := os.Getenv("LAMBDA_TASK_ROOT"); got != "/var/task" {
+		t.Errorf("LAMBDA_TASK_ROOT = %q, want %q", got, "/var/task")
+	}
+	if got := os.Getenv("AWS_REGION"); got != "us-east-1" {
+		t.Errorf("AWS_REGION = %q, want %q", got, "us-east-1")
+	}
+}
+
+// TestActivateLambdaEnv_RestoresOnHappyPath verifies that calling
+// restore() rolls the environment back to its pre-activation state.
+func TestActivateLambdaEnv_RestoresOnHappyPath(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "preexisting-fn")
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "test-agent-function" {
+		t.Fatalf("during activation AWS_LAMBDA_FUNCTION_NAME = %q, want preset value", got)
+	}
+
+	snap.restore()
+
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "preexisting-fn" {
+		t.Errorf("after restore AWS_LAMBDA_FUNCTION_NAME = %q, want %q", got, "preexisting-fn")
+	}
+}
+
+// TestActivateLambdaEnv_RestoresUnsetState pins down that a var which
+// was NOT set before activation is correctly unset on restore (rather
+// than restored to empty string — those are meaningfully different to
+// os.LookupEnv consumers).
+func TestActivateLambdaEnv_RestoresUnsetState(t *testing.T) {
+	clearSimulatorEnv(t)
+	// Make sure this really is unset.
+	os.Unsetenv("AWS_LAMBDA_FUNCTION_NAME")
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	snap.restore()
+
+	if _, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {
+		t.Errorf("AWS_LAMBDA_FUNCTION_NAME should be unset after restore, but is present")
+	}
+}
+
+// TestActivateLambdaEnv_ClearsProxyURLBase proves the simulator wipes
+// SWML_PROXY_URL_BASE during activation — the load-bearing behaviour
+// that matches mock_env.py and makes Lambda URL construction visible.
+func TestActivateLambdaEnv_ClearsProxyURLBase(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("SWML_PROXY_URL_BASE", "https://proxy.outer-shell.example.com")
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	defer snap.restore()
+
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != "" {
+		t.Errorf("during activation SWML_PROXY_URL_BASE = %q, want cleared", got)
+	}
+}
+
+// TestActivateLambdaEnv_RestoresProxyURLBase confirms the original
+// value of SWML_PROXY_URL_BASE is put back after restore(). Leaking
+// a cleared proxy base would break any subsequent test that relies
+// on it.
+func TestActivateLambdaEnv_RestoresProxyURLBase(t *testing.T) {
+	clearSimulatorEnv(t)
+	const original = "https://proxy.outer-shell.example.com"
+	t.Setenv("SWML_PROXY_URL_BASE", original)
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	snap.restore()
+
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != original {
+		t.Errorf("after restore SWML_PROXY_URL_BASE = %q, want %q", got, original)
+	}
+}
+
+// TestActivateLambdaEnv_RestoresOnErrorPath runs the simulated
+// invocation through a handler that returns an error, and verifies
+// the environment is still restored afterwards. Leaked env state
+// would cause downstream tests in the same process to behave
+// nondeterministically.
+func TestActivateLambdaEnv_RestoresOnErrorPath(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("SWML_PROXY_URL_BASE", "https://original.example.com")
+
+	// The handler panics to simulate a buggy agent. The test uses a
+	// dedicated recovering wrapper so the panic doesn't tear the
+	// test binary down — we only want to prove env state rolls back.
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		snap := activateLambdaEnv(SimulateLambdaOptions{})
+		defer snap.restore()
+		panic("simulated agent crash")
+	}()
+
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != "https://original.example.com" {
+		t.Errorf("after panic+restore SWML_PROXY_URL_BASE = %q, want original", got)
+	}
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "" {
+		t.Errorf("after panic+restore AWS_LAMBDA_FUNCTION_NAME = %q, want empty", got)
+	}
+}
+
+// TestActivateLambdaEnv_WithOptions exercises the override fields on
+// SimulateLambdaOptions: custom function name, region, and explicit
+// function URL all propagate into the environment.
+func TestActivateLambdaEnv_WithOptions(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	snap := activateLambdaEnv(SimulateLambdaOptions{
+		FunctionName:        "custom-fn",
+		Region:              "eu-west-1",
+		FunctionURLOverride: "https://override.example.com/",
+	})
+	defer snap.restore()
+
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "custom-fn" {
+		t.Errorf("FUNCTION_NAME = %q, want %q", got, "custom-fn")
+	}
+	if got := os.Getenv("AWS_REGION"); got != "eu-west-1" {
+		t.Errorf("AWS_REGION = %q, want %q", got, "eu-west-1")
+	}
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_URL"); got != "https://override.example.com/" {
+		t.Errorf("AWS_LAMBDA_FUNCTION_URL = %q, want override", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Adapter dispatch (dump-swml + exec) through the Lambda handler
+// ---------------------------------------------------------------------------
+
+// extractWebhookURL digs into a rendered SWML document for the first
+// SWAIG function's web_hook_url. Mirrors the helper inside
+// pkg/lambda/integration_test.go (duplicated here to keep this test
+// file self-contained).
+func extractWebhookURL(t *testing.T, body []byte) string {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("response is not JSON: %v\nbody=%s", err, string(body))
+	}
+	sections, _ := doc["sections"].(map[string]any)
+	main, _ := sections["main"].([]any)
+	for _, verb := range main {
+		v, _ := verb.(map[string]any)
+		ai, _ := v["ai"].(map[string]any)
+		sw, _ := ai["SWAIG"].(map[string]any)
+		if sw == nil {
+			continue
+		}
+		fns, _ := sw["functions"].([]any)
+		for _, fn := range fns {
+			fm, _ := fn.(map[string]any)
+			if url, ok := fm["web_hook_url"].(string); ok && url != "" {
+				return url
+			}
+		}
+		if url, ok := sw["web_hook_url"].(string); ok && url != "" {
+			return url
+		}
+		if defs, _ := sw["defaults"].(map[string]any); defs != nil {
+			if url, ok := defs["web_hook_url"].(string); ok && url != "" {
+				return url
+			}
+		}
+	}
+	t.Fatalf("no web_hook_url found in SWML document: %s", string(body))
+	return ""
+}
+
+// TestSimulateDumpSWMLViaLambda_NonRootRoute is the load-bearing
+// regression test called out in the task: a Lambda-simulated agent
+// at route /my-agent produces SWML whose webhook URL contains
+// /my-agent/swaig.
+func TestSimulateDumpSWMLViaLambda_NonRootRoute(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	factory := func() http.Handler {
+		return newTestAgent("/my-agent", "u", "p").AsRouter()
+	}
+	body, err := SimulateDumpSWMLViaLambda(
+		factory,
+		"/my-agent",
+		SimulateLambdaOptions{},
+		BasicAuth{User: "u", Password: "p"},
+	)
+	if err != nil {
+		t.Fatalf("SimulateDumpSWMLViaLambda: %v", err)
+	}
+
+	url := extractWebhookURL(t, body)
+	if !strings.Contains(url, "/my-agent/swaig") {
+		t.Fatalf(
+			"webhook URL = %q, want substring %q. Non-root route must be "+
+				"preserved through the Lambda adapter.",
+			url, "/my-agent/swaig",
+		)
+	}
+	if !strings.Contains(url, "lambda-url.") || !strings.Contains(url, ".on.aws") {
+		t.Errorf("webhook URL = %q, want Lambda-style host", url)
+	}
+}
+
+// TestSimulateDumpSWMLViaLambda_ClearsProxyBaseBeforeRender is the
+// other load-bearing behaviour: even if the outer shell has
+// SWML_PROXY_URL_BASE set, the simulator clears it before the agent
+// is constructed, so the webhook URLs come out Lambda-shaped rather
+// than pointing at the outer proxy. This is what the factory-based
+// simulator API buys us: the agent captures SWML_PROXY_URL_BASE at
+// construction, so it has to be built post-activation.
+func TestSimulateDumpSWMLViaLambda_ClearsProxyBaseBeforeRender(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("SWML_PROXY_URL_BASE", "https://outer.example.com")
+
+	factory := func() http.Handler {
+		return newTestAgent("/my-agent", "u", "p").AsRouter()
+	}
+	body, err := SimulateDumpSWMLViaLambda(
+		factory,
+		"/my-agent",
+		SimulateLambdaOptions{},
+		BasicAuth{User: "u", Password: "p"},
+	)
+	if err != nil {
+		t.Fatalf("SimulateDumpSWMLViaLambda: %v", err)
+	}
+
+	url := extractWebhookURL(t, body)
+	if strings.Contains(url, "outer.example.com") {
+		t.Fatalf(
+			"webhook URL = %q still contains outer proxy host; simulator "+
+				"failed to clear SWML_PROXY_URL_BASE before agent load",
+			url,
+		)
+	}
+	if !strings.Contains(url, ".lambda-url.") || !strings.Contains(url, ".on.aws") {
+		t.Fatalf(
+			"webhook URL = %q is not Lambda-style; simulator didn't engage "+
+				"Lambda URL generation",
+			url,
+		)
+	}
+	if !strings.Contains(url, "/my-agent/swaig") {
+		t.Errorf("webhook URL = %q, want /my-agent/swaig substring", url)
+	}
+
+	// And the outer proxy env var must be restored on exit.
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != "https://outer.example.com" {
+		t.Errorf("SWML_PROXY_URL_BASE after simulator exit = %q, want restored", got)
+	}
+}
+
+// TestSimulateDumpSWMLViaLambda_RootRoute pins down the root-route
+// case — a less common deployment but worth guarding against trailing-
+// slash bugs.
+func TestSimulateDumpSWMLViaLambda_RootRoute(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	factory := func() http.Handler {
+		return newTestAgent("/", "u", "p").AsRouter()
+	}
+	body, err := SimulateDumpSWMLViaLambda(
+		factory,
+		"/",
+		SimulateLambdaOptions{},
+		BasicAuth{User: "u", Password: "p"},
+	)
+	if err != nil {
+		t.Fatalf("SimulateDumpSWMLViaLambda: %v", err)
+	}
+
+	url := extractWebhookURL(t, body)
+	if !strings.Contains(url, "/swaig") {
+		t.Errorf("webhook URL = %q, want /swaig suffix", url)
+	}
+	if !strings.Contains(url, ".lambda-url.") || !strings.Contains(url, ".on.aws") {
+		t.Errorf("webhook URL = %q, want Lambda-style host", url)
+	}
+}
+
+// TestSimulateExecToolViaLambda verifies SWAIG dispatch through the
+// simulated adapter hits the right tool handler.
+func TestSimulateExecToolViaLambda(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	factory := func() http.Handler {
+		return newTestAgent("/my-agent", "u", "p").AsRouter()
+	}
+	body, err := SimulateExecToolViaLambda(
+		factory,
+		"/my-agent",
+		"ping",
+		map[string]any{"msg": "hi"},
+		SimulateLambdaOptions{},
+		BasicAuth{User: "u", Password: "p"},
+	)
+	if err != nil {
+		t.Fatalf("SimulateExecToolViaLambda: %v", err)
+	}
+
+	if !strings.Contains(string(body), "pong: hi") {
+		t.Errorf("tool response body = %q, want substring %q", string(body), "pong: hi")
+	}
+}
+
+// TestSimulateExecToolViaLambda_RestoresOnError proves env restore
+// runs even when the tool call fails (here: we return HTTP 401 by
+// passing wrong credentials, so the adapter yields an error).
+func TestSimulateExecToolViaLambda_RestoresOnError(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("SWML_PROXY_URL_BASE", "https://original.example.com")
+
+	factory := func() http.Handler {
+		return newTestAgent("/my-agent", "u", "p").AsRouter()
+	}
+	_, err := SimulateExecToolViaLambda(
+		factory,
+		"/my-agent",
+		"ping",
+		map[string]any{},
+		SimulateLambdaOptions{},
+		BasicAuth{User: "wrong", Password: "credentials"},
+	)
+	if err == nil {
+		t.Fatal("expected error for wrong auth credentials")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error = %v, want HTTP 401", err)
+	}
+
+	// Even though the simulated call errored, env should be restored.
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != "https://original.example.com" {
+		t.Errorf("after error SWML_PROXY_URL_BASE = %q, want restored", got)
+	}
+	if _, ok := os.LookupEnv("AWS_LAMBDA_FUNCTION_NAME"); ok {
+		t.Errorf("AWS_LAMBDA_FUNCTION_NAME leaked past restore")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Library API boundary: the lambda adapter does actually get used
+// ---------------------------------------------------------------------------
+
+// TestSimulateLambdaInvocation_NilHandlerRejected ensures we bail out
+// cleanly rather than panicking on a programming error.
+func TestSimulateLambdaInvocation_NilHandlerRejected(t *testing.T) {
+	_, err := SimulateLambdaInvocation(nil, http.MethodGet, "/", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil handler")
+	}
+}
+
+// TestSimulateLambdaInvocation_PassThroughMethodAndPath sanity-checks
+// that method/path flow into the synthetic event correctly by wiring
+// a handler that echoes them back through pkg/lambda.
+func TestSimulateLambdaInvocation_PassThroughMethodAndPath(t *testing.T) {
+	var seenMethod, seenPath string
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	_, err := SimulateLambdaInvocation(h, http.MethodPost, "/agent-a/swaig", nil, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("SimulateLambdaInvocation: %v", err)
+	}
+	if seenMethod != "POST" {
+		t.Errorf("handler saw method %q, want POST", seenMethod)
+	}
+	if seenPath != "/agent-a/swaig" {
+		t.Errorf("handler saw path %q, want /agent-a/swaig", seenPath)
+	}
+}
+
+// TestSimulateLambdaInvocation_RealAdapter ties the simulator to the
+// actual pkg/lambda adapter by reaching into the same API that a
+// Lambda-deployed agent would use. This is what proves "route through
+// the adapter, NOT the HTTP server" in this CI: the simulator
+// composes lambda.NewHandler under the hood.
+func TestSimulateLambdaInvocation_RealAdapter(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	a := newTestAgent("/my-agent", "u", "p")
+
+	// Call pkg/lambda directly as a sanity check that what the
+	// simulator invokes is byte-identical to what a real Lambda
+	// runtime would do.
+	adapter := lambda.NewHandler(a.AsRouter())
+	evt := events.LambdaFunctionURLRequest{
+		RawPath: "/my-agent",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{
+			"authorization": basicAuthHeader("u", "p"),
+			"content-type":  "application/json",
+		},
+		Body: "{}",
+	}
+	resp, err := adapter.HandleFunctionURL(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("direct adapter call failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("direct adapter status = %d, want 200, body=%q", resp.StatusCode, resp.Body)
+	}
+
+	// Now invoke the same agent via the simulator; its response body
+	// should parse as the same SWML shape.
+	snap := activateLambdaEnv(SimulateLambdaOptions{})
+	defer snap.restore()
+	result, err := SimulateLambdaInvocation(
+		a.AsRouter(),
+		"POST",
+		"/my-agent",
+		map[string]string{
+			"authorization": basicAuthHeader("u", "p"),
+			"content-type":  "application/json",
+		},
+		strings.NewReader("{}"),
+	)
+	if err != nil {
+		t.Fatalf("simulator call failed: %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("simulator status = %d, want 200", result.Status)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(result.Body, &doc); err != nil {
+		t.Fatalf("simulator body is not JSON: %v\nbody=%s", err, string(result.Body))
+	}
+	if _, ok := doc["sections"].(map[string]any); !ok {
+		t.Errorf("simulator body missing 'sections': %v", doc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CLI-level integration: validate --simulate-serverless behaviour through run()
+// ---------------------------------------------------------------------------
+
+// TestRun_SimulateServerless_RejectsUnimplementedPlatform drives the
+// CLI entry point (run) with an unimplemented platform and confirms
+// it exits non-zero (returns a non-nil error) with a message that
+// points at Phase 9.
+func TestRun_SimulateServerless_RejectsUnimplementedPlatform(t *testing.T) {
+	for _, platform := range []string{"gcf", "azure", "cgi"} {
+		t.Run(platform, func(t *testing.T) {
+			cfg := config{
+				url:                "http://localhost:3000/",
+				dumpSWML:           true,
+				simulateServerless: platform,
+			}
+			err := run(cfg)
+			if err == nil {
+				t.Fatalf("expected error for --simulate-serverless %s", platform)
+			}
+			if !strings.Contains(err.Error(), "Phase 9") && !strings.Contains(err.Error(), "not implemented") {
+				t.Errorf("error for %s should reference Phase 9 or 'not implemented'; got: %v", platform, err)
+			}
+		})
+	}
+}
+
+// TestRun_SimulateServerless_RejectsUnknownPlatform ensures typos
+// surface as "unknown platform" errors.
+func TestRun_SimulateServerless_RejectsUnknownPlatform(t *testing.T) {
+	cfg := config{
+		url:                "http://localhost:3000/",
+		dumpSWML:           true,
+		simulateServerless: "lamda", // typo
+	}
+	err := run(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+	if !strings.Contains(err.Error(), "unknown platform") {
+		t.Errorf("error should say 'unknown platform'; got: %v", err)
+	}
+}
+
+// TestRun_SimulateServerless_SetsAndRestoresEnvForURLMode simulates
+// the CLI flow with --url + --simulate-serverless lambda pointed at
+// an httptest server. The server asserts the Lambda env vars were
+// set when the request arrived; after run() returns the test
+// verifies those vars are restored (i.e. unset) in the outer process.
+func TestRun_SimulateServerless_SetsAndRestoresEnvForURLMode(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	// The server checks the env the *caller's* process has — not the
+	// request headers — because that's what the CLI mutates. When the
+	// CLI issues a GET to this server, the caller's process still
+	// sees AWS_LAMBDA_FUNCTION_NAME set.
+	var seenDuringRequest string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenDuringRequest = os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":"1.0.0","sections":{"main":[]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		url:                srv.URL,
+		dumpSWML:           true,
+		simulateServerless: "lambda",
+	}
+	if err := run(cfg); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if seenDuringRequest == "" {
+		t.Errorf("during simulated run, AWS_LAMBDA_FUNCTION_NAME was empty; simulator didn't activate env")
+	}
+
+	// After run() returns, env must be restored.
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "" {
+		t.Errorf("after run AWS_LAMBDA_FUNCTION_NAME = %q, want cleared", got)
+	}
+}
+
+// TestRun_SimulateServerless_RestoresEnvOnURLError drives the CLI
+// against a URL that returns 500, confirms run() reports the error,
+// and checks env vars were rolled back.
+func TestRun_SimulateServerless_RestoresEnvOnURLError(t *testing.T) {
+	clearSimulatorEnv(t)
+	t.Setenv("SWML_PROXY_URL_BASE", "https://outer.example.com")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		url:                srv.URL,
+		dumpSWML:           true,
+		simulateServerless: "lambda",
+	}
+	if err := run(cfg); err == nil {
+		t.Fatal("expected run() to return an error for HTTP 500")
+	}
+
+	// Env still restored despite error.
+	if got := os.Getenv("SWML_PROXY_URL_BASE"); got != "https://outer.example.com" {
+		t.Errorf("SWML_PROXY_URL_BASE after error = %q, want restored", got)
+	}
+	if got := os.Getenv("AWS_LAMBDA_FUNCTION_NAME"); got != "" {
+		t.Errorf("AWS_LAMBDA_FUNCTION_NAME after error = %q, want empty", got)
+	}
+}
+
+// TestRun_SimulateServerless_NoURLErrorsCleanly ensures that the
+// "Go CLI without an agent source" case fails fast with a helpful
+// pointer to the library API, rather than silently succeeding.
+func TestRun_SimulateServerless_NoURLErrorsCleanly(t *testing.T) {
+	cfg := config{
+		simulateServerless: "lambda",
+		dumpSWML:           true,
+	}
+	err := run(cfg)
+	if err == nil {
+		t.Fatal("expected error when --simulate-serverless is used without --url")
+	}
+	if !strings.Contains(err.Error(), "--url") {
+		t.Errorf("error should mention --url; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "SimulateDumpSWMLViaLambda") {
+		t.Errorf("error should point at the library API; got: %v", err)
+	}
+}
+
+// TestRun_SimulateServerless_DefaultsToDumpSWML verifies that running
+// `--simulate-serverless lambda --url ...` with no explicit sub-action
+// falls back to --dump-swml mode (matches the Python CLI's "bare
+// simulate" behaviour).
+func TestRun_SimulateServerless_DefaultsToDumpSWML(t *testing.T) {
+	clearSimulatorEnv(t)
+
+	var served bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served = true
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"version":"1.0.0","sections":{"main":[]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := config{
+		url:                srv.URL,
+		simulateServerless: "lambda",
+		// No --dump-swml / --list-tools / --exec on purpose.
+	}
+	if err := run(cfg); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !served {
+		t.Error("expected the test server to be hit under default (dump-swml) mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flag parser coverage for the new flag
+// ---------------------------------------------------------------------------
+
+func TestParseFlags_SimulateServerless(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "lambda flag",
+			args: []string{"--url", "http://localhost/", "--simulate-serverless", "lambda", "--dump-swml"},
+			want: "lambda",
+		},
+		{
+			name: "not present",
+			args: []string{"--url", "http://localhost/", "--dump-swml"},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := parseFlags(tt.args)
+			if cfg.simulateServerless != tt.want {
+				t.Errorf("simulateServerless = %q, want %q", cfg.simulateServerless, tt.want)
+			}
+		})
+	}
+}

--- a/examples/lambda/main.go
+++ b/examples/lambda/main.go
@@ -2,30 +2,47 @@
 
 // Example: lambda
 //
-// Serverless Lambda handler pattern. Demonstrates how to structure an AI
-// agent for deployment on AWS Lambda or similar serverless platforms.
-// The agent is created at package level and exposes an HTTP handler
-// that can be wrapped with an API Gateway adapter.
+// AWS Lambda deployment of a SignalWire AI agent, using the built-in
+// pkg/lambda adapter. The same main.go can be compiled as a Lambda
+// binary (GOOS=linux GOARCH=amd64 go build -o bootstrap) and deployed as
+// a Lambda Function URL or behind an API Gateway v2 HTTP API.
+//
+// When running in Lambda, the SDK automatically detects the environment
+// (via AWS_LAMBDA_FUNCTION_NAME or LAMBDA_TASK_ROOT) and generates
+// webhook URLs that resolve to the running function — no extra proxy
+// configuration is required. Set AWS_LAMBDA_FUNCTION_URL if your
+// function URL does not match the default
+// https://{function}.lambda-url.{region}.on.aws pattern.
 package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
+	awslambda "github.com/aws/aws-lambda-go/lambda"
+
 	"github.com/signalwire/signalwire-go/pkg/agent"
+	"github.com/signalwire/signalwire-go/pkg/lambda"
 	"github.com/signalwire/signalwire-go/pkg/swaig"
+	"github.com/signalwire/signalwire-go/pkg/swml"
 )
 
-// Create the agent at package level so it is initialised once per Lambda
-// cold start. In a real Lambda deployment you would wrap agent.AsRouter()
-// with an API Gateway adapter (e.g. github.com/awslabs/aws-lambda-go-api-proxy).
+// Create the agent once at package load so it survives across Lambda
+// invocations (warm starts). Holding any per-invocation state on the
+// agent would defeat that caching — use request-scoped structures
+// inside tool handlers instead.
 var a = newAgent()
 
 func newAgent() *agent.AgentBase {
 	ag := agent.NewAgentBase(
 		agent.WithName("LambdaAgent"),
-		agent.WithRoute("/"),
-		agent.WithPort(3016),
+		// Non-root route is the recommended default: it lets you host
+		// multiple agents behind a single Function URL if you grow into
+		// that deployment. The SDK appends /swaig and /post_prompt to
+		// this route automatically.
+		agent.WithRoute("/my-agent"),
+		agent.WithPort(3016), // only used when running the agent locally
 	)
 
 	ag.AddLanguage(map[string]any{
@@ -59,7 +76,7 @@ func newAgent() *agent.AgentBase {
 				name = "friend"
 			}
 			return swaig.NewFunctionResult(
-				fmt.Sprintf("Hello %s! I'm running in a serverless environment!", name),
+				fmt.Sprintf("Hello %s! I'm running in a serverless environment.", name),
 			)
 		},
 	})
@@ -77,17 +94,24 @@ func newAgent() *agent.AgentBase {
 	return ag
 }
 
-// In a real Lambda deployment, you would expose the handler like:
-//
-//   import "github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
-//   var handler = httpadapter.New(a.AsRouter()).ProxyWithContext
-//
-// For local testing, just run the agent directly.
-func main() {
-	fmt.Println("Starting LambdaAgent on :3016/ ...")
-	fmt.Println("  In production, wrap a.AsRouter() with a Lambda adapter.")
+// handler is the Lambda-facing entry point. lambda.NewHandler wraps the
+// agent's http.Router so every SWML and SWAIG request arriving as a
+// Lambda Function URL invocation is handled by the same code that serves
+// the local HTTP listener.
+var handler = lambda.NewHandler(a.AsRouter())
 
+func main() {
+	// If we're running under the Lambda runtime, hand control to it.
+	// Otherwise, start the agent locally so the same binary can be used
+	// for iterative development.
+	if swml.GetExecutionMode() == swml.ModeLambda {
+		awslambda.Start(handler.HandleFunctionURL)
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "Not running in Lambda; starting local HTTP server on :3016/my-agent ...")
 	if err := a.Run(); err != nil {
-		fmt.Printf("Agent error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Agent error: %v\n", err)
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/signalwire/signalwire-go
 go 1.22.5
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/aws/aws-lambda-go v1.54.0
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/agent/web_test.go
+++ b/pkg/agent/web_test.go
@@ -136,6 +136,90 @@ func TestManualSetProxyUrl_Basic(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Lambda + proxy route preservation (regression)
+// ---------------------------------------------------------------------------
+//
+// These tests pin down the exact bug called out in the Lambda port brief:
+// when SWML_PROXY_URL_BASE is set AND the agent is running inside Lambda,
+// the webhook URL MUST include both the agent's route and the /swaig
+// suffix. Python and TypeScript originally dropped the route in this
+// combination; the Go SDK had the correct behaviour from the start but
+// we now guard it with these explicit checks.
+
+// clearAgentAWSEnv zeroes the env vars inspected by swml.GetExecutionMode
+// and the proxy override, so that tests running inside a real cloud
+// runtime (GKE, Lambda, etc.) start from a clean slate.
+func clearAgentAWSEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"GATEWAY_INTERFACE",
+		"AWS_LAMBDA_FUNCTION_NAME",
+		"LAMBDA_TASK_ROOT",
+		"AWS_LAMBDA_FUNCTION_URL",
+		"AWS_REGION",
+		"FUNCTION_TARGET",
+		"K_SERVICE",
+		"GOOGLE_CLOUD_PROJECT",
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+		"SWML_PROXY_URL_BASE",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestBuildWebhookURL_LambdaNonRootRouteAppendsRoute(t *testing.T) {
+	clearAgentAWSEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo-func")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://demo-func.lambda-url.us-east-1.on.aws")
+
+	a := NewAgentBase(
+		WithRoute("/my-agent"),
+		WithBasicAuth("u", "p"),
+	)
+	url := a.buildWebhookURL()
+	const want = "/my-agent/swaig"
+	if !strings.Contains(url, want) {
+		t.Fatalf("buildWebhookURL() = %q, want substring %q", url, want)
+	}
+	if !strings.Contains(url, "demo-func.lambda-url.us-east-1.on.aws") {
+		t.Fatalf("buildWebhookURL() = %q, want Lambda host", url)
+	}
+}
+
+// REGRESSION GUARD: non-root route + Lambda env + proxy base must all
+// produce a webhook URL that still contains the agent's route + /swaig.
+// This is the exact combo that originally hid the bug in Python and TS.
+func TestBuildWebhookURL_Regression_LambdaProxyRouteCombo(t *testing.T) {
+	clearAgentAWSEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo-func")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://should-be-ignored.lambda-url.us-east-1.on.aws")
+	t.Setenv("SWML_PROXY_URL_BASE", "https://xyz.lambda-url.us-east-1.on.aws")
+
+	a := NewAgentBase(
+		WithRoute("/my-agent"),
+		WithBasicAuth("u", "p"),
+	)
+	url := a.buildWebhookURL()
+	if !strings.Contains(url, "/my-agent/swaig") {
+		t.Fatalf(
+			"route-preservation regression: buildWebhookURL() = %q, "+
+				"want substring %q. The proxy base MUST have the "+
+				"agent's route and /swaig appended.",
+			url, "/my-agent/swaig",
+		)
+	}
+	if !strings.Contains(url, "xyz.lambda-url.us-east-1.on.aws") {
+		t.Fatalf("buildWebhookURL() = %q, expected proxy host", url)
+	}
+	// Make absolutely sure the buggy shape is NOT present.
+	if strings.HasSuffix(url, "xyz.lambda-url.us-east-1.on.aws/swaig") {
+		t.Fatalf("buildWebhookURL() = %q matches the forbidden shape", url)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Dynamic config callback
 // ---------------------------------------------------------------------------
 

--- a/pkg/lambda/integration_test.go
+++ b/pkg/lambda/integration_test.go
@@ -1,0 +1,375 @@
+package lambda_test
+
+// This file houses the cross-package integration tests that wire a real
+// agent.AgentBase + swml.Service stack through the Lambda adapter. It
+// lives in a separate _test package to avoid a dependency cycle with
+// pkg/agent (which would pull the agent package into pkg/lambda at
+// compile time if declared in the same `package lambda` block).
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/signalwire/signalwire-go/pkg/agent"
+	"github.com/signalwire/signalwire-go/pkg/lambda"
+	"github.com/signalwire/signalwire-go/pkg/swaig"
+)
+
+// clearAWSEnv wipes the AWS env vars that would otherwise leak between
+// tests running in the same process. GetExecutionMode inspects these
+// directly and there is no dependency-injected seam at the moment.
+func clearAWSEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"AWS_LAMBDA_FUNCTION_NAME",
+		"LAMBDA_TASK_ROOT",
+		"AWS_LAMBDA_FUNCTION_URL",
+		"AWS_REGION",
+		"SWML_PROXY_URL_BASE",
+		"GATEWAY_INTERFACE",
+		"FUNCTION_TARGET",
+		"K_SERVICE",
+		"GOOGLE_CLOUD_PROJECT",
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// basicAuthHeader returns the HTTP basic-auth header value for the given
+// credentials.
+func basicAuthHeader(user, pass string) string {
+	cred := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	return "Basic " + cred
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end Lambda dispatch
+// ---------------------------------------------------------------------------
+
+// TestLambdaHandler_ServesSWMLDocument drives a complete agent through the
+// Lambda adapter and asserts the SWML document comes out intact. This is
+// the main smoke test for the "wrap agent as Lambda handler" use case.
+func TestLambdaHandler_ServesSWMLDocument(t *testing.T) {
+	clearAWSEnv(t)
+
+	const user, pass = "user", "pass"
+	a := agent.NewAgentBase(
+		agent.WithName("IntegrationAgent"),
+		agent.WithRoute("/my-agent"),
+		agent.WithBasicAuth(user, pass),
+	)
+	a.PromptAddSection("Role", "You are helpful.", nil)
+
+	h := lambda.NewHandler(a.AsRouter())
+
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/my-agent",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{
+			"authorization": basicAuthHeader(user, pass),
+			"content-type":  "application/json",
+		},
+		Body: "{}",
+	}
+
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%q", resp.StatusCode, resp.Body)
+	}
+	if ct := resp.Headers["Content-Type"]; !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &doc); err != nil {
+		t.Fatalf("response body is not JSON: %v", err)
+	}
+	if v, _ := doc["version"].(string); v == "" {
+		t.Errorf("SWML document missing version field: %v", doc)
+	}
+}
+
+// TestLambdaHandler_RejectsMissingAuth verifies that the adapter correctly
+// surfaces the agent's auth middleware — 401 comes back through the Lambda
+// response envelope when credentials are absent.
+func TestLambdaHandler_RejectsMissingAuth(t *testing.T) {
+	clearAWSEnv(t)
+
+	a := agent.NewAgentBase(
+		agent.WithName("AuthAgent"),
+		agent.WithRoute("/secure"),
+		agent.WithBasicAuth("u", "p"),
+	)
+	h := lambda.NewHandler(a.AsRouter())
+
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/secure",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+		// Intentionally no Authorization header.
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+	if resp.Headers["Www-Authenticate"] == "" && resp.Headers["WWW-Authenticate"] == "" {
+		t.Errorf("expected WWW-Authenticate header in 401 response, got headers=%v", resp.Headers)
+	}
+}
+
+// TestLambdaHandler_DispatchesSwaigFunctionCall verifies that a SWAIG
+// function call delivered via the Lambda adapter is routed to the correct
+// tool handler and the handler's FunctionResult is returned unmodified.
+func TestLambdaHandler_DispatchesSwaigFunctionCall(t *testing.T) {
+	clearAWSEnv(t)
+
+	const user, pass = "swaig-u", "swaig-p"
+	a := agent.NewAgentBase(
+		agent.WithName("SwaigAgent"),
+		agent.WithRoute("/bot"),
+		agent.WithBasicAuth(user, pass),
+	)
+	a.DefineTool(agent.ToolDefinition{
+		Name:        "greet",
+		Description: "Greet",
+		Parameters:  map[string]any{"name": map[string]any{"type": "string"}},
+		Handler: func(args map[string]any, raw map[string]any) *swaig.FunctionResult {
+			return swaig.NewFunctionResult(fmt.Sprintf("hello %v", args["name"]))
+		},
+	})
+
+	h := lambda.NewHandler(a.AsRouter())
+
+	// The Go SDK's handleSwaig treats `argument` as the flat args map
+	// (matching how the existing pkg/agent tests exercise it). The nested
+	// parsed/raw shape seen in Python is not accepted here.
+	body := `{"function":"greet","argument":{"name":"Ada"}}`
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/bot/swaig",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{
+			"authorization": basicAuthHeader(user, pass),
+			"content-type":  "application/json",
+		},
+		Body: body,
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%q", resp.StatusCode, resp.Body)
+	}
+	if !strings.Contains(resp.Body, "hello Ada") {
+		t.Errorf("response body missing greeting: %q", resp.Body)
+	}
+}
+
+// TestLambdaHandler_HealthEndpointNoAuth verifies that health checks don't
+// require basic auth — something typical Lambda deployments rely on.
+func TestLambdaHandler_HealthEndpointNoAuth(t *testing.T) {
+	clearAWSEnv(t)
+
+	a := agent.NewAgentBase(
+		agent.WithName("HealthAgent"),
+		agent.WithRoute("/app"),
+		agent.WithBasicAuth("u", "p"),
+	)
+	h := lambda.NewHandler(a.AsRouter())
+
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/health",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression guard: route preservation under Lambda env
+// ---------------------------------------------------------------------------
+//
+// This is the critical bug documented in the port brief: the webhook URL
+// baked into the rendered SWML document must include both the agent's
+// route AND the /swaig suffix. Earlier Python/TS fixes missed the Route
+// append when a proxy base was set.
+//
+// The test renders the SWML document through the Lambda adapter with a
+// non-root Route and both Lambda + proxy env vars set, then walks the
+// document down to the AI verb's SWAIG.functions[].web_hook_url and
+// asserts the full expected URL string. Relying on the rendered document
+// rather than an internal helper means we catch regressions even if the
+// relevant code paths get refactored.
+
+func TestLambdaHandler_Regression_WebhookURLIncludesRoute(t *testing.T) {
+	clearAWSEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo-func")
+	t.Setenv("AWS_REGION", "us-east-1")
+	// Proxy base overrides Lambda URL construction; the regression bug
+	// was specifically that this override dropped the agent's route.
+	t.Setenv("SWML_PROXY_URL_BASE", "https://xyz.lambda-url.us-east-1.on.aws")
+
+	const user, pass = "u", "p"
+	a := agent.NewAgentBase(
+		agent.WithName("RouteRegression"),
+		agent.WithRoute("/my-agent"),
+		agent.WithBasicAuth(user, pass),
+	)
+	a.DefineTool(agent.ToolDefinition{
+		Name:        "ping",
+		Description: "ping",
+		Handler: func(args, raw map[string]any) *swaig.FunctionResult {
+			return swaig.NewFunctionResult("pong")
+		},
+	})
+
+	h := lambda.NewHandler(a.AsRouter())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/my-agent",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{"authorization": basicAuthHeader(user, pass)},
+		Body:    "{}",
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	webhookURL := extractFirstSwaigWebhook(t, resp.Body)
+	wantSuffix := "/my-agent/swaig"
+	if !strings.Contains(webhookURL, wantSuffix) {
+		t.Fatalf(
+			"route-preservation regression: webhook URL = %q, want substring %q. "+
+				"The proxy base + Lambda combo must still include the agent's route.",
+			webhookURL, wantSuffix,
+		)
+	}
+	// Also verify the scheme/host block came from the proxy env var, not
+	// from the localhost fallback.
+	if !strings.Contains(webhookURL, "xyz.lambda-url.us-east-1.on.aws") {
+		t.Fatalf("webhook URL = %q, want proxy host substring", webhookURL)
+	}
+	// And verify it is NOT the buggy shape that omits the route.
+	if strings.HasSuffix(webhookURL, "xyz.lambda-url.us-east-1.on.aws/swaig") ||
+		strings.Contains(webhookURL, ".on.aws@") && strings.HasSuffix(webhookURL, "/swaig") && !strings.Contains(webhookURL, "/my-agent/swaig") {
+		t.Fatalf("webhook URL matches the forbidden bare-proxy shape: %q", webhookURL)
+	}
+}
+
+// TestLambdaHandler_Regression_WebhookURLLambdaOnly exercises the other
+// half of the same invariant: even when NO proxy base is configured, a
+// Lambda-mode agent with a non-root Route must still produce a webhook
+// URL that includes that route.
+func TestLambdaHandler_Regression_WebhookURLLambdaOnly(t *testing.T) {
+	clearAWSEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo-func")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://demo-func.lambda-url.us-east-1.on.aws")
+
+	const user, pass = "u", "p"
+	a := agent.NewAgentBase(
+		agent.WithName("LambdaOnly"),
+		agent.WithRoute("/bot"),
+		agent.WithBasicAuth(user, pass),
+	)
+	a.DefineTool(agent.ToolDefinition{
+		Name:        "noop",
+		Description: "noop",
+		Handler: func(args, raw map[string]any) *swaig.FunctionResult {
+			return swaig.NewFunctionResult("ok")
+		},
+	})
+
+	h := lambda.NewHandler(a.AsRouter())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/bot",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{"authorization": basicAuthHeader(user, pass)},
+		Body:    "{}",
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+
+	webhookURL := extractFirstSwaigWebhook(t, resp.Body)
+	const wantSuffix = "/bot/swaig"
+	if !strings.Contains(webhookURL, wantSuffix) {
+		t.Fatalf("webhook URL = %q, want substring %q", webhookURL, wantSuffix)
+	}
+	if !strings.Contains(webhookURL, "demo-func.lambda-url.us-east-1.on.aws") {
+		t.Fatalf("webhook URL = %q, want Lambda function URL host", webhookURL)
+	}
+}
+
+// extractFirstSwaigWebhook walks a rendered SWML document (as a JSON
+// string) and returns the web_hook_url of the first SWAIG function it
+// finds. t.Fatal is called if the structure is missing — this is always
+// a test bug rather than an expected condition, so a hard fail is fine.
+func extractFirstSwaigWebhook(t *testing.T, body string) string {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(body), &doc); err != nil {
+		t.Fatalf("SWML body is not JSON: %v; body=%q", err, body)
+	}
+	sections, _ := doc["sections"].(map[string]any)
+	main, _ := sections["main"].([]any)
+	for _, v := range main {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		aiCfg, ok := m["ai"].(map[string]any)
+		if !ok {
+			continue
+		}
+		swaigCfg, ok := aiCfg["SWAIG"].(map[string]any)
+		if !ok {
+			continue
+		}
+		fns, _ := swaigCfg["functions"].([]any)
+		if len(fns) == 0 {
+			t.Fatalf("SWAIG functions array is empty; document=%v", doc)
+		}
+		first, _ := fns[0].(map[string]any)
+		url, _ := first["web_hook_url"].(string)
+		return url
+	}
+	t.Fatalf("could not find ai verb with SWAIG functions in document; body=%s", body)
+	return ""
+}
+

--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -1,0 +1,244 @@
+// Package lambda adapts a net/http handler produced by the SignalWire
+// Agents SDK (typically agent.AsRouter()) so it can run inside AWS Lambda.
+//
+// The adapter translates a Lambda invocation event into a synthetic
+// *http.Request, runs the underlying handler against an in-memory response
+// recorder, and marshals the recorder's result back into the Lambda
+// response type that matches the invoking event.
+//
+// Two event shapes are supported, because they are the two ways an AI
+// agent is realistically exposed over HTTP on Lambda:
+//
+//   - Lambda Function URLs (events.LambdaFunctionURLRequest /
+//     LambdaFunctionURLResponse). This is the simplest deployment and
+//     the one we recommend; no API Gateway is required.
+//
+//   - API Gateway HTTP API v2 (events.APIGatewayV2HTTPRequest /
+//     APIGatewayV2HTTPResponse). Identical payload shape in practice,
+//     but consumers with an API Gateway layer want the exact response
+//     type rather than an assignable alias.
+//
+// The classic REST API (v1) payload is intentionally not supported as a
+// first-class path to keep this package small. Users who need v1 can wrap
+// it via github.com/awslabs/aws-lambda-go-api-proxy.
+//
+// # Usage
+//
+//	package main
+//
+//	import (
+//	    "github.com/aws/aws-lambda-go/lambda"
+//	    swlambda "github.com/signalwire/signalwire-go/pkg/lambda"
+//	    "github.com/signalwire/signalwire-go/pkg/agent"
+//	)
+//
+//	var a = agent.NewAgentBase(agent.WithName("MyAgent"), agent.WithRoute("/my-agent"))
+//	var handler = swlambda.NewHandler(a.AsRouter())
+//
+//	func main() {
+//	    lambda.Start(handler.HandleFunctionURL)
+//	}
+//
+// Because agent.AsRouter() installs routes relative to the agent's Route
+// (e.g. /my-agent, /my-agent/swaig), the Lambda event's RawPath must line
+// up with that Route. Lambda Function URLs preserve the full request path
+// unchanged, so no rewriting is needed in the common case.
+package lambda
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// Handler wraps an http.Handler so it can service AWS Lambda invocations.
+// Construct one with NewHandler.
+type Handler struct {
+	h http.Handler
+}
+
+// NewHandler returns a Handler that dispatches Lambda events to the given
+// http.Handler. The handler is usually agent.AsRouter() but any
+// http.Handler works.
+//
+// Panics if h is nil to fail loudly at cold-start rather than silently
+// returning 500 on every invocation.
+func NewHandler(h http.Handler) *Handler {
+	if h == nil {
+		panic("lambda.NewHandler: http.Handler must not be nil")
+	}
+	return &Handler{h: h}
+}
+
+// HandleFunctionURL processes a Lambda Function URL invocation. It is
+// intended to be passed to github.com/aws/aws-lambda-go/lambda.Start.
+func (l *Handler) HandleFunctionURL(ctx context.Context, req events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+	r, err := l.buildRequest(ctx, req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Cookies, req.Body, req.IsBase64Encoded)
+	if err != nil {
+		return events.LambdaFunctionURLResponse{}, err
+	}
+
+	rec := httptest.NewRecorder()
+	l.h.ServeHTTP(rec, r)
+
+	body, isBase64 := encodeBody(rec.Body.Bytes())
+	headers, cookies := splitCookies(rec.Header())
+	return events.LambdaFunctionURLResponse{
+		StatusCode:      rec.Code,
+		Headers:         headers,
+		Body:            body,
+		IsBase64Encoded: isBase64,
+		Cookies:         cookies,
+	}, nil
+}
+
+// HandleAPIGatewayV2 processes an API Gateway HTTP API v2 invocation.
+// The payload shape is virtually identical to Function URLs, but the
+// response type differs, so we provide a dedicated entry point.
+func (l *Handler) HandleAPIGatewayV2(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	r, err := l.buildRequest(ctx, req.RequestContext.HTTP.Method, req.RawPath, req.RawQueryString, req.Headers, req.Cookies, req.Body, req.IsBase64Encoded)
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{}, err
+	}
+
+	rec := httptest.NewRecorder()
+	l.h.ServeHTTP(rec, r)
+
+	body, isBase64 := encodeBody(rec.Body.Bytes())
+	headers, cookies := splitCookies(rec.Header())
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode:      rec.Code,
+		Headers:         headers,
+		Body:            body,
+		IsBase64Encoded: isBase64,
+		Cookies:         cookies,
+	}, nil
+}
+
+// buildRequest constructs a synthetic *http.Request from Lambda event
+// fields that the underlying http.Handler can serve against.
+//
+// The reconstruction is lossy in one intentional way: Method is taken
+// from the event's HTTP block, not from headers, because that is where
+// AWS puts it. Everything else is forwarded verbatim.
+func (l *Handler) buildRequest(
+	ctx context.Context,
+	method, rawPath, rawQuery string,
+	headers map[string]string,
+	cookies []string,
+	body string,
+	isBase64 bool,
+) (*http.Request, error) {
+	if method == "" {
+		method = http.MethodGet
+	}
+	if rawPath == "" {
+		rawPath = "/"
+	}
+
+	// Reconstruct the target URL. We deliberately use a fake host because
+	// the handler doesn't use r.Host for routing — ServeMux uses r.URL.Path.
+	target := rawPath
+	if rawQuery != "" {
+		target = rawPath + "?" + rawQuery
+	}
+	u, err := url.ParseRequestURI(target)
+	if err != nil {
+		return nil, fmt.Errorf("lambda adapter: invalid request URI %q: %w", target, err)
+	}
+
+	// Decode body. Lambda delivers binary data (and sometimes text) with
+	// isBase64Encoded=true; raw JSON comes through as a plain string.
+	// We always pass a non-nil reader so handlers that unconditionally
+	// call io.ReadAll(r.Body) do not nil-deref on empty payloads.
+	var bodyReader io.Reader = bytes.NewReader(nil)
+	if body != "" {
+		if isBase64 {
+			raw, decErr := base64.StdEncoding.DecodeString(body)
+			if decErr != nil {
+				return nil, fmt.Errorf("lambda adapter: base64 body decode failed: %w", decErr)
+			}
+			bodyReader = bytes.NewReader(raw)
+		} else {
+			bodyReader = strings.NewReader(body)
+		}
+	}
+
+	r, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("lambda adapter: NewRequest failed: %w", err)
+	}
+
+	// Populate headers. Lambda normalises header names to lowercase; Go's
+	// http package canonicalises on Set, so the resulting r.Header is
+	// indistinguishable from a real HTTP request.
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+
+	// Function URLs put cookies in a separate "cookies" array rather than
+	// a combined Cookie header. Fold them back into the header so handlers
+	// that read r.Cookies() see what they expect.
+	if len(cookies) > 0 {
+		if existing := r.Header.Get("Cookie"); existing != "" {
+			r.Header.Set("Cookie", existing+"; "+strings.Join(cookies, "; "))
+		} else {
+			r.Header.Set("Cookie", strings.Join(cookies, "; "))
+		}
+	}
+
+	// Ensure RequestURI is empty for client-style requests, which is
+	// what ServeHTTP expects on synthetic requests. http.NewRequest
+	// already leaves it empty; this is a belt-and-braces reminder.
+	r.RequestURI = ""
+
+	return r, nil
+}
+
+// splitCookies extracts Set-Cookie header values into the dedicated
+// cookies slice that Lambda Function URL / API Gateway V2 responses
+// expect, and returns the remaining headers flattened into the
+// single-value map the Lambda response schema requires.
+//
+// Combining multiple Set-Cookie headers into a single comma-joined
+// string would break browsers; the Lambda response types expose a
+// separate Cookies field precisely so the proxy can emit them as
+// multiple Set-Cookie lines.
+func splitCookies(h http.Header) (map[string]string, []string) {
+	out := make(map[string]string, len(h))
+	var cookies []string
+	for k, v := range h {
+		if len(v) == 0 {
+			continue
+		}
+		if http.CanonicalHeaderKey(k) == "Set-Cookie" {
+			cookies = append(cookies, v...)
+			continue
+		}
+		// For all other headers, joining multiple values with ", " is
+		// the canonical HTTP combining rule.
+		out[k] = strings.Join(v, ", ")
+	}
+	return out, cookies
+}
+
+// encodeBody returns the response body in a format Lambda accepts. If the
+// body is valid UTF-8 it is returned verbatim; otherwise it is base64
+// encoded and the second return value is set to true. Binary responses
+// (audio, images, etc.) are rare for this SDK — SWML is always JSON — but
+// handling them correctly is cheap.
+func encodeBody(b []byte) (string, bool) {
+	if utf8.Valid(b) {
+		return string(b), false
+	}
+	return base64.StdEncoding.EncodeToString(b), true
+}

--- a/pkg/lambda/lambda_test.go
+++ b/pkg/lambda/lambda_test.go
@@ -1,0 +1,292 @@
+package lambda
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// echoHandler answers any request with a JSON body describing exactly what
+// it received. Tests assert on this echoed shape to verify the adapter is
+// translating Lambda events into http.Requests faithfully.
+func echoHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		out := map[string]any{
+			"method":      r.Method,
+			"path":        r.URL.Path,
+			"query":       r.URL.RawQuery,
+			"body":        string(bodyBytes),
+			"auth_header": r.Header.Get("Authorization"),
+			"xyz":         r.Header.Get("X-Custom"),
+			"cookie":      r.Header.Get("Cookie"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Add("Set-Cookie", "a=1")
+		w.Header().Add("Set-Cookie", "b=2")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+func TestNewHandler_PanicsOnNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when http.Handler is nil")
+		}
+	}()
+	_ = NewHandler(nil)
+}
+
+func TestNewHandler_ReturnsNonNil(t *testing.T) {
+	if h := NewHandler(echoHandler()); h == nil {
+		t.Error("NewHandler returned nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Function URL dispatch
+// ---------------------------------------------------------------------------
+
+func TestHandleFunctionURL_PassesMethodPathAndQuery(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		RawPath:        "/my-agent/swaig",
+		RawQueryString: "agent_id=123&session=abc",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers: map[string]string{"content-type": "application/json"},
+		Body:    `{"function":"greet"}`,
+	}
+
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var echoed map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &echoed); err != nil {
+		t.Fatalf("response body not JSON: %v", err)
+	}
+	if echoed["method"] != "POST" {
+		t.Errorf("method = %v, want POST", echoed["method"])
+	}
+	if echoed["path"] != "/my-agent/swaig" {
+		t.Errorf("path = %v, want /my-agent/swaig", echoed["path"])
+	}
+	if echoed["query"] != "agent_id=123&session=abc" {
+		t.Errorf("query = %v, want agent_id=123&session=abc", echoed["query"])
+	}
+	if echoed["body"] != `{"function":"greet"}` {
+		t.Errorf("body = %v, want JSON payload", echoed["body"])
+	}
+}
+
+func TestHandleFunctionURL_CopiesHeaders(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+		Headers: map[string]string{
+			"authorization": "Basic dXNlcjpwYXNz",
+			"x-custom":      "hello",
+		},
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	var echoed map[string]any
+	_ = json.Unmarshal([]byte(resp.Body), &echoed)
+	if echoed["auth_header"] != "Basic dXNlcjpwYXNz" {
+		t.Errorf("auth_header = %v", echoed["auth_header"])
+	}
+	if echoed["xyz"] != "hello" {
+		t.Errorf("X-Custom = %v", echoed["xyz"])
+	}
+}
+
+func TestHandleFunctionURL_FoldsCookiesIntoHeader(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+		Cookies: []string{"session=xyz", "theme=dark"},
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	var echoed map[string]any
+	_ = json.Unmarshal([]byte(resp.Body), &echoed)
+	got, _ := echoed["cookie"].(string)
+	if !strings.Contains(got, "session=xyz") || !strings.Contains(got, "theme=dark") {
+		t.Errorf("folded cookie header = %q, want both cookies", got)
+	}
+}
+
+func TestHandleFunctionURL_DecodesBase64Body(t *testing.T) {
+	h := NewHandler(echoHandler())
+	payload := `{"hello":"world"}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body:            encoded,
+		IsBase64Encoded: true,
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	var echoed map[string]any
+	_ = json.Unmarshal([]byte(resp.Body), &echoed)
+	if echoed["body"] != payload {
+		t.Errorf("decoded body = %v, want %q", echoed["body"], payload)
+	}
+}
+
+func TestHandleFunctionURL_InvalidBase64ReturnsError(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body:            "not valid base64!!!",
+		IsBase64Encoded: true,
+	}
+	_, err := h.HandleFunctionURL(context.Background(), req)
+	if err == nil {
+		t.Error("expected base64 decode error, got nil")
+	}
+}
+
+func TestHandleFunctionURL_DefaultsMethodAndPath(t *testing.T) {
+	// Handler should not crash when optional fields are zero.
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		// Method and RawPath intentionally left empty
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (defaults applied)", resp.StatusCode)
+	}
+	var echoed map[string]any
+	_ = json.Unmarshal([]byte(resp.Body), &echoed)
+	if echoed["method"] != "GET" {
+		t.Errorf("default method = %v, want GET", echoed["method"])
+	}
+	if echoed["path"] != "/" {
+		t.Errorf("default path = %v, want /", echoed["path"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response-side conversion
+// ---------------------------------------------------------------------------
+
+func TestHandleFunctionURL_SetCookieMovedToCookiesField(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	// echoHandler adds TWO Set-Cookie headers. They must end up in the
+	// Cookies slice, NOT comma-joined into a single Set-Cookie header.
+	if len(resp.Cookies) != 2 {
+		t.Errorf("Cookies length = %d, want 2; Cookies=%v", len(resp.Cookies), resp.Cookies)
+	}
+	if _, ok := resp.Headers["Set-Cookie"]; ok {
+		t.Errorf("Set-Cookie should have moved to Cookies field, headers=%v", resp.Headers)
+	}
+}
+
+func TestHandleFunctionURL_BinaryResponseIsBase64Encoded(t *testing.T) {
+	// A handler returning invalid UTF-8 must come out base64-encoded.
+	binary := []byte{0xff, 0xfe, 0xfd}
+	h := NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(binary)
+	}))
+	req := events.LambdaFunctionURLRequest{
+		RawPath: "/",
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+	}
+	resp, err := h.HandleFunctionURL(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleFunctionURL: %v", err)
+	}
+	if !resp.IsBase64Encoded {
+		t.Fatal("IsBase64Encoded = false, want true for binary body")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(resp.Body)
+	if err != nil {
+		t.Fatalf("response body is not valid base64: %v", err)
+	}
+	if string(decoded) != string(binary) {
+		t.Errorf("decoded body = %x, want %x", decoded, binary)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API Gateway V2 dispatch
+// ---------------------------------------------------------------------------
+
+func TestHandleAPIGatewayV2_BasicRoundTrip(t *testing.T) {
+	h := NewHandler(echoHandler())
+	req := events.APIGatewayV2HTTPRequest{
+		RawPath: "/my-agent/swaig",
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body: `{"function":"noop"}`,
+	}
+	resp, err := h.HandleAPIGatewayV2(context.Background(), req)
+	if err != nil {
+		t.Fatalf("HandleAPIGatewayV2: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	var echoed map[string]any
+	_ = json.Unmarshal([]byte(resp.Body), &echoed)
+	if echoed["path"] != "/my-agent/swaig" {
+		t.Errorf("path = %v, want /my-agent/swaig", echoed["path"])
+	}
+}

--- a/pkg/swml/execution_mode.go
+++ b/pkg/swml/execution_mode.go
@@ -1,0 +1,93 @@
+package swml
+
+import "os"
+
+// ExecutionMode identifies the runtime environment the service is executing in.
+// The value is used to adjust URL construction, request parsing, and auth
+// handling for platforms that do not provide a traditional TCP listener.
+type ExecutionMode string
+
+const (
+	// ModeServer is the default long-running HTTP server mode.
+	ModeServer ExecutionMode = "server"
+	// ModeCGI indicates the process was invoked by a CGI host
+	// (detected via GATEWAY_INTERFACE).
+	ModeCGI ExecutionMode = "cgi"
+	// ModeLambda indicates the process is running inside AWS Lambda
+	// (detected via AWS_LAMBDA_FUNCTION_NAME or LAMBDA_TASK_ROOT).
+	ModeLambda ExecutionMode = "lambda"
+	// ModeGoogleCloudFunction indicates a Google Cloud Functions
+	// runtime (detected via FUNCTION_TARGET, K_SERVICE, or
+	// GOOGLE_CLOUD_PROJECT).
+	ModeGoogleCloudFunction ExecutionMode = "google_cloud_function"
+	// ModeAzureFunction indicates an Azure Functions runtime
+	// (detected via AZURE_FUNCTIONS_ENVIRONMENT, FUNCTIONS_WORKER_RUNTIME,
+	// or AzureWebJobsStorage).
+	ModeAzureFunction ExecutionMode = "azure_function"
+)
+
+// GetExecutionMode inspects the process environment and returns the detected
+// runtime mode. The detection order matches the Python and TypeScript SDKs so
+// that the same env vars resolve to the same mode across languages.
+//
+// Detection order:
+//  1. CGI         (GATEWAY_INTERFACE)
+//  2. AWS Lambda  (AWS_LAMBDA_FUNCTION_NAME or LAMBDA_TASK_ROOT)
+//  3. GCF         (FUNCTION_TARGET, K_SERVICE, or GOOGLE_CLOUD_PROJECT)
+//  4. Azure       (AZURE_FUNCTIONS_ENVIRONMENT, FUNCTIONS_WORKER_RUNTIME,
+//     or AzureWebJobsStorage)
+//  5. Server      (default fallback)
+func GetExecutionMode() ExecutionMode {
+	if os.Getenv("GATEWAY_INTERFACE") != "" {
+		return ModeCGI
+	}
+	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" || os.Getenv("LAMBDA_TASK_ROOT") != "" {
+		return ModeLambda
+	}
+	if os.Getenv("FUNCTION_TARGET") != "" ||
+		os.Getenv("K_SERVICE") != "" ||
+		os.Getenv("GOOGLE_CLOUD_PROJECT") != "" {
+		return ModeGoogleCloudFunction
+	}
+	if os.Getenv("AZURE_FUNCTIONS_ENVIRONMENT") != "" ||
+		os.Getenv("FUNCTIONS_WORKER_RUNTIME") != "" ||
+		os.Getenv("AzureWebJobsStorage") != "" {
+		return ModeAzureFunction
+	}
+	return ModeServer
+}
+
+// lambdaBaseURL returns the Lambda-specific base URL (scheme+host, no route)
+// using AWS_LAMBDA_FUNCTION_URL if present, otherwise reconstructing the
+// canonical Function URL from AWS_REGION and AWS_LAMBDA_FUNCTION_NAME.
+//
+// The returned string has any trailing slash stripped so that the caller can
+// safely concatenate the agent's route onto it. An empty string is returned
+// only if the environment does not supply enough information to build a URL
+// (no function name AND no explicit URL), which should never happen in a real
+// Lambda runtime.
+func lambdaBaseURL() string {
+	if explicit := os.Getenv("AWS_LAMBDA_FUNCTION_URL"); explicit != "" {
+		return trimTrailingSlash(explicit)
+	}
+	functionName := os.Getenv("AWS_LAMBDA_FUNCTION_NAME")
+	if functionName == "" {
+		return ""
+	}
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	return "https://" + functionName + ".lambda-url." + region + ".on.aws"
+}
+
+// trimTrailingSlash removes a single trailing "/" if present. Used rather
+// than strings.TrimRight because we only want to strip one slash, not all
+// trailing slashes (though in practice that distinction does not matter for
+// AWS Lambda Function URL values).
+func trimTrailingSlash(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '/' {
+		return s[:len(s)-1]
+	}
+	return s
+}

--- a/pkg/swml/execution_mode_test.go
+++ b/pkg/swml/execution_mode_test.go
@@ -1,0 +1,280 @@
+package swml
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Execution mode detection
+// ---------------------------------------------------------------------------
+//
+// Every subtest clears the known serverless-detection env vars so that a
+// developer running these tests inside an actual cloud runtime does not get
+// spurious failures (e.g. a CI pipeline running on GKE where
+// GOOGLE_CLOUD_PROJECT happens to be set). t.Setenv restores the prior value
+// at the end of the test automatically.
+
+// clearExecutionEnv zeroes every env var inspected by GetExecutionMode so
+// each subtest starts from a deterministic baseline.
+func clearExecutionEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"GATEWAY_INTERFACE",
+		"AWS_LAMBDA_FUNCTION_NAME",
+		"LAMBDA_TASK_ROOT",
+		"AWS_LAMBDA_FUNCTION_URL",
+		"AWS_REGION",
+		"FUNCTION_TARGET",
+		"K_SERVICE",
+		"GOOGLE_CLOUD_PROJECT",
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+		"SWML_PROXY_URL_BASE",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestGetExecutionMode_DefaultIsServer(t *testing.T) {
+	clearExecutionEnv(t)
+	if got := GetExecutionMode(); got != ModeServer {
+		t.Errorf("GetExecutionMode() = %q, want %q", got, ModeServer)
+	}
+}
+
+func TestGetExecutionMode_DetectsCGI(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("GATEWAY_INTERFACE", "CGI/1.1")
+	if got := GetExecutionMode(); got != ModeCGI {
+		t.Errorf("GetExecutionMode() = %q, want %q", got, ModeCGI)
+	}
+}
+
+func TestGetExecutionMode_DetectsLambda_FunctionName(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-func")
+	if got := GetExecutionMode(); got != ModeLambda {
+		t.Errorf("GetExecutionMode() = %q, want %q", got, ModeLambda)
+	}
+}
+
+func TestGetExecutionMode_DetectsLambda_TaskRoot(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("LAMBDA_TASK_ROOT", "/var/task")
+	if got := GetExecutionMode(); got != ModeLambda {
+		t.Errorf("GetExecutionMode() = %q, want %q", got, ModeLambda)
+	}
+}
+
+func TestGetExecutionMode_DetectsGCF(t *testing.T) {
+	tests := []string{"FUNCTION_TARGET", "K_SERVICE", "GOOGLE_CLOUD_PROJECT"}
+	for _, env := range tests {
+		t.Run(env, func(t *testing.T) {
+			clearExecutionEnv(t)
+			t.Setenv(env, "something")
+			if got := GetExecutionMode(); got != ModeGoogleCloudFunction {
+				t.Errorf("GetExecutionMode() = %q, want %q", got, ModeGoogleCloudFunction)
+			}
+		})
+	}
+}
+
+func TestGetExecutionMode_DetectsAzure(t *testing.T) {
+	tests := []string{
+		"AZURE_FUNCTIONS_ENVIRONMENT",
+		"FUNCTIONS_WORKER_RUNTIME",
+		"AzureWebJobsStorage",
+	}
+	for _, env := range tests {
+		t.Run(env, func(t *testing.T) {
+			clearExecutionEnv(t)
+			t.Setenv(env, "something")
+			if got := GetExecutionMode(); got != ModeAzureFunction {
+				t.Errorf("GetExecutionMode() = %q, want %q", got, ModeAzureFunction)
+			}
+		})
+	}
+}
+
+// CGI takes precedence over every other serverless marker because CGI can be
+// layered on top of any host — matching the Python SDK ordering.
+func TestGetExecutionMode_CGIWinsOverLambda(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("GATEWAY_INTERFACE", "CGI/1.1")
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-func")
+	if got := GetExecutionMode(); got != ModeCGI {
+		t.Errorf("GetExecutionMode() = %q, want %q (CGI should win)", got, ModeCGI)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lambda base URL construction
+// ---------------------------------------------------------------------------
+
+func TestLambdaBaseURL_UsesExplicitFunctionURL(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://abc123.lambda-url.us-west-2.on.aws")
+	// Function name + region should be IGNORED when the explicit URL is present,
+	// matching the Python reference implementation.
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "other-func")
+	t.Setenv("AWS_REGION", "eu-central-1")
+
+	got := lambdaBaseURL()
+	want := "https://abc123.lambda-url.us-west-2.on.aws"
+	if got != want {
+		t.Errorf("lambdaBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaBaseURL_StripsTrailingSlashFromExplicitURL(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://abc123.lambda-url.us-west-2.on.aws/")
+
+	got := lambdaBaseURL()
+	want := "https://abc123.lambda-url.us-west-2.on.aws"
+	if got != want {
+		t.Errorf("lambdaBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaBaseURL_BuildsFromFunctionNameAndRegion(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-agent")
+	t.Setenv("AWS_REGION", "eu-west-1")
+
+	got := lambdaBaseURL()
+	want := "https://my-agent.lambda-url.eu-west-1.on.aws"
+	if got != want {
+		t.Errorf("lambdaBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaBaseURL_DefaultsRegionToUSEast1(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "my-agent")
+	// AWS_REGION intentionally unset.
+
+	got := lambdaBaseURL()
+	want := "https://my-agent.lambda-url.us-east-1.on.aws"
+	if got != want {
+		t.Errorf("lambdaBaseURL() = %q, want %q", got, want)
+	}
+}
+
+func TestLambdaBaseURL_EmptyIfNothingConfigured(t *testing.T) {
+	clearExecutionEnv(t)
+	if got := lambdaBaseURL(); got != "" {
+		t.Errorf("lambdaBaseURL() = %q, want empty string", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetFullURL integration with Lambda env vars
+// ---------------------------------------------------------------------------
+//
+// These tests are the main contract. The Python and TS SDKs had a bug
+// where the proxy short-circuit returned the bare proxy URL WITHOUT
+// appending the agent's route, resulting in broken SWAIG callbacks. The Go
+// SDK already has the correct behaviour and these tests pin it down so a
+// future refactor cannot regress.
+
+func TestGetFullURL_LambdaWithExplicitFunctionURL_RootRoute(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo") // trip mode detection
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://xyz.lambda-url.us-east-1.on.aws")
+
+	// WithRoute("/") is canonicalised to "" internally via
+	// strings.TrimRight, matching the existing TestServiceGetFullURL
+	// expectation for server mode. The result therefore has no trailing
+	// slash. This is the intentional SDK contract.
+	svc := NewService(WithName("demo"), WithRoute("/"))
+	got := svc.GetFullURL(false)
+	want := "https://xyz.lambda-url.us-east-1.on.aws"
+	if got != want {
+		t.Errorf("GetFullURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGetFullURL_LambdaWithExplicitFunctionURL_NonRootRoute(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://xyz.lambda-url.us-east-1.on.aws")
+
+	svc := NewService(WithName("demo"), WithRoute("/my-agent"))
+	got := svc.GetFullURL(false)
+	want := "https://xyz.lambda-url.us-east-1.on.aws/my-agent"
+	if got != want {
+		t.Errorf("GetFullURL() = %q, want %q", got, want)
+	}
+}
+
+func TestGetFullURL_LambdaFallbackFromFunctionName(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo-func")
+	t.Setenv("AWS_REGION", "us-east-2")
+	// AWS_LAMBDA_FUNCTION_URL intentionally unset: we want to exercise the
+	// region+name fallback path.
+
+	svc := NewService(WithName("demo"), WithRoute("/my-agent"))
+	got := svc.GetFullURL(false)
+	want := "https://demo-func.lambda-url.us-east-2.on.aws/my-agent"
+	if got != want {
+		t.Errorf("GetFullURL() = %q, want %q", got, want)
+	}
+}
+
+// ROUTE-PRESERVATION REGRESSION GUARD. This is the bug that bit the Python
+// and TypeScript SDKs: when SWML_PROXY_URL_BASE is set in a Lambda env, the
+// returned URL MUST still include the agent's route. Without this test, a
+// future refactor could reintroduce the "bare proxy URL" bug.
+func TestGetFullURL_Regression_LambdaNonRootRouteWithProxyBase(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://ignored.lambda-url.us-east-1.on.aws")
+	t.Setenv("SWML_PROXY_URL_BASE", "https://proxy.example.com")
+
+	svc := NewService(WithName("demo"), WithRoute("/my-agent"))
+	got := svc.GetFullURL(false)
+	want := "https://proxy.example.com/my-agent"
+	if got != want {
+		t.Fatalf(
+			"route-preservation regression: GetFullURL() = %q, want %q. "+
+				"The proxy base URL MUST have the agent's route appended.",
+			got, want,
+		)
+	}
+}
+
+// Pairs with the regression test above: without a proxy base set, Lambda
+// detection must STILL append the agent's route.
+func TestGetFullURL_Regression_LambdaNonRootRouteWithoutProxyBase(t *testing.T) {
+	clearExecutionEnv(t)
+	t.Setenv("AWS_LAMBDA_FUNCTION_NAME", "demo")
+	t.Setenv("AWS_LAMBDA_FUNCTION_URL", "https://xxx.lambda-url.us-east-1.on.aws")
+
+	svc := NewService(WithName("demo"), WithRoute("/my-agent"))
+	got := svc.GetFullURL(false)
+	want := "https://xxx.lambda-url.us-east-1.on.aws/my-agent"
+	if got != want {
+		t.Fatalf(
+			"route-preservation regression: GetFullURL() = %q, want %q. "+
+				"The Lambda function URL MUST have the agent's route appended.",
+			got, want,
+		)
+	}
+}
+
+// Server mode (no Lambda env vars, no proxy) keeps the existing local-URL
+// behaviour. Guards against the Lambda code path leaking into plain
+// development use.
+func TestGetFullURL_ServerModeUnchanged(t *testing.T) {
+	clearExecutionEnv(t)
+
+	svc := NewService(WithName("demo"), WithPort(3000), WithRoute("/agent"))
+	got := svc.GetFullURL(false)
+	want := "http://localhost:3000/agent"
+	if got != want {
+		t.Errorf("GetFullURL() = %q, want %q", got, want)
+	}
+}

--- a/pkg/swml/service.go
+++ b/pkg/swml/service.go
@@ -409,26 +409,59 @@ func (s *Service) UserEvent(config map[string]any) error {
 // --- HTTP server ---
 
 // GetFullURL returns the full URL for this service including auth.
+//
+// Base URL resolution order:
+//  1. SWML_PROXY_URL_BASE (explicit proxy override — always wins)
+//  2. Platform-specific base derived from GetExecutionMode() when running
+//     inside a serverless runtime (currently AWS Lambda)
+//  3. Local http://host:port base (default server mode)
+//
+// In every branch the agent's Route is appended to the base. Callers that
+// need to serve SWAIG / post_prompt endpoints then append further path
+// segments onto the result. This invariant is load-bearing: a Lambda-hosted
+// agent at route "/my-agent" must emit SWAIG URLs like
+// "https://xxx.lambda-url.us-east-1.on.aws/my-agent/swaig" — NOT
+// "https://xxx.lambda-url.us-east-1.on.aws/swaig". See buildWebhookURL in
+// pkg/agent/agent.go for the defensive HasSuffix re-check that enforces the
+// same property downstream.
 func (s *Service) GetFullURL(includeAuth bool) string {
+	if s.proxyURLBase != "" {
+		base := strings.TrimRight(s.proxyURLBase, "/")
+		if includeAuth {
+			return insertAuth(base, s.basicAuthUser, s.basicAuthPassword) + s.Route
+		}
+		return base + s.Route
+	}
+
+	if base := platformBaseURL(GetExecutionMode()); base != "" {
+		if includeAuth {
+			return insertAuth(base, s.basicAuthUser, s.basicAuthPassword) + s.Route
+		}
+		return base + s.Route
+	}
+
 	scheme := "http"
 	host := s.Host
 	if host == "0.0.0.0" {
 		host = "localhost"
 	}
-
-	if s.proxyURLBase != "" {
-		base := strings.TrimRight(s.proxyURLBase, "/")
-		if includeAuth {
-			return fmt.Sprintf("%s%s", insertAuth(base, s.basicAuthUser, s.basicAuthPassword), s.Route)
-		}
-		return base + s.Route
-	}
-
 	base := fmt.Sprintf("%s://%s:%d", scheme, host, s.Port)
 	if includeAuth {
-		return fmt.Sprintf("%s%s", insertAuth(base, s.basicAuthUser, s.basicAuthPassword), s.Route)
+		return insertAuth(base, s.basicAuthUser, s.basicAuthPassword) + s.Route
 	}
 	return base + s.Route
+}
+
+// platformBaseURL returns a serverless-platform-specific base URL (scheme +
+// host, no path) for the given execution mode, or the empty string if the
+// mode has no platform override. Callers concatenate Route onto the result.
+func platformBaseURL(mode ExecutionMode) string {
+	switch mode {
+	case ModeLambda:
+		return lambdaBaseURL()
+	default:
+		return ""
+	}
 }
 
 // RegisterRoutingCallback registers a callback for a specific path.


### PR DESCRIPTION
## Summary

- Adds full Lambda runtime support: execution-mode detection, Lambda URL generation, and an event-to-`http.Handler` adapter in `pkg/lambda`. Agent's route is concatenated into every webhook URL on every branch (proxy + Lambda + local) with a defensive `HasSuffix` re-check — guards against the route-dropping bug recently fixed in the Python and TypeScript SDKs.
- Adds `--simulate-serverless lambda` to `swaig-test` (library API form since Go agents are binaries). Env vars are applied via `HandlerFactory` pattern so `AgentBase` construction happens *after* `SWML_PROXY_URL_BASE` is cleared — verified by a regression test that catches construction-order bugs.
- Follows the conditional-required structure now documented in the porting-sdk repo's § Serverless Support (Step 0–6) and Phase 10 CLI sections.

## Test plan

- [x] `go test ./...` — all 17 packages pass, 0 skipped
- [x] `go test -race ./pkg/lambda/... ./pkg/swml/... ./pkg/agent/...` — clean
- [x] `go vet ./...` — clean
- [x] Route-preservation regression tests at both `GetFullURL` and `buildWebhookURL` layers
- [x] Simulator env set/restore verified on happy + panic paths
- [x] Non-root route + Lambda env + proxy-base combo asserted in integration test
- [x] `--simulate-serverless gcf|azure|cgi` rejected with clear Phase-9 error

Commits:
- \`df24bd3\` Add AWS Lambda runtime support
- \`9874d09\` Add --simulate-serverless flag to swaig-test CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)