### PR TITLE
Align RelayError with Python SDK

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -287,7 +287,7 @@ func (c *Client) authenticate() error {
 			c.mu.Unlock()
 
 			if msg.Error != nil {
-				return fmt.Errorf("auth error %d: %s", msg.Error.Code, msg.Error.Message)
+				return NewRelayError(msg.Error.Code, msg.Error.Message)
 			}
 
 			var authResult struct {
@@ -448,7 +448,7 @@ func (c *Client) execute(method string, params map[string]any) (json.RawMessage,
 			Message string `json:"message"`
 		}
 		if err := json.Unmarshal(resp, &errResp); err == nil && errResp.Code != 0 {
-			return nil, fmt.Errorf("relay error %d: %s", errResp.Code, errResp.Message)
+			return nil, NewRelayError(errResp.Code, errResp.Message)
 		}
 		return resp, nil
 	case <-c.ctx.Done():

--- a/pkg/relay/error.go
+++ b/pkg/relay/error.go
@@ -1,0 +1,25 @@
+package relay
+
+import "fmt"
+
+// RelayError is a typed error returned by the RELAY protocol client.
+// It carries the numeric code and message from the server so callers can
+// programmatically inspect failures via errors.As.
+//
+// The error format matches Python's RelayError.__str__:
+// "RELAY error {code}: {message}".
+type RelayError struct {
+	Code    int
+	Message string
+}
+
+// Error implements the built-in error interface.
+// Format matches Python's RelayError.__str__: "RELAY error {code}: {message}".
+func (e *RelayError) Error() string {
+	return fmt.Sprintf("RELAY error %d: %s", e.Code, e.Message)
+}
+
+// NewRelayError constructs a RelayError with the given code and message.
+func NewRelayError(code int, message string) *RelayError {
+	return &RelayError{Code: code, Message: message}
+}


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: add typed RelayError for Relay protocol failures (P0)

Brings signalwire-go to parity with Python's RelayError class in
signalwire/relay/client.py:1106.

- RelayError struct with Code int, Message string, and Error() string
  formatting "RELAY error {code}: {message}" (matches Python __str__).
- NewRelayError constructor for consistent Go-idiomatic construction.
- client.go:290 (auth error) and client.go:451 (relay error response)
  now return *RelayError instead of opaque fmt.Errorf strings, enabling
  callers to use errors.As for programmatic code inspection.

Closes #61.

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #61

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
