### PR TITLE
Align livewire sentinel + compat types with Python SDK

### DIFF
--- a/pkg/livewire/livewire.go
+++ b/pkg/livewire/livewire.go
@@ -608,3 +608,73 @@ type AgentHandoff struct {
 
 // StopResponse signals that a tool should not trigger another LLM reply.
 type StopResponse struct{}
+
+// ---------------------------------------------------------------------------
+// ToolError
+// ---------------------------------------------------------------------------
+
+// ToolError signals a tool execution error. Return a *ToolError from a tool
+// handler to tell the framework the tool failed; the error message is forwarded
+// to the LLM as a tool-failure notification rather than triggering a normal
+// LLM reply. Parallel to StopResponse in this file.
+type ToolError struct {
+	Message string
+}
+
+// Error implements the built-in error interface.
+func (e *ToolError) Error() string { return e.Message }
+
+// NewToolError constructs a ToolError with the given message.
+func NewToolError(message string) *ToolError { return &ToolError{Message: message} }
+
+// ---------------------------------------------------------------------------
+// ChatContext
+// ---------------------------------------------------------------------------
+
+// ChatMessage holds a single role/content pair in a conversation history.
+// The JSON tags match the dict keys produced by the Python ChatContext.append()
+// implementation: {"role": ..., "content": ...}.
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatContext buffers a conversation as an ordered list of role/content
+// messages.  It mirrors the Python livewire.ChatContext stub which is
+// API-compatible with the livekit-agents ChatContext shape.
+type ChatContext struct {
+	Messages []ChatMessage
+}
+
+// NewChatContext returns an empty ChatContext ready for use.
+func NewChatContext() *ChatContext { return &ChatContext{} }
+
+// Append adds a role/content message to the context and returns the receiver
+// for method chaining.  If role is empty it defaults to "user"; if content is
+// empty it defaults to "" (empty string), matching the Python defaults
+// role="user", text="".
+func (c *ChatContext) Append(role, content string) *ChatContext {
+	if role == "" {
+		role = "user"
+	}
+	c.Messages = append(c.Messages, ChatMessage{Role: role, Content: content})
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// InferenceTTS
+// ---------------------------------------------------------------------------
+
+// InferenceTTS is a no-op stub providing LiveKit import compatibility.
+// SignalWire's control plane handles text-to-speech; this type exists so
+// code written for livekit/agents inference.TTS can be dropped in unchanged.
+type InferenceTTS struct {
+	Model string
+}
+
+// NewInferenceTTS creates an InferenceTTS stub with the given model hint.
+// The model value is stored for compatibility but is otherwise unused.
+func NewInferenceTTS(model string) *InferenceTTS {
+	getGlobalNoop().once("inference_tts", fmt.Sprintf("NewInferenceTTS(%q): SignalWire's control plane handles text-to-speech -- inference stubs are no-ops", model))
+	return &InferenceTTS{Model: model}
+}


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: add livewire sentinel and compat types (P0)

Brings signalwire-go to parity with three missing public types in Python's
signalwire/livewire/__init__.py.

- ChatContext + ChatMessage + NewChatContext + Append (line 162) —
  conversation history buffer with role/content messages and fluent chaining.
- ToolError + NewToolError (line 145) — sentinel error type mirroring
  Python's ToolError(Exception), implementing the built-in error interface.
  Parallel to existing StopResponse in the same file.
- InferenceTTS + NewInferenceTTS (line 755) — no-op LiveKit import
  compatibility stub; model hint stored but unused.

Closes #25 (ChatContext), #77 (ToolError), #44 (InferenceTTS).

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #25
Closes #44
Closes #77

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
