### PR TITLE
Align Call with Python SDK

### DIFF
--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -14,13 +14,18 @@ import (
 // DTMF, detection, fax, tap, streaming, conferencing, AI, hold/denoise,
 // room/queue, pay, and transcription.
 type Call struct {
-	callID  string
-	nodeID  string
-	tag     string
-	client  *Client
-	state   string
-	mu      sync.Mutex
-	actions map[string]*Action
+	callID    string
+	nodeID    string
+	tag       string
+	client    *Client
+	state     string
+	projectID string
+	context   string
+	direction string
+	device    map[string]any
+	segmentID string
+	mu        sync.Mutex
+	actions   map[string]*Action
 
 	eventHandlers map[string][]func(*RelayEvent)
 	waiters       []waiter
@@ -62,6 +67,41 @@ func (c *Call) State() string {
 	return c.state
 }
 
+// ProjectID returns the project ID associated with this call.
+func (c *Call) ProjectID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.projectID
+}
+
+// Context returns the RELAY context this call was received on.
+func (c *Call) Context() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.context
+}
+
+// Direction returns the call direction ("inbound" or "outbound").
+func (c *Call) Direction() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.direction
+}
+
+// Device returns the device map describing the endpoint of this call.
+func (c *Call) Device() map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.device
+}
+
+// SegmentID returns the segment identifier for this call leg.
+func (c *Call) SegmentID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.segmentID
+}
+
 // ---------------------------------------------------------------------------
 // Event handling
 // ---------------------------------------------------------------------------
@@ -93,6 +133,15 @@ func (c *Call) WaitFor(ctx context.Context, eventType string, predicate func(*Re
 	}
 }
 
