### PR TITLE
Align SWML verb handlers with Python SDK

### DIFF
--- a/pkg/swml/ai_verb_handler.go
+++ b/pkg/swml/ai_verb_handler.go
@@ -183,9 +183,9 @@ func (h *AIVerbHandler) BuildConfig(params map[string]any) (map[string]any, erro
 			extraParams[k] = v
 		}
 	}
-	if len(extraParams) > 0 {
-		config["params"] = extraParams
-	}
+	// Always emit "params" (even if empty) to match Python's AIVerbHandler.build_config,
+	// which initializes config["params"] = {} before the kwargs loop.
+	config["params"] = extraParams
 
 	return config, nil
 }

--- a/pkg/swml/ai_verb_handler.go
+++ b/pkg/swml/ai_verb_handler.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package swml
+
+import "fmt"
+
+// AIVerbHandler is a concrete VerbHandler for the SWML "ai" verb.
+//
+// It implements the VerbHandler interface and provides validation and
+// configuration-building logic for the AI verb. This is the Go equivalent
+// of the Python AIVerbHandler class in core/swml_handler.py.
+//
+// The AI verb is complex and requires specialized handling, particularly
+// for managing prompts, SWAIG functions, and AI configurations.
+type AIVerbHandler struct{}
+
+// NewAIVerbHandler returns a new AIVerbHandler ready for registration.
+//
+// Example:
+//
+//	svc.RegisterVerbHandler(swml.NewAIVerbHandler())
+func NewAIVerbHandler() *AIVerbHandler {
+	return &AIVerbHandler{}
+}
+
+// GetVerbName returns "ai", the name of the SWML verb this handler handles.
+func (h *AIVerbHandler) GetVerbName() string {
+	return "ai"
+}
+
+// ValidateConfig validates the configuration map for the AI verb.
+//
+// Validation rules (ported from Python AIVerbHandler.validate_config):
+//   - "prompt" key must be present and must be a map[string]any.
+//   - "prompt" must contain exactly one of "text" or "pom" (mutually exclusive).
+//   - If "prompt.contexts" is present it must be a map[string]any.
+//   - If "SWAIG" is present it must be a map[string]any.
+//
+// Returns (true, nil) when the config is valid; (false, errors) when it is not.
+func (h *AIVerbHandler) ValidateConfig(config map[string]any) (bool, []string) {
+	var errors []string
+
+	// Require "prompt" key.
+	rawPrompt, ok := config["prompt"]
+	if !ok {
+		errors = append(errors, "Missing required field 'prompt'")
+		return false, errors
+	}
+
+	prompt, ok := rawPrompt.(map[string]any)
+	if !ok {
+		errors = append(errors, "'prompt' must be an object")
+		return false, errors
+	}
+
+	// Exactly one of "text" or "pom" must be present (mutually exclusive).
+	_, hasText := prompt["text"]
+	_, hasPom := prompt["pom"]
+	baseCount := 0
+	if hasText {
+		baseCount++
+	}
+	if hasPom {
+		baseCount++
+	}
+	switch {
+	case baseCount == 0:
+		errors = append(errors, "'prompt' must contain either 'text' or 'pom' as base prompt")
+	case baseCount > 1:
+		errors = append(errors, "'prompt' can only contain one of: 'text' or 'pom' (mutually exclusive)")
+	}
+
+	// "prompt.contexts" is optional but must be a map when present.
+	if rawContexts, exists := prompt["contexts"]; exists {
+		if _, ok := rawContexts.(map[string]any); !ok {
+			errors = append(errors, "'prompt.contexts' must be an object")
+		}
+	}
+
+	// "SWAIG" is optional but must be a map when present.
+	if rawSWAIG, exists := config["SWAIG"]; exists {
+		if _, ok := rawSWAIG.(map[string]any); !ok {
+			errors = append(errors, "'SWAIG' must be an object")
+		}
+	}
+
+	return len(errors) == 0, errors
+}
+
+// BuildConfig assembles an AI verb configuration map from the provided params.
+//
+// Recognised keys in params (ported from Python AIVerbHandler.build_config):
+//
+//   - "prompt_text"     (string)          — text prompt; mutually exclusive with "prompt_pom"
+//   - "prompt_pom"      ([]any or similar) — POM structure; mutually exclusive with "prompt_text"
+//   - "contexts"        (map[string]any)  — optional contexts / steps configuration
+//   - "post_prompt"     (string)          — optional post-prompt text; wrapped in {"text": value}
+//   - "post_prompt_url" (string)          — optional post-prompt URL
+//   - "swaig"           (map[string]any)  — optional SWAIG configuration; emitted as "SWAIG"
+//
+// Additional keys in params are handled as follows (matching Python **kwargs logic):
+//   - "languages", "hints", "pronounce", "global_data" — emitted as top-level keys.
+//   - All other extra keys are collected under a nested "params" map.
+//
+// Returns (configMap, nil) on success, or (nil, error) if the parameters are
+// contradictory (e.g. both prompt_text and prompt_pom supplied, or neither).
+func (h *AIVerbHandler) BuildConfig(params map[string]any) (map[string]any, error) {
+	config := make(map[string]any)
+
+	// Extract named params — mirroring Python's named arguments.
+	promptText, _ := params["prompt_text"]
+	promptPom, _ := params["prompt_pom"]
+	contexts, _ := params["contexts"]
+	postPrompt, _ := params["post_prompt"]
+	postPromptURL, _ := params["post_prompt_url"]
+	swaig, _ := params["swaig"]
+
+	// Exactly one of prompt_text / prompt_pom is required.
+	hasText := promptText != nil
+	hasPom := promptPom != nil
+	baseCount := 0
+	if hasText {
+		baseCount++
+	}
+	if hasPom {
+		baseCount++
+	}
+	switch {
+	case baseCount == 0:
+		return nil, fmt.Errorf("either prompt_text or prompt_pom must be provided as base prompt")
+	case baseCount > 1:
+		return nil, fmt.Errorf("prompt_text and prompt_pom are mutually exclusive")
+	}
+
+	// Build prompt object.
+	promptConfig := make(map[string]any)
+	if hasText {
+		promptConfig["text"] = promptText
+	} else {
+		promptConfig["pom"] = promptPom
+	}
+	if contexts != nil {
+		promptConfig["contexts"] = contexts
+	}
+	config["prompt"] = promptConfig
+
+	// Post-prompt: wrapped in {"text": value} to match Python behaviour.
+	if postPrompt != nil {
+		config["post_prompt"] = map[string]any{"text": postPrompt}
+	}
+
+	// Post-prompt URL.
+	if postPromptURL != nil {
+		config["post_prompt_url"] = postPromptURL
+	}
+
+	// SWAIG: emitted as top-level "SWAIG" key.
+	if swaig != nil {
+		config["SWAIG"] = swaig
+	}
+
+	// Pass-through kwargs — mirroring Python's **kwargs handling.
+	// "languages", "hints", "pronounce", "global_data" go to the top level;
+	// everything else accumulates under "params".
+	topLevelKeys := map[string]bool{
+		"prompt_text": true, "prompt_pom": true, "contexts": true,
+		"post_prompt": true, "post_prompt_url": true, "swaig": true,
+	}
+	extraParams := make(map[string]any)
+	for k, v := range params {
+		if topLevelKeys[k] {
+			continue
+		}
+		switch k {
+		case "languages", "hints", "pronounce", "global_data":
+			config[k] = v
+		default:
+			extraParams[k] = v
+		}
+	}
+	if len(extraParams) > 0 {
+		config["params"] = extraParams
+	}
+
+	return config, nil
+}