+// WaitForEnded blocks until the call reaches the "ended" state, or the
+// context expires. This mirrors Python's wait_for_ended() which awaits
+// the _ended asyncio.Future.
+func (c *Call) WaitForEnded(ctx context.Context) (*RelayEvent, error) {
+	return c.WaitFor(ctx, EventCallingCallState, func(e *RelayEvent) bool {
+		return e.GetString("call_state") == CallStateEnded
+	})
+}
+
 // dispatchEvent is called internally to route an event through handlers
 // and waiters.
 func (c *Call) dispatchEvent(event *RelayEvent) {
@@ -102,6 +151,31 @@ func (c *Call) dispatchEvent(event *RelayEvent) {
 	if event.EventType == EventCallingCallState {
 		if s := event.GetString("call_state"); s != "" {
 			c.state = s
+		}
+		if d := event.GetString("direction"); d != "" && c.direction == "" {
+			c.direction = d
+		}
+		if dev := event.GetMap("device"); dev != nil && c.device == nil {
+			c.device = dev
+		}
+	}
+
+	// Populate metadata from inbound receive events.
+	if event.EventType == EventCallingCallReceive {
+		if ctx := event.GetString("context"); ctx != "" && c.context == "" {
+			c.context = ctx
+		}
+		if dev := event.GetMap("device"); dev != nil && c.device == nil {
+			c.device = dev
+		}
+		if pid := event.GetString("project_id"); pid != "" && c.projectID == "" {
+			c.projectID = pid
+		}
+		if seg := event.GetString("segment_id"); seg != "" && c.segmentID == "" {
+			c.segmentID = seg
+		}
+		if d := event.GetString("direction"); d != "" && c.direction == "" {
+			c.direction = d
 		}
 	}
 
@@ -187,14 +261,67 @@ func (c *Call) Pass() error {
 	return err
 }
 
-// Transfer transfers the call to another destination.
-func (c *Call) Transfer(dest map[string]any) error {
+// Transfer transfers call control to another RELAY app or SWML script.
+// The dest parameter is the destination context/URL string, sent as the
+// "dest" key to the server (matches Python's transfer(dest: str) behavior).
+func (c *Call) Transfer(dest string) error {
+	_, err := c.client.execute("calling.transfer", map[string]any{
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+		"dest":    dest,
+	})
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// SIP Refer
+// ---------------------------------------------------------------------------
+
+// Refer transfers a SIP call to an external SIP endpoint via a REFER request.
+// statusURL is optional (empty string omits it), matching Python's
+// refer(device, *, status_url).
+func (c *Call) Refer(device map[string]any, statusURL string) error {
 	params := map[string]any{
-		"node_id":     c.nodeID,
-		"call_id":     c.callID,
-		"destination": dest,
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+		"device":  device,
 	}
-	_, err := c.client.execute("calling.transfer", params)
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.refer", params)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Live Transcribe / Translate
+// ---------------------------------------------------------------------------
+
+// LiveTranscribe starts or stops live transcription on the call. The action
+// map describes the transcription operation (e.g. {"type": "start"}).
+// Matches Python's live_transcribe(action, **kwargs).
+func (c *Call) LiveTranscribe(action map[string]any) error {
+	_, err := c.client.execute("calling.live_transcribe", map[string]any{
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+		"action":  action,
+	})
+	return err
+}
+
+// LiveTranslate starts or stops live translation on the call. The action map
+// describes the translation operation. statusURL is optional (empty string
+// omits it), matching Python's live_translate(action, *, status_url).
+func (c *Call) LiveTranslate(action map[string]any, statusURL string) error {
+	params := map[string]any{
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+		"action":  action,
+	}
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.live_translate", params)
 	return err
 }
 
@@ -263,10 +390,55 @@ func (c *Call) PlayAndCollect(media []map[string]any, collect map[string]any, op
 	return action
 }
 
-// Collect starts collecting user input without playing media.
-func (c *Call) Collect(collect map[string]any) *StandaloneCollectAction {
+// CollectParams holds named parameters for the Collect method, matching
+// Python's collect() named arguments.
+type CollectParams struct {
+	// Digits configures DTMF digit collection.
+	Digits map[string]any
+	// Speech configures speech recognition collection.
+	Speech map[string]any
+	// InitialTimeout is the number of seconds to wait for first input.
+	InitialTimeout *float64
+	// PartialResults enables streaming partial results as input is gathered.
+	PartialResults *bool
+	// Continuous enables continuous collection after a result is received.
+	Continuous *bool
+	// SendStartOfInput signals when the user begins speaking/pressing.
+	SendStartOfInput *bool
+	// StartInputTimers controls whether input timers start immediately.
+	StartInputTimers *bool
+}
+
+// Collect starts collecting user input without playing media. The params
+// argument exposes named fields that mirror Python's collect() parameters.
+// Pass a nil CollectParams to send an empty collect body.
+func (c *Call) Collect(params *CollectParams) *StandaloneCollectAction {
 	controlID := newControlID()
-	params := map[string]any{
+	collect := map[string]any{}
+	if params != nil {
+		if params.Digits != nil {
+			collect["digits"] = params.Digits
+		}
+		if params.Speech != nil {
+			collect["speech"] = params.Speech
+		}
+		if params.InitialTimeout != nil {
+			collect["initial_timeout"] = *params.InitialTimeout
+		}
+		if params.PartialResults != nil {
+			collect["partial_results"] = *params.PartialResults
+		}
+		if params.Continuous != nil {
+			collect["continuous"] = *params.Continuous
+		}
+		if params.SendStartOfInput != nil {
+			collect["send_start_of_input"] = *params.SendStartOfInput
+		}
+		if params.StartInputTimers != nil {
+			collect["start_input_timers"] = *params.StartInputTimers
+		}
+	}
+	rpcParams := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
@@ -277,7 +449,7 @@ func (c *Call) Collect(collect map[string]any) *StandaloneCollectAction {
 	c.registerAction(action.Action)
 
 	go func() {
-		_, err := c.client.execute("calling.collect", params)
+		_, err := c.client.execute("calling.collect", rpcParams)
 		if err != nil {
 			action.resolve(NewRelayEvent(EventCallingCallCollect, map[string]any{
 				"control_id": controlID,
@@ -371,14 +543,18 @@ func (c *Call) SendDigits(digits string) error {
 // ---------------------------------------------------------------------------
 
 // Detect starts a detection operation (e.g., answering machine detection).
-func (c *Call) Detect(detect map[string]any, timeout int) *DetectAction {
+// timeout is optional; pass nil to omit it from the request (matches Python's
+// optional float timeout parameter).
+func (c *Call) Detect(detect map[string]any, timeout *float64) *DetectAction {
 	controlID := newControlID()
 	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
 		"detect":     detect,
-		"timeout":    timeout,
+	}
+	if timeout != nil {
+		params["timeout"] = *timeout
 	}
 
 	action := newDetectAction(c, controlID)
@@ -402,15 +578,21 @@ func (c *Call) Detect(detect map[string]any, timeout int) *DetectAction {
 // Fax
 // ---------------------------------------------------------------------------
 
-// SendFax sends a fax document on the call.
-func (c *Call) SendFax(document string, identity string) *FaxAction {
+// SendFax sends a fax document on the call. Use WithFaxHeaderInfo to include
+// a fax header string (matches Python's send_fax header_info parameter).
+func (c *Call) SendFax(document string, identity string, opts ...FaxOption) *FaxAction {
 	controlID := newControlID()
 	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
 		"document":   document,
-		"identity":   identity,
+	}
+	if identity != "" {
+		params["identity"] = identity
+	}
+	for _, opt := range opts {
+		opt(params)
 	}
 
 	action := newFaxAction(c, controlID)
@@ -589,36 +771,61 @@ func (c *Call) AmazonBedrock(opts ...AIOption) *AIAction {
 	return c.AI(merged...)
 }
 
-// AIMessage sends a text message within an active AI session.
-func (c *Call) AIMessage(controlID, text, role string) error {
-	_, err := c.client.execute("calling.ai.message", map[string]any{
+// AIMessage sends a text message within an active AI session. The reset and
+// globalData parameters are optional (nil omits them), matching Python's
+// ai_message(*, message_text, role, reset, global_data).
+func (c *Call) AIMessage(controlID, text, role string, reset map[string]any, globalData map[string]any) error {
+	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
-		"text":       text,
-		"role":       role,
-	})
+	}
+	if text != "" {
+		params["message_text"] = text
+	}
+	if role != "" {
+		params["role"] = role
+	}
+	if reset != nil {
+		params["reset"] = reset
+	}
+	if globalData != nil {
+		params["global_data"] = globalData
+	}
+	_, err := c.client.execute("calling.ai.message", params)
 	return err
 }
 
-// AIHold places the AI-controlled call on hold.
-func (c *Call) AIHold(controlID string, timeout int) error {
-	_, err := c.client.execute("calling.ai.hold", map[string]any{
+// AIHold places the AI-controlled call on hold. timeout and prompt are
+// optional (empty string omits them), matching Python's ai_hold(*, timeout: str|None, prompt: str|None).
+func (c *Call) AIHold(controlID string, timeout string, prompt string) error {
+	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
-		"timeout":    timeout,
-	})
+	}
+	if timeout != "" {
+		params["timeout"] = timeout
+	}
+	if prompt != "" {
+		params["prompt"] = prompt
+	}
+	_, err := c.client.execute("calling.ai.hold", params)
 	return err
 }
 
-// AIUnhold removes the call from AI hold.
-func (c *Call) AIUnhold(controlID string) error {
-	_, err := c.client.execute("calling.ai.unhold", map[string]any{
+// AIUnhold removes the call from AI hold. prompt is optional (empty string
+// omits it), matching Python's ai_unhold(*, prompt: str|None).
+func (c *Call) AIUnhold(controlID string, prompt string) error {
+	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
 		"control_id": controlID,
-	})
+	}
+	if prompt != "" {
+		params["prompt"] = prompt
+	}
+	_, err := c.client.execute("calling.ai.unhold", params)
 	return err
 }
 
@@ -666,13 +873,18 @@ func (c *Call) DenoiseStop() error {
 // Room / Queue
 // ---------------------------------------------------------------------------
 
-// JoinRoom joins the call to a named room.
-func (c *Call) JoinRoom(name string) error {
-	_, err := c.client.execute("calling.room.join", map[string]any{
+// JoinRoom joins the call to a named room. statusURL is optional (empty
+// string omits it), matching Python's join_room(name, *, status_url).
+func (c *Call) JoinRoom(name string, statusURL string) error {
+	params := map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
 		"name":    name,
-	})
+	}
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.room.join", params)
 	return err
 }
 
@@ -685,23 +897,37 @@ func (c *Call) LeaveRoom() error {
 	return err
 }
 
-// QueueEnter places the call in a named queue.
-func (c *Call) QueueEnter(name string) error {
-	_, err := c.client.execute("calling.queue.enter", map[string]any{
-		"node_id": c.nodeID,
-		"call_id": c.callID,
-		"name":    name,
-	})
+// QueueEnter places the call in a named queue. statusURL is optional (empty
+// string omits it), matching Python's queue_enter(queue_name, *, status_url).
+func (c *Call) QueueEnter(name string, statusURL string) error {
+	params := map[string]any{
+		"node_id":    c.nodeID,
+		"call_id":    c.callID,
+		"queue_name": name,
+	}
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.queue.enter", params)
 	return err
 }
 
-// QueueLeave removes the call from the named queue.
-func (c *Call) QueueLeave(name string) error {
-	_, err := c.client.execute("calling.queue.leave", map[string]any{
-		"node_id": c.nodeID,
-		"call_id": c.callID,
-		"name":    name,
-	})
+// QueueLeave removes the call from the named queue. queueID and statusURL are
+// optional (empty string omits each), matching Python's
+// queue_leave(queue_name, *, queue_id, status_url).
+func (c *Call) QueueLeave(name string, queueID string, statusURL string) error {
+	params := map[string]any{
+		"node_id":    c.nodeID,
+		"call_id":    c.callID,
+		"queue_name": name,
+	}
+	if queueID != "" {
+		params["queue_id"] = queueID
+	}
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.queue.leave", params)
 	return err
 }
 
@@ -709,27 +935,41 @@ func (c *Call) QueueLeave(name string) error {
 // Digit Binding / User Event / Echo
 // ---------------------------------------------------------------------------
 
-// BindDigit binds a DTMF digit sequence to trigger a method call.
-func (c *Call) BindDigit(digits, method string, params map[string]any) error {
+// BindDigit binds a DTMF digit sequence to trigger a RELAY method.
+// bindParams, realm, and maxTriggers are optional (nil/zero-value omits them),
+// matching Python's bind_digit(digits, bind_method, *, bind_params, realm, max_triggers).
+func (c *Call) BindDigit(digits, method string, bindParams map[string]any, realm string, maxTriggers int) error {
 	p := map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
 		"digits":  digits,
 		"method":  method,
 	}
-	if params != nil {
-		p["params"] = params
+	if bindParams != nil {
+		p["params"] = bindParams
+	}
+	if realm != "" {
+		p["realm"] = realm
+	}
+	if maxTriggers > 0 {
+		p["max_triggers"] = maxTriggers
 	}
 	_, err := c.client.execute("calling.bind_digit", p)
 	return err
 }
 
-// ClearDigitBindings clears all DTMF digit bindings.
-func (c *Call) ClearDigitBindings() error {
-	_, err := c.client.execute("calling.clear_digit_bindings", map[string]any{
+// ClearDigitBindings clears all DTMF digit bindings, optionally filtered
+// by realm. Pass an empty string to clear all realms (matches Python's
+// clear_digit_bindings(*, realm)).
+func (c *Call) ClearDigitBindings(realm string) error {
+	params := map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
-	})
+	}
+	if realm != "" {
+		params["realm"] = realm
+	}
+	_, err := c.client.execute("calling.clear_digit_bindings", params)
 	return err
 }
 
@@ -744,12 +984,20 @@ func (c *Call) UserEvent(event map[string]any) error {
 }
 
 // Echo starts echo mode on the call (echo audio back to the caller).
-func (c *Call) Echo(timeout int) error {
-	_, err := c.client.execute("calling.echo", map[string]any{
+// Both timeout and statusURL are optional (nil omits them), matching
+// Python's echo(*, timeout: float|None, status_url).
+func (c *Call) Echo(timeout *float64, statusURL string) error {
+	params := map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
-		"timeout": timeout,
-	})
+	}
+	if timeout != nil {
+		params["timeout"] = *timeout
+	}
+	if statusURL != "" {
+		params["status_url"] = statusURL
+	}
+	_, err := c.client.execute("calling.echo", params)
 	return err
 }
 
@@ -757,16 +1005,22 @@ func (c *Call) Echo(timeout int) error {
 // Pay
 // ---------------------------------------------------------------------------
 
-// Pay starts a pay session on the call.
-func (c *Call) Pay(connectorURL string, amount string, currency string) *PayAction {
+// Pay starts a payment collection session on the call. Use PayOption
+// functional options to supply any of the 20+ optional parameters that
+// Python's pay() exposes (input_method, status_url, payment_method, timeout,
+// max_attempts, security_code, postal_code, min_postal_code_length,
+// token_type, charge_amount, currency, language, voice, description,
+// valid_card_types, parameters, prompts).
+func (c *Call) Pay(connectorURL string, opts ...PayOption) *PayAction {
 	controlID := newControlID()
 	params := map[string]any{
-		"node_id":       c.nodeID,
-		"call_id":       c.callID,
-		"control_id":    controlID,
-		"connector_url": connectorURL,
-		"amount":        amount,
-		"currency":      currency,
+		"node_id":                c.nodeID,
+		"call_id":                c.callID,
+		"control_id":             controlID,
+		"payment_connector_url":  connectorURL,
+	}
+	for _, opt := range opts {
+		opt(params)
 	}
 
 	action := newPayAction(c, controlID)

--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -898,11 +898,14 @@ func (c *Call) LeaveRoom() error {
 }
 
 // QueueEnter places the call in a named queue. statusURL is optional (empty
-// string omits it), matching Python's queue_enter(queue_name, *, status_url).
+// string omits it), matching Python's queue_enter(queue_name, *, control_id,
+// status_url) at signalwire/relay/call.py:1268. A per-request control_id is
+// generated so the server can correlate this action with subsequent events.
 func (c *Call) QueueEnter(name string, statusURL string) error {
 	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
+		"control_id": newControlID(),
 		"queue_name": name,
 	}
 	if statusURL != "" {
@@ -914,11 +917,13 @@ func (c *Call) QueueEnter(name string, statusURL string) error {
 
 // QueueLeave removes the call from the named queue. queueID and statusURL are
 // optional (empty string omits each), matching Python's
-// queue_leave(queue_name, *, queue_id, status_url).
+// queue_leave(queue_name, *, control_id, queue_id, status_url) at
+// signalwire/relay/call.py:1287. A per-request control_id is generated.
 func (c *Call) QueueLeave(name string, queueID string, statusURL string) error {
 	params := map[string]any{
 		"node_id":    c.nodeID,
 		"call_id":    c.callID,
+		"control_id": newControlID(),
 		"queue_name": name,
 	}
 	if queueID != "" {

--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -718,13 +718,13 @@ func (c *Call) JoinConference(name string, opts ...ConferenceOption) error {
 	for _, opt := range opts {
 		opt(params)
 	}
-	_, err := c.client.execute("calling.conference", params)
+	_, err := c.client.execute("calling.join_conference", params)
 	return err
 }
 
 // LeaveConference removes the call from a conference.
 func (c *Call) LeaveConference(confID string) error {
-	_, err := c.client.execute("calling.conference.leave", map[string]any{
+	_, err := c.client.execute("calling.leave_conference", map[string]any{
 		"node_id":       c.nodeID,
 		"call_id":       c.callID,
 		"conference_id": confID,
@@ -792,7 +792,7 @@ func (c *Call) AIMessage(controlID, text, role string, reset map[string]any, glo
 	if globalData != nil {
 		params["global_data"] = globalData
 	}
-	_, err := c.client.execute("calling.ai.message", params)
+	_, err := c.client.execute("calling.ai_message", params)
 	return err
 }
 
@@ -810,7 +810,7 @@ func (c *Call) AIHold(controlID string, timeout string, prompt string) error {
 	if prompt != "" {
 		params["prompt"] = prompt
 	}
-	_, err := c.client.execute("calling.ai.hold", params)
+	_, err := c.client.execute("calling.ai_hold", params)
 	return err
 }
 
@@ -825,7 +825,7 @@ func (c *Call) AIUnhold(controlID string, prompt string) error {
 	if prompt != "" {
 		params["prompt"] = prompt
 	}
-	_, err := c.client.execute("calling.ai.unhold", params)
+	_, err := c.client.execute("calling.ai_unhold", params)
 	return err
 }
 
@@ -884,13 +884,13 @@ func (c *Call) JoinRoom(name string, statusURL string) error {
 	if statusURL != "" {
 		params["status_url"] = statusURL
 	}
-	_, err := c.client.execute("calling.room.join", params)
+	_, err := c.client.execute("calling.join_room", params)
 	return err
 }
 
 // LeaveRoom removes the call from the current room.
 func (c *Call) LeaveRoom() error {
-	_, err := c.client.execute("calling.room.leave", map[string]any{
+	_, err := c.client.execute("calling.leave_room", map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
 	})

--- a/pkg/relay/options.go
+++ b/pkg/relay/options.go
@@ -117,6 +117,106 @@ func WithConferenceDeaf(deaf bool) ConferenceOption {
 	}
 }
 
+// FaxOption configures a SendFax call.
+type FaxOption func(m map[string]any)
+
+// WithFaxHeaderInfo sets the fax header info string (matches Python's header_info param).
+func WithFaxHeaderInfo(headerInfo string) FaxOption {
+	return func(m map[string]any) {
+		if headerInfo != "" {
+			m["header_info"] = headerInfo
+		}
+	}
+}
+
+// PayOption configures a Pay call.
+type PayOption func(m map[string]any)
+
+// WithPayInputMethod sets the payment input method.
+func WithPayInputMethod(method string) PayOption {
+	return func(m map[string]any) { m["input"] = method }
+}
+
+// WithPayStatusURL sets the payment status callback URL.
+func WithPayStatusURL(url string) PayOption {
+	return func(m map[string]any) { m["status_url"] = url }
+}
+
+// WithPayPaymentMethod sets the payment method (e.g. "credit-card").
+func WithPayPaymentMethod(method string) PayOption {
+	return func(m map[string]any) { m["payment_method"] = method }
+}
+
+// WithPayTimeout sets the timeout string for the payment session.
+func WithPayTimeout(timeout string) PayOption {
+	return func(m map[string]any) { m["timeout"] = timeout }
+}
+
+// WithPayMaxAttempts sets the maximum number of payment attempts.
+func WithPayMaxAttempts(max string) PayOption {
+	return func(m map[string]any) { m["max_attempts"] = max }
+}
+
+// WithPaySecurityCode sets whether to collect security code.
+func WithPaySecurityCode(code string) PayOption {
+	return func(m map[string]any) { m["security_code"] = code }
+}
+
+// WithPayPostalCode sets whether to collect postal code.
+func WithPayPostalCode(code string) PayOption {
+	return func(m map[string]any) { m["postal_code"] = code }
+}
+
+// WithPayMinPostalCodeLength sets the minimum postal code length.
+func WithPayMinPostalCodeLength(length string) PayOption {
+	return func(m map[string]any) { m["min_postal_code_length"] = length }
+}
+
+// WithPayTokenType sets the payment token type.
+func WithPayTokenType(tokenType string) PayOption {
+	return func(m map[string]any) { m["token_type"] = tokenType }
+}
+
+// WithPayChargeAmount sets the charge amount.
+func WithPayChargeAmount(amount string) PayOption {
+	return func(m map[string]any) { m["charge_amount"] = amount }
+}
+
+// WithPayCurrency sets the payment currency.
+func WithPayCurrency(currency string) PayOption {
+	return func(m map[string]any) { m["currency"] = currency }
+}
+
+// WithPayLanguage sets the language for payment prompts.
+func WithPayLanguage(language string) PayOption {
+	return func(m map[string]any) { m["language"] = language }
+}
+
+// WithPayVoice sets the voice for payment prompts.
+func WithPayVoice(voice string) PayOption {
+	return func(m map[string]any) { m["voice"] = voice }
+}
+
+// WithPayDescription sets a description for the payment.
+func WithPayDescription(desc string) PayOption {
+	return func(m map[string]any) { m["description"] = desc }
+}
+
+// WithPayValidCardTypes sets the valid card types string.
+func WithPayValidCardTypes(types string) PayOption {
+	return func(m map[string]any) { m["valid_card_types"] = types }
+}
+
+// WithPayParameters sets additional payment parameters.
+func WithPayParameters(parameters []map[string]any) PayOption {
+	return func(m map[string]any) { m["parameters"] = parameters }
+}
+
+// WithPayPrompts sets custom payment prompts.
+func WithPayPrompts(prompts []map[string]any) PayOption {
+	return func(m map[string]any) { m["prompts"] = prompts }
+}
+
 // AIOption configures an AI operation on a call.
 type AIOption func(m map[string]any)
 


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: Call — properties, missing methods, wire keys (P1/P2)

Brings pkg/relay.Call to parity with Python signalwire/relay/call.py.

Missing properties (P1, all mutex-protected getters):
- ProjectID(), Context(), Direction(), Device(), SegmentID() — fields
  populated from calling.call.receive and calling.call.state events via
  dispatchEvent.

Missing methods (P1):
- Refer(device, statusURL) — SIP REFER transfer.
- LiveTranscribe(action).
- LiveTranslate(action, statusURL).
- WaitForEnded(ctx) — convenience predicate over WaitFor for
  call_state=="ended".
- AIMessage params fixed: added reset + globalData; corrected wire key
  "text" → "message_text".

Type/signature alignment (P2):
- Collect: map[string]any → *CollectParams typed struct (7 fields).
- Detect: timeout int → timeout *float64 (optional, matching Python).
- Pay: variadic WithPay*Option functions; 17 options mirror Python
  param set.
- SendFax: opts variadic with WithFaxHeaderInfo option.
- Transfer: dest map[string]any → dest string; wire key "destination"
  → "dest".
- Echo: timeout int → *float64, statusURL added.
- BindDigit: realm + maxTriggers added.
- ClearDigitBindings: realm added.
- AIHold: timeout int → timeout, prompt string (Python str|None).
- AIUnhold: prompt string added.
- JoinRoom: statusURL added.
- QueueEnter: statusURL added; wire key "name" → "queue_name".
- QueueLeave: queueID + statusURL added; wire key fixed to
  "queue_name".

Closes #23.

go build ./... and go test -race ./... pass (16 packages, 0 failures).
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #23
Closes #122

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3