--- a/pkg/swml/service.go
+++ b/pkg/swml/service.go
@@ -57,6 +57,10 @@ type Service struct {
 
 	// Verb method cache: maps verb name to whether it exists in schema
 	verbCache map[string]bool
+
+	// verbHandlers holds pluggable handlers registered by callers for custom
+	// or extended SWML verbs. Keyed by the verb name returned by VerbHandler.GetVerbName().
+	verbHandlers map[string]VerbHandler
 }
 
 // ServiceOption is a functional option for configuring a Service.
@@ -158,6 +162,9 @@ func NewService(opts ...ServiceOption) *Service {
 		s.schema = schema
 		s.Logger.Debug("loaded schema with %d verbs", schema.VerbCount())
 	}
+
+	// Register built-in verb handlers (mirrors Python VerbHandlerRegistry.__init__).
+	s.RegisterVerbHandler(NewAIVerbHandler())
 
 	return s
 }

--- a/pkg/swml/verb_handler.go
+++ b/pkg/swml/verb_handler.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package swml
+
+// VerbHandler defines the contract for specialized SWML verb handlers.
+//
+// Implementations provide verb-specific validation and configuration-building
+// logic for complex SWML verbs that cannot be handled generically. This is
+// the Go equivalent of the Python SWMLVerbHandler abstract base class.
+type VerbHandler interface {
+	// GetVerbName returns the name of the SWML verb this handler handles.
+	//
+	// The returned name must match the verb name used in SWML documents
+	// (e.g., "ai", "play", "record").
+	GetVerbName() string
+
+	// ValidateConfig validates the configuration map for this verb.
+	//
+	// config is the configuration dictionary for this verb. It returns
+	// (isValid, errorMessages): isValid is true when the config passes all
+	// validation checks, and errorMessages contains human-readable descriptions
+	// of any validation failures. When isValid is true, errorMessages will be
+	// empty.
+	ValidateConfig(config map[string]any) (bool, []string)
+
+	// BuildConfig builds a configuration map for this verb from the provided
+	// parameters.
+	//
+	// params contains keyword arguments specific to this verb, mirroring the
+	// **kwargs pattern from Python. It returns the constructed configuration
+	// map, or an error if the provided parameters are insufficient or
+	// contradictory.
+	BuildConfig(params map[string]any) (map[string]any, error)
+}
+
+// RegisterVerbHandler registers a custom handler for a SWML verb, keyed by
+// the name returned by h.GetVerbName(). A subsequent call with the same verb
+// name replaces the previous handler. This is the Go equivalent of Python's
+// VerbHandlerRegistry.register_handler.
+func (s *Service) RegisterVerbHandler(h VerbHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.verbHandlers == nil {
+		s.verbHandlers = make(map[string]VerbHandler)
+	}
+	s.verbHandlers[h.GetVerbName()] = h
+}
+
+// GetVerbHandler returns the registered handler for verbName, or nil if no
+// handler has been registered for that verb. This is the Go equivalent of
+// Python's VerbHandlerRegistry.get_handler.
+func (s *Service) GetVerbHandler(verbName string) VerbHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.verbHandlers[verbName]
+}
+
+// HasVerbHandler reports whether a custom handler is registered for verbName.
+// This is the Go equivalent of Python's VerbHandlerRegistry.has_handler.
+func (s *Service) HasVerbHandler(verbName string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.verbHandlers[verbName]
+	return ok
+}

--- a/pkg/swml/verb_handler_test.go
+++ b/pkg/swml/verb_handler_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package swml
+
+import (
+	"testing"
+)
+
+// --- Service registry: RegisterVerbHandler / GetVerbHandler / HasVerbHandler ---
+
+// stubVerbHandler implements VerbHandler for registry tests.
+type stubVerbHandler struct {
+	name string
+}
+
+func (s *stubVerbHandler) GetVerbName() string { return s.name }
+func (s *stubVerbHandler) ValidateConfig(map[string]any) (bool, []string) {
+	return true, nil
+}
+func (s *stubVerbHandler) BuildConfig(params map[string]any) (map[string]any, error) {
+	return params, nil
+}
+
+func TestServiceRegisterVerbHandlerStoresAndLooksUp(t *testing.T) {
+	svc := NewService(WithName("test"))
+	h := &stubVerbHandler{name: "custom_verb"}
+
+	if svc.HasVerbHandler("custom_verb") {
+		t.Fatalf("HasVerbHandler should be false before registration")
+	}
+	if got := svc.GetVerbHandler("custom_verb"); got != nil {
+		t.Fatalf("GetVerbHandler should return nil before registration, got %#v", got)
+	}
+
+	svc.RegisterVerbHandler(h)
+
+	if !svc.HasVerbHandler("custom_verb") {
+		t.Fatalf("HasVerbHandler should be true after registration")
+	}
+	got := svc.GetVerbHandler("custom_verb")
+	if got != h {
+		t.Fatalf("GetVerbHandler returned %#v, want %p", got, h)
+	}
+}
+
+func TestServiceRegisterVerbHandlerReplacesPrevious(t *testing.T) {
+	svc := NewService(WithName("test"))
+	first := &stubVerbHandler{name: "dup"}
+	second := &stubVerbHandler{name: "dup"}
+
+	svc.RegisterVerbHandler(first)
+	svc.RegisterVerbHandler(second)
+
+	got := svc.GetVerbHandler("dup")
+	if got != second {
+		t.Fatalf("GetVerbHandler returned %p, expected the second handler %p", got, second)
+	}
+}
+
+func TestServiceAIHandlerRegisteredByDefault(t *testing.T) {
+	// NewService should pre-register the AIVerbHandler for the "ai" verb —
+	// matches Python's SWMLVerbHandlerRegistry __init__ which populates
+	// AIVerbHandler automatically.
+	svc := NewService(WithName("test"))
+	if !svc.HasVerbHandler("ai") {
+		t.Fatalf(`expected default "ai" verb handler registered by NewService`)
+	}
+	h := svc.GetVerbHandler("ai")
+	if _, ok := h.(*AIVerbHandler); !ok {
+		t.Fatalf(`default "ai" handler should be *AIVerbHandler, got %T`, h)
+	}
+}
+
+// --- AIVerbHandler.ValidateConfig ---
+
+func TestAIVerbHandlerValidateConfigMissingPrompt(t *testing.T) {
+	h := NewAIVerbHandler()
+	valid, errs := h.ValidateConfig(map[string]any{})
+	if valid {
+		t.Fatalf("ValidateConfig should reject config without prompt")
+	}
+	if len(errs) == 0 {
+		t.Fatalf("expected error messages, got none")
+	}
+}
+
+func TestAIVerbHandlerValidateConfigPromptNotObject(t *testing.T) {
+	h := NewAIVerbHandler()
+	valid, errs := h.ValidateConfig(map[string]any{"prompt": "bare-string"})
+	if valid {
+		t.Fatalf("ValidateConfig should reject a bare-string prompt")
+	}
+	if len(errs) == 0 {
+		t.Fatalf("expected error messages for bare-string prompt")
+	}
+}
+
+func TestAIVerbHandlerValidateConfigAcceptsText(t *testing.T) {
+	h := NewAIVerbHandler()
+	valid, errs := h.ValidateConfig(map[string]any{
+		"prompt": map[string]any{"text": "hello"},
+	})
+	if !valid {
+		t.Fatalf("ValidateConfig should accept text prompt, got errors: %v", errs)
+	}
+}
+
+func TestAIVerbHandlerValidateConfigAcceptsPOM(t *testing.T) {
+	h := NewAIVerbHandler()
+	valid, errs := h.ValidateConfig(map[string]any{
+		"prompt": map[string]any{"pom": []any{map[string]any{"title": "x"}}},
+	})
+	if !valid {
+		t.Fatalf("ValidateConfig should accept pom prompt, got errors: %v", errs)
+	}
+}
+
+func TestAIVerbHandlerValidateConfigTextAndPOMMutuallyExclusive(t *testing.T) {
+	h := NewAIVerbHandler()
+	valid, _ := h.ValidateConfig(map[string]any{
+		"prompt": map[string]any{"text": "hi", "pom": []any{}},
+	})
+	if valid {
+		t.Fatalf("ValidateConfig should reject having both text and pom")
+	}
+}
+
+// --- AIVerbHandler.BuildConfig ---
+
+func TestAIVerbHandlerBuildConfigAlwaysEmitsParams(t *testing.T) {
+	// Regression guard for issue #118 — Python always emits
+	// config["params"] = {} even when no extra kwargs are supplied.
+	h := NewAIVerbHandler()
+	cfg, err := h.BuildConfig(map[string]any{"prompt_text": "hi"})
+	if err != nil {
+		t.Fatalf("BuildConfig returned error: %v", err)
+	}
+	params, present := cfg["params"]
+	if !present {
+		t.Fatalf(`expected "params" key in BuildConfig output, got keys: %v`, mapKeys(cfg))
+	}
+	m, ok := params.(map[string]any)
+	if !ok {
+		t.Fatalf(`"params" should be map[string]any, got %T`, params)
+	}
+	if len(m) != 0 {
+		t.Fatalf(`expected empty "params" map, got %v`, m)
+	}
+}
+
+func TestAIVerbHandlerBuildConfigCollectsExtraKwargs(t *testing.T) {
+	h := NewAIVerbHandler()
+	cfg, err := h.BuildConfig(map[string]any{
+		"prompt_text": "hi",
+		"tenant_id":   "abc",
+		"custom_flag": true,
+	})
+	if err != nil {
+		t.Fatalf("BuildConfig returned error: %v", err)
+	}
+	params, _ := cfg["params"].(map[string]any)
+	if params["tenant_id"] != "abc" {
+		t.Fatalf(`params["tenant_id"] = %v, want "abc"`, params["tenant_id"])
+	}
+	if params["custom_flag"] != true {
+		t.Fatalf(`params["custom_flag"] = %v, want true`, params["custom_flag"])
+	}
+}
+
+func TestAIVerbHandlerBuildConfigPromotesWellKnownKeys(t *testing.T) {
+	// languages/hints/pronounce/global_data go to the top level, not into params.
+	// Matches Python AIVerbHandler.build_config.
+	h := NewAIVerbHandler()
+	cfg, err := h.BuildConfig(map[string]any{
+		"prompt_text": "hi",
+		"languages":   []any{"en"},
+		"hints":       []any{"foo"},
+		"pronounce":   []any{},
+		"global_data": map[string]any{"k": "v"},
+	})
+	if err != nil {
+		t.Fatalf("BuildConfig returned error: %v", err)
+	}
+	for _, k := range []string{"languages", "hints", "pronounce", "global_data"} {
+		if _, ok := cfg[k]; !ok {
+			t.Errorf("expected top-level key %q in output", k)
+		}
+	}
+	// None of those should end up under params.
+	params, _ := cfg["params"].(map[string]any)
+	for _, k := range []string{"languages", "hints", "pronounce", "global_data"} {
+		if _, present := params[k]; present {
+			t.Errorf("top-level key %q must not appear in params", k)
+		}
+	}
+}
+
+func TestAIVerbHandlerBuildConfigRejectsMissingPrompt(t *testing.T) {
+	h := NewAIVerbHandler()
+	_, err := h.BuildConfig(map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error when neither prompt_text nor prompt_pom supplied")
+	}
+}
+
+func TestAIVerbHandlerBuildConfigRejectsBothPrompts(t *testing.T) {
+	h := NewAIVerbHandler()
+	_, err := h.BuildConfig(map[string]any{
+		"prompt_text": "hi",
+		"prompt_pom":  []any{},
+	})
+	if err == nil {
+		t.Fatalf("expected error when both prompt_text and prompt_pom supplied")
+	}
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: add SWML verb handler extension point (P0)

Brings signalwire-go to parity with Python's pluggable SWML verb-handler
surface in signalwire/core/swml_handler.py.

- VerbHandler interface (pkg/swml/verb_handler.go) with GetVerbName /
  ValidateConfig / BuildConfig — Go equivalent of SWMLVerbHandler(ABC).
- Registry methods on *Service (RegisterVerbHandler / GetVerbHandler /
  HasVerbHandler) + verbHandlers map, guarded by the existing Service mutex.
- AIVerbHandler concrete implementation (pkg/swml/ai_verb_handler.go)
  mirroring Python's AIVerbHandler validation (prompt presence, text/pom
  exclusivity, SWAIG shape) and BuildConfig output map. Registered on
  NewService so the AI verb has a handler by default.

Closes #19 (AIVerbHandler), #76 (SWMLVerbHandler), #78 (VerbHandlerRegistry).

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #19
Closes #76
Closes #78
Closes #118

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3

