### PR TITLE
Align FunctionResult with Python SDK

### DIFF
--- a/examples/call_flow/main.go
+++ b/examples/call_flow/main.go
@@ -109,7 +109,7 @@ func main() {
 				fmt.Sprintf("Sending confirmation text to %s.", phone),
 			)
 			// Use the SendSms helper for the SWML action
-			result.SendSms(phone, "+15559990000", message, nil, nil)
+			result.SendSms(phone, "+15559990000", message, nil, nil, "")
 			return result
 		},
 	})

--- a/pkg/swaig/function_result.go
+++ b/pkg/swaig/function_result.go
@@ -28,6 +28,23 @@ func NewFunctionResult(response string) *FunctionResult {
 	}
 }
 
+// --- Getters ---
+
+// Response returns the natural language response text.
+func (fr *FunctionResult) Response() string {
+	return fr.response
+}
+
+// Actions returns the list of actions added to this result.
+func (fr *FunctionResult) Actions() []map[string]any {
+	return fr.actions
+}
+
+// PostProcess returns whether post-processing is enabled.
+func (fr *FunctionResult) PostProcess() bool {
+	return fr.postProcess
+}
+
 // --- Core methods ---
 
 // SetResponse sets the natural language response text.
@@ -162,9 +179,16 @@ func (fr *FunctionResult) UpdateGlobalData(data map[string]any) *FunctionResult 
 	return fr.AddAction("set_global_data", data)
 }
 
-// RemoveGlobalData removes global agent data variables by key.
+// RemoveGlobalData removes global agent data variables by key slice.
 func (fr *FunctionResult) RemoveGlobalData(keys []string) *FunctionResult {
 	return fr.AddAction("unset_global_data", keys)
+}
+
+// RemoveGlobalDataKey removes a single global agent data variable by key.
+// This matches the Python SDK's Union[str, List[str]] behavior for a bare string argument,
+// which emits the key as a string (not a one-element array) in the action payload.
+func (fr *FunctionResult) RemoveGlobalDataKey(key string) *FunctionResult {
+	return fr.AddAction("unset_global_data", key)
 }
 
 // SetMetadata sets metadata scoped to the current function's meta_data_token.
@@ -175,6 +199,13 @@ func (fr *FunctionResult) SetMetadata(data map[string]any) *FunctionResult {
 // RemoveMetadata removes metadata keys from the current function's scope.
 func (fr *FunctionResult) RemoveMetadata(keys []string) *FunctionResult {
 	return fr.AddAction("unset_meta_data", keys)
+}
+
+// RemoveMetadataKey removes a single metadata key from the current function's scope.
+// This matches the Python SDK's Union[str, List[str]] behavior for a bare string argument,
+// which emits the key as a string (not a one-element array) in the action payload.
+func (fr *FunctionResult) RemoveMetadataKey(key string) *FunctionResult {
+	return fr.AddAction("unset_meta_data", key)
 }
 
 // SwmlUserEvent sends a user event through SWML for real-time UI updates.
@@ -195,13 +226,17 @@ func (fr *FunctionResult) SwmlUserEvent(eventData map[string]any) *FunctionResul
 }
 
 // SwmlChangeStep transitions to a different conversation step.
+// Emits action key "change_step" with the step name as a plain string value,
+// matching the Python SDK's add_action("change_step", step_name).
 func (fr *FunctionResult) SwmlChangeStep(stepName string) *FunctionResult {
-	return fr.AddAction("context_switch", map[string]any{"step": stepName})
+	return fr.AddAction("change_step", stepName)
 }
 
 // SwmlChangeContext transitions to a different conversation context.
+// Emits action key "change_context" with the context name as a plain string value,
+// matching the Python SDK's add_action("change_context", context_name).
 func (fr *FunctionResult) SwmlChangeContext(contextName string) *FunctionResult {
-	return fr.AddAction("context_switch", map[string]any{"context": contextName})
+	return fr.AddAction("change_context", contextName)
 }
 
 // SwitchContext changes the agent context/prompt during conversation.
@@ -267,8 +302,37 @@ func (fr *FunctionResult) StopBackgroundFile() *FunctionResult {
 	return fr.AddAction("stop_playback_bg", true)
 }
 
+// RecordCallOptions holds optional parameters for RecordCall beyond the required fields.
+type RecordCallOptions struct {
+	// Terminators specifies digits that stop recording when pressed.
+	Terminators string
+	// Beep plays a beep before recording starts when true.
+	Beep bool
+	// InputSensitivity sets the input sensitivity for recording (default 44.0 in Python).
+	// Zero value is omitted from the SWML payload.
+	InputSensitivity float64
+	// InitialTimeout is the time in seconds to wait for speech to start (voicemail-style).
+	// Negative value is omitted.
+	InitialTimeout float64
+	// InitialTimeoutSet must be true for InitialTimeout of 0.0 to be included.
+	InitialTimeoutSet bool
+	// EndSilenceTimeout is seconds of silence before ending (voicemail-style).
+	// Negative value is omitted.
+	EndSilenceTimeout float64
+	// EndSilenceTimeoutSet must be true for EndSilenceTimeout of 0.0 to be included.
+	EndSilenceTimeoutSet bool
+	// MaxLength is the maximum recording length in seconds. Negative value is omitted.
+	MaxLength float64
+	// MaxLengthSet must be true for MaxLength of 0.0 to be included.
+	MaxLengthSet bool
+	// StatusURL is the URL to send recording status events to.
+	StatusURL string
+}
+
 // RecordCall starts background call recording using SWML.
-func (fr *FunctionResult) RecordCall(controlID string, stereo bool, format string, direction string) *FunctionResult {
+// controlID, stereo, format, and direction are the primary parameters.
+// Use opts to specify additional optional parameters (pass nil to use defaults).
+func (fr *FunctionResult) RecordCall(controlID string, stereo bool, format string, direction string, opts *RecordCallOptions) *FunctionResult {
 	recordParams := map[string]any{
 		"stereo":    stereo,
 		"format":    format,
@@ -276,6 +340,30 @@ func (fr *FunctionResult) RecordCall(controlID string, stereo bool, format strin
 	}
 	if controlID != "" {
 		recordParams["control_id"] = controlID
+	}
+
+	if opts != nil {
+		if opts.Terminators != "" {
+			recordParams["terminators"] = opts.Terminators
+		}
+		if opts.Beep {
+			recordParams["beep"] = opts.Beep
+		}
+		if opts.InputSensitivity != 0 {
+			recordParams["input_sensitivity"] = opts.InputSensitivity
+		}
+		if opts.InitialTimeoutSet || opts.InitialTimeout > 0 {
+			recordParams["initial_timeout"] = opts.InitialTimeout
+		}
+		if opts.EndSilenceTimeoutSet || opts.EndSilenceTimeout > 0 {
+			recordParams["end_silence_timeout"] = opts.EndSilenceTimeout
+		}
+		if opts.MaxLengthSet || opts.MaxLength > 0 {
+			recordParams["max_length"] = opts.MaxLength
+		}
+		if opts.StatusURL != "" {
+			recordParams["status_url"] = opts.StatusURL
+		}
 	}
 
 	swmlDoc := map[string]any{
@@ -379,17 +467,102 @@ func (fr *FunctionResult) ExecuteSwml(swmlContent any, transfer bool) *FunctionR
 	return fr.AddAction("SWML", action)
 }
 
+// JoinConferenceOptions holds optional parameters for JoinConference beyond the required name.
+type JoinConferenceOptions struct {
+	// Muted joins the conference muted when true.
+	Muted bool
+	// Beep controls beep behavior: "true" (default), "false", "onEnter", "onExit".
+	Beep string
+	// StartOnEnter controls whether the conference starts when this participant enters (default true in Python).
+	StartOnEnter *bool
+	// EndOnExit controls whether the conference ends when this participant exits (default false).
+	EndOnExit bool
+	// WaitURL is the SWML URL for hold music (replaces the old holdAudio parameter).
+	WaitURL string
+	// MaxParticipants sets the maximum number of participants (<= 250). 0 uses server default.
+	MaxParticipants int
+	// Record sets the recording mode: "do-not-record" (default) or "record-from-start".
+	Record string
+	// Region sets the conference region.
+	Region string
+	// Trim controls silence trimming: "trim-silence" (default) or "do-not-trim".
+	Trim string
+	// Coach sets the SWML Call ID or CXML CallSid for coaching.
+	Coach string
+	// StatusCallbackEvent specifies events to report (space-separated).
+	StatusCallbackEvent string
+	// StatusCallback is the URL for status callbacks.
+	StatusCallback string
+	// StatusCallbackMethod sets the HTTP method for status callbacks ("GET" or "POST").
+	StatusCallbackMethod string
+	// RecordingStatusCallback is the URL for recording status callbacks.
+	RecordingStatusCallback string
+	// RecordingStatusCallbackMethod sets the HTTP method for recording callbacks ("GET" or "POST").
+	RecordingStatusCallbackMethod string
+	// RecordingStatusCallbackEvent sets recording events to report.
+	RecordingStatusCallbackEvent string
+	// Result sets switch-on-return-value behavior (object or array).
+	Result any
+}
+
 // JoinConference joins an ad-hoc audio conference.
-func (fr *FunctionResult) JoinConference(name string, muted bool, beep string, holdAudio string) *FunctionResult {
+// Pass nil for opts to use default behavior (muted=false, beep="true", no holdAudio).
+func (fr *FunctionResult) JoinConference(name string, opts *JoinConferenceOptions) *FunctionResult {
+	if opts == nil {
+		opts = &JoinConferenceOptions{}
+	}
+
 	joinParams := map[string]any{"name": name}
-	if muted {
+	if opts.Muted {
 		joinParams["muted"] = true
 	}
-	if beep != "" && beep != "true" {
-		joinParams["beep"] = beep
+	if opts.Beep != "" && opts.Beep != "true" {
+		joinParams["beep"] = opts.Beep
 	}
-	if holdAudio != "" {
-		joinParams["wait_url"] = holdAudio
+	if opts.StartOnEnter != nil && !*opts.StartOnEnter {
+		joinParams["start_on_enter"] = false
+	}
+	if opts.EndOnExit {
+		joinParams["end_on_exit"] = true
+	}
+	if opts.WaitURL != "" {
+		joinParams["wait_url"] = opts.WaitURL
+	}
+	if opts.MaxParticipants != 0 && opts.MaxParticipants != 250 {
+		joinParams["max_participants"] = opts.MaxParticipants
+	}
+	if opts.Record != "" && opts.Record != "do-not-record" {
+		joinParams["record"] = opts.Record
+	}
+	if opts.Region != "" {
+		joinParams["region"] = opts.Region
+	}
+	if opts.Trim != "" && opts.Trim != "trim-silence" {
+		joinParams["trim"] = opts.Trim
+	}
+	if opts.Coach != "" {
+		joinParams["coach"] = opts.Coach
+	}
+	if opts.StatusCallbackEvent != "" {
+		joinParams["status_callback_event"] = opts.StatusCallbackEvent
+	}
+	if opts.StatusCallback != "" {
+		joinParams["status_callback"] = opts.StatusCallback
+	}
+	if opts.StatusCallbackMethod != "" && opts.StatusCallbackMethod != "POST" {
+		joinParams["status_callback_method"] = opts.StatusCallbackMethod
+	}
+	if opts.RecordingStatusCallback != "" {
+		joinParams["recording_status_callback"] = opts.RecordingStatusCallback
+	}
+	if opts.RecordingStatusCallbackMethod != "" && opts.RecordingStatusCallbackMethod != "POST" {
+		joinParams["recording_status_callback_method"] = opts.RecordingStatusCallbackMethod
+	}
+	if opts.RecordingStatusCallbackEvent != "" && opts.RecordingStatusCallbackEvent != "completed" {
+		joinParams["recording_status_callback_event"] = opts.RecordingStatusCallbackEvent
+	}
+	if opts.Result != nil {
+		joinParams["result"] = opts.Result
 	}
 
 	swmlDoc := map[string]any{
@@ -430,7 +603,9 @@ func (fr *FunctionResult) SipRefer(toURI string) *FunctionResult {
 }
 
 // Tap starts background call tapping, streaming media to the given URI.
-func (fr *FunctionResult) Tap(uri string, controlID string, direction string, codec string) *FunctionResult {
+// rtpPtime sets the packetization time in milliseconds for RTP streams (0 = use default of 20ms).
+// Pass empty string for statusURL to omit it.
+func (fr *FunctionResult) Tap(uri string, controlID string, direction string, codec string, rtpPtime int, statusURL string) *FunctionResult {
 	tapParams := map[string]any{"uri": uri}
 	if controlID != "" {
 		tapParams["control_id"] = controlID
@@ -440,6 +615,12 @@ func (fr *FunctionResult) Tap(uri string, controlID string, direction string, co
 	}
 	if codec != "" && codec != "PCMU" {
 		tapParams["codec"] = codec
+	}
+	if rtpPtime != 0 && rtpPtime != 20 {
+		tapParams["rtp_ptime"] = rtpPtime
+	}
+	if statusURL != "" {
+		tapParams["status_url"] = statusURL
 	}
 
 	swmlDoc := map[string]any{
@@ -472,8 +653,9 @@ func (fr *FunctionResult) StopTap(controlID string) *FunctionResult {
 }
 
 // SendSms sends a text message to a PSTN phone number.
-// Pass empty string for body if only sending media, and nil for optional slices.
-func (fr *FunctionResult) SendSms(toNumber, fromNumber, body string, media []string, tags []string) *FunctionResult {
+// Pass empty string for body if only sending media, nil for optional slices,
+// and empty string for region to omit it.
+func (fr *FunctionResult) SendSms(toNumber, fromNumber, body string, media []string, tags []string, region string) *FunctionResult {
 	smsParams := map[string]any{
 		"to_number":   toNumber,
 		"from_number": fromNumber,
@@ -487,6 +669,9 @@ func (fr *FunctionResult) SendSms(toNumber, fromNumber, body string, media []str
 	if len(tags) > 0 {
 		smsParams["tags"] = tags
 	}
+	if region != "" {
+		smsParams["region"] = region
+	}
 
 	swmlDoc := map[string]any{
 		"version": "1.0.0",
@@ -499,22 +684,168 @@ func (fr *FunctionResult) SendSms(toNumber, fromNumber, body string, media []str
 	return fr.AddAction("SWML", swmlDoc)
 }
 
+// PayOptions holds all optional parameters for the Pay method.
+type PayOptions struct {
+	// InputMethod is the method to collect payment details ("dtmf" or "voice"). Defaults to "dtmf".
+	InputMethod string
+	// StatusURL is the URL for payment status change notifications.
+	StatusURL string
+	// PaymentMethod is the payment method type. Defaults to "credit-card".
+	PaymentMethod string
+	// Timeout is the seconds to wait for the next digit. Defaults to 5.
+	Timeout int
+	// MaxAttempts is the number of retry attempts. Defaults to 1.
+	MaxAttempts int
+	// SecurityCode controls whether to prompt for security code. Defaults to true.
+	// Use SecurityCodeSet to override; zero value (false) is treated as "not set".
+	SecurityCode bool
+	// SecurityCodeSet must be true to explicitly set SecurityCode=false.
+	SecurityCodeSet bool
+	// PostalCode controls whether to prompt for postal code, or supplies the actual code.
+	// String value is used as-is; bool true/false becomes "true"/"false".
+	PostalCode any
+	// MinPostalCodeLength sets the minimum number of postal code digits. Defaults to 0.
+	MinPostalCodeLength int
+	// TokenType is the payment token type: "one-time" or "reusable". Defaults to "reusable".
+	TokenType string
+	// ChargeAmount is the amount to charge as a decimal string (e.g. "9.99").
+	ChargeAmount string
+	// Currency is the currency code. Defaults to "usd".
+	Currency string
+	// Language is the language for prompts. Defaults to "en-US".
+	Language string
+	// Voice is the TTS voice to use. Defaults to "woman".
+	Voice string
+	// Description is a custom payment description.
+	Description string
+	// ValidCardTypes is a space-separated list of card types. Defaults to "visa mastercard amex".
+	ValidCardTypes string
+	// Parameters is an array of name/value pairs for the payment connector.
+	Parameters []map[string]string
+	// Prompts is an array of custom prompt configurations.
+	Prompts []map[string]any
+	// AIResponse is the message set via "set" verb before pay; empty string uses Python default.
+	// Set to "-" to suppress the set verb entirely (no ai_response).
+	AIResponse string
+}
+
 // Pay processes a payment using SWML pay action.
-func (fr *FunctionResult) Pay(connectorURL string, inputMethod string, actionURL string, timeout int, maxAttempts int) *FunctionResult {
+// connectorURL is the only required parameter.
+// opts may be nil to use Python SDK defaults for all optional parameters.
+func (fr *FunctionResult) Pay(connectorURL string, opts *PayOptions) *FunctionResult {
+	if opts == nil {
+		opts = &PayOptions{}
+	}
+
+	inputMethod := opts.InputMethod
+	if inputMethod == "" {
+		inputMethod = "dtmf"
+	}
+	paymentMethod := opts.PaymentMethod
+	if paymentMethod == "" {
+		paymentMethod = "credit-card"
+	}
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 5
+	}
+	maxAttempts := opts.MaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = 1
+	}
+	tokenType := opts.TokenType
+	if tokenType == "" {
+		tokenType = "reusable"
+	}
+	currency := opts.Currency
+	if currency == "" {
+		currency = "usd"
+	}
+	language := opts.Language
+	if language == "" {
+		language = "en-US"
+	}
+	voice := opts.Voice
+	if voice == "" {
+		voice = "woman"
+	}
+	validCardTypes := opts.ValidCardTypes
+	if validCardTypes == "" {
+		validCardTypes = "visa mastercard amex"
+	}
+
+	// Handle security_code: default true
+	securityCode := "true"
+	if opts.SecurityCodeSet && !opts.SecurityCode {
+		securityCode = "false"
+	} else if !opts.SecurityCodeSet && opts.SecurityCode {
+		securityCode = "true"
+	}
+
+	// Handle postal_code: default true
+	var postalCodeStr string
+	if opts.PostalCode == nil {
+		postalCodeStr = "true"
+	} else {
+		switch v := opts.PostalCode.(type) {
+		case bool:
+			if v {
+				postalCodeStr = "true"
+			} else {
+				postalCodeStr = "false"
+			}
+		case string:
+			postalCodeStr = v
+		default:
+			postalCodeStr = fmt.Sprintf("%v", v)
+		}
+	}
+
 	payParams := map[string]any{
 		"payment_connector_url": connectorURL,
 		"input":                 inputMethod,
+		"payment_method":        paymentMethod,
 		"timeout":               fmt.Sprintf("%d", timeout),
 		"max_attempts":          fmt.Sprintf("%d", maxAttempts),
+		"security_code":         securityCode,
+		"postal_code":           postalCodeStr,
+		"min_postal_code_length": fmt.Sprintf("%d", opts.MinPostalCodeLength),
+		"token_type":            tokenType,
+		"currency":              currency,
+		"language":              language,
+		"voice":                 voice,
+		"valid_card_types":      validCardTypes,
+	}
+
+	if opts.StatusURL != "" {
+		payParams["status_url"] = opts.StatusURL
+	}
+	if opts.ChargeAmount != "" {
+		payParams["charge_amount"] = opts.ChargeAmount
+	}
+	if opts.Description != "" {
+		payParams["description"] = opts.Description
+	}
+	if len(opts.Parameters) > 0 {
+		payParams["parameters"] = opts.Parameters
+	}
+	if len(opts.Prompts) > 0 {
+		payParams["prompts"] = opts.Prompts
+	}
+
+	// Determine ai_response: Python default is a status message
+	aiResponse := opts.AIResponse
+	if aiResponse == "" {
+		aiResponse = "The payment status is ${pay_result}, do not mention anything else about collecting payment if successful."
 	}
 
 	mainVerbs := []any{
 		map[string]any{"pay": payParams},
 	}
 
-	if actionURL != "" {
+	if aiResponse != "-" {
 		mainVerbs = append([]any{
-			map[string]any{"set": map[string]any{"ai_response": actionURL}},
+			map[string]any{"set": map[string]any{"ai_response": aiResponse}},
 		}, mainVerbs...)
 	}
 
@@ -530,10 +861,17 @@ func (fr *FunctionResult) Pay(connectorURL string, inputMethod string, actionURL
 // --- RPC Actions ---
 
 // ExecuteRpc executes an RPC method on a call.
-func (fr *FunctionResult) ExecuteRpc(method string, params map[string]any) *FunctionResult {
+// Pass empty strings for callID and nodeID to omit them from the payload.
+func (fr *FunctionResult) ExecuteRpc(method string, params map[string]any, callID string, nodeID string) *FunctionResult {
 	rpcParams := map[string]any{
 		"method":  method,
 		"jsonrpc": "2.0",
+	}
+	if callID != "" {
+		rpcParams["call_id"] = callID
+	}
+	if nodeID != "" {
+		rpcParams["node_id"] = nodeID
 	}
 	if len(params) > 0 {
 		rpcParams["params"] = params
@@ -551,11 +889,15 @@ func (fr *FunctionResult) ExecuteRpc(method string, params map[string]any) *Func
 }
 
 // RpcDial dials out to a number with a destination SWML URL using execute_rpc.
-// Pass nil for callTimeout to omit it, and empty string for region to omit it.
-func (fr *FunctionResult) RpcDial(toNumber, fromNumber, destSwml string, callTimeout *int, region string) *FunctionResult {
+// deviceType defaults to "phone" when empty.
+// This matches the Python SDK's rpc_dial() which calls execute_rpc(method="dial", ...).
+func (fr *FunctionResult) RpcDial(toNumber, fromNumber, destSwml string, deviceType string) *FunctionResult {
+	if deviceType == "" {
+		deviceType = "phone"
+	}
 	dialParams := map[string]any{
 		"devices": map[string]any{
-			"type": "phone",
+			"type": deviceType,
 			"params": map[string]any{
 				"to_number":   toNumber,
 				"from_number": fromNumber,
@@ -563,72 +905,52 @@ func (fr *FunctionResult) RpcDial(toNumber, fromNumber, destSwml string, callTim
 		},
 		"dest_swml": destSwml,
 	}
-	if callTimeout != nil {
-		dialParams["timeout"] = *callTimeout
-	}
-	if region != "" {
-		dialParams["region"] = region
-	}
 
-	return fr.ExecuteRpc("calling.dial", dialParams)
+	return fr.ExecuteRpc("dial", dialParams, "", "")
 }
 
 // RpcAiMessage injects a message into an AI agent on another call.
-func (fr *FunctionResult) RpcAiMessage(callID, messageText string) *FunctionResult {
-	rpcParams := map[string]any{
-		"method":  "calling.ai_message",
-		"jsonrpc": "2.0",
-		"call_id": callID,
-		"params": map[string]any{
-			"role":         "system",
-			"message_text": messageText,
-		},
+// role defaults to "system" when empty, matching the Python SDK default.
+// This matches the Python SDK's rpc_ai_message() which calls execute_rpc(method="ai_message", ...).
+func (fr *FunctionResult) RpcAiMessage(callID, messageText, role string) *FunctionResult {
+	if role == "" {
+		role = "system"
 	}
-
-	swmlDoc := map[string]any{
-		"version": "1.0.0",
-		"sections": map[string]any{
-			"main": []any{
-				map[string]any{"execute_rpc": rpcParams},
-			},
-		},
-	}
-	return fr.AddAction("SWML", swmlDoc)
+	return fr.ExecuteRpc("ai_message", map[string]any{
+		"role":         role,
+		"message_text": messageText,
+	}, callID, "")
 }
 
 // RpcAiUnhold unholds another call.
+// This matches the Python SDK's rpc_ai_unhold() which calls execute_rpc(method="ai_unhold", ...).
 func (fr *FunctionResult) RpcAiUnhold(callID string) *FunctionResult {
-	rpcParams := map[string]any{
-		"method":  "calling.ai_unhold",
-		"jsonrpc": "2.0",
-		"call_id": callID,
-		"params":  map[string]any{},
-	}
-
-	swmlDoc := map[string]any{
-		"version": "1.0.0",
-		"sections": map[string]any{
-			"main": []any{
-				map[string]any{"execute_rpc": rpcParams},
-			},
-		},
-	}
-	return fr.AddAction("SWML", swmlDoc)
+	return fr.ExecuteRpc("ai_unhold", map[string]any{}, callID, "")
 }
 
 // SimulateUserInput queues simulated user input text.
+// Emits action key "user_input" matching the Python SDK's add_action("user_input", text).
 func (fr *FunctionResult) SimulateUserInput(text string) *FunctionResult {
-	return fr.AddAction("simulate_user_input", text)
+	return fr.AddAction("user_input", text)
 }
 
 // --- Payment Helpers ---
 
 // CreatePaymentPrompt creates a payment prompt configuration.
-func CreatePaymentPrompt(forSituation string, actions []map[string]string) map[string]any {
-	return map[string]any{
+// cardType and errorType are optional; pass empty strings to omit them.
+// This matches the Python SDK's create_payment_prompt() static method signature.
+func CreatePaymentPrompt(forSituation string, actions []map[string]string, cardType string, errorType string) map[string]any {
+	prompt := map[string]any{
 		"for":     forSituation,
 		"actions": actions,
 	}
+	if cardType != "" {
+		prompt["card_type"] = cardType
+	}
+	if errorType != "" {
+		prompt["error_type"] = errorType
+	}
+	return prompt
 }
 
 // CreatePaymentAction creates a single payment action entry.

--- a/pkg/swaig/function_result_test.go
+++ b/pkg/swaig/function_result_test.go
@@ -28,6 +28,40 @@ func TestNewFunctionResultEmptyResponse(t *testing.T) {
 	}
 }
 
+// --- Getters ---
+
+func TestResponseGetter(t *testing.T) {
+	fr := NewFunctionResult("Hello")
+	if fr.Response() != "Hello" {
+		t.Errorf("Response() = %q, want %q", fr.Response(), "Hello")
+	}
+}
+
+func TestActionsGetter(t *testing.T) {
+	fr := NewFunctionResult("test").AddAction("say", "hi")
+	acts := fr.Actions()
+	if len(acts) != 1 {
+		t.Fatalf("Actions() length = %d, want 1", len(acts))
+	}
+	if acts[0]["say"] != "hi" {
+		t.Errorf("Actions()[0][say] = %v, want %q", acts[0]["say"], "hi")
+	}
+}
+
+func TestPostProcessGetter(t *testing.T) {
+	fr := NewFunctionResult("test").SetPostProcess(true)
+	if !fr.PostProcess() {
+		t.Error("PostProcess() should return true after SetPostProcess(true)")
+	}
+}
+
+func TestPostProcessGetterDefault(t *testing.T) {
+	fr := NewFunctionResult("test")
+	if fr.PostProcess() {
+		t.Error("PostProcess() should return false by default")
+	}
+}
+
 func TestToMapBasic(t *testing.T) {
 	fr := NewFunctionResult("test response")
 	m := fr.ToMap()
@@ -337,6 +371,18 @@ func TestRemoveGlobalData(t *testing.T) {
 	}
 }
 
+func TestRemoveGlobalDataKey(t *testing.T) {
+	fr := NewFunctionResult("removed").
+		RemoveGlobalDataKey("single-key")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	// Single key variant emits bare string, not array — matches Python Union[str, List[str]] behavior
+	key := actions[0]["unset_global_data"].(string)
+	if key != "single-key" {
+		t.Errorf("unset_global_data = %v, want %q", key, "single-key")
+	}
+}
+
 func TestSetMetadata(t *testing.T) {
 	fr := NewFunctionResult("metadata").
 		SetMetadata(map[string]any{"session": "abc123"})
@@ -356,6 +402,18 @@ func TestRemoveMetadata(t *testing.T) {
 	keys := actions[0]["unset_meta_data"].([]string)
 	if len(keys) != 1 || keys[0] != "old_key" {
 		t.Errorf("keys = %v, want [old_key]", keys)
+	}
+}
+
+func TestRemoveMetadataKey(t *testing.T) {
+	fr := NewFunctionResult("remove").
+		RemoveMetadataKey("single-meta-key")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	// Single key variant emits bare string, not array — matches Python Union[str, List[str]] behavior
+	key := actions[0]["unset_meta_data"].(string)
+	if key != "single-meta-key" {
+		t.Errorf("unset_meta_data = %v, want %q", key, "single-meta-key")
 	}
 }
 
@@ -384,9 +442,9 @@ func TestSwmlChangeStep(t *testing.T) {
 		SwmlChangeStep("betting")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
-	cs := actions[0]["context_switch"].(map[string]any)
-	if cs["step"] != "betting" {
-		t.Errorf("step = %v, want %q", cs["step"], "betting")
+	// Python emits {"change_step": "betting"} — plain string, not a struct
+	if actions[0]["change_step"] != "betting" {
+		t.Errorf("change_step = %v, want %q", actions[0]["change_step"], "betting")
 	}
 }
 
@@ -395,9 +453,9 @@ func TestSwmlChangeContext(t *testing.T) {
 		SwmlChangeContext("support")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
-	cs := actions[0]["context_switch"].(map[string]any)
-	if cs["context"] != "support" {
-		t.Errorf("context = %v, want %q", cs["context"], "support")
+	// Python emits {"change_context": "support"} — plain string, not a struct
+	if actions[0]["change_context"] != "support" {
+		t.Errorf("change_context = %v, want %q", actions[0]["change_context"], "support")
 	}
 }
 
@@ -509,7 +567,7 @@ func TestStopBackgroundFile(t *testing.T) {
 
 func TestRecordCall(t *testing.T) {
 	fr := NewFunctionResult("recording").
-		RecordCall("rec-123", true, "wav", "both")
+		RecordCall("rec-123", true, "wav", "both", nil)
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -534,7 +592,7 @@ func TestRecordCall(t *testing.T) {
 
 func TestRecordCallNoControlID(t *testing.T) {
 	fr := NewFunctionResult("recording").
-		RecordCall("", false, "mp3", "speak")
+		RecordCall("", false, "mp3", "speak", nil)
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -545,6 +603,48 @@ func TestRecordCallNoControlID(t *testing.T) {
 
 	if _, ok := params["control_id"]; ok {
 		t.Error("control_id should not be present when empty")
+	}
+}
+
+func TestRecordCallWithOptions(t *testing.T) {
+	fr := NewFunctionResult("recording").
+		RecordCall("rec-456", false, "mp3", "speak", &RecordCallOptions{
+			Terminators:       "#",
+			Beep:              true,
+			InputSensitivity:  40.0,
+			InitialTimeout:    5.0,
+			EndSilenceTimeout: 3.0,
+			MaxLength:         120.0,
+			StatusURL:         "https://example.com/recording-status",
+		})
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	params := verb["record_call"].(map[string]any)
+
+	if params["terminators"] != "#" {
+		t.Errorf("terminators = %v, want %q", params["terminators"], "#")
+	}
+	if params["beep"] != true {
+		t.Errorf("beep = %v, want true", params["beep"])
+	}
+	if params["input_sensitivity"] != 40.0 {
+		t.Errorf("input_sensitivity = %v, want 40.0", params["input_sensitivity"])
+	}
+	if params["initial_timeout"] != 5.0 {
+		t.Errorf("initial_timeout = %v, want 5.0", params["initial_timeout"])
+	}
+	if params["end_silence_timeout"] != 3.0 {
+		t.Errorf("end_silence_timeout = %v, want 3.0", params["end_silence_timeout"])
+	}
+	if params["max_length"] != 120.0 {
+		t.Errorf("max_length = %v, want 120.0", params["max_length"])
+	}
+	if params["status_url"] != "https://example.com/recording-status" {
+		t.Errorf("status_url = %v", params["status_url"])
 	}
 }
 
@@ -713,7 +813,11 @@ func TestExecuteSwmlDoesNotMutateInput(t *testing.T) {
 
 func TestJoinConference(t *testing.T) {
 	fr := NewFunctionResult("joining").
-		JoinConference("my-conf", true, "onEnter", "https://example.com/hold.mp3")
+		JoinConference("my-conf", &JoinConferenceOptions{
+			Muted:   true,
+			Beep:    "onEnter",
+			WaitURL: "https://example.com/hold.mp3",
+		})
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -738,7 +842,7 @@ func TestJoinConference(t *testing.T) {
 
 func TestJoinConferenceDefaults(t *testing.T) {
 	fr := NewFunctionResult("joining").
-		JoinConference("simple-conf", false, "true", "")
+		JoinConference("simple-conf", nil)
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -755,6 +859,46 @@ func TestJoinConferenceDefaults(t *testing.T) {
 	}
 	if _, ok := params["wait_url"]; ok {
 		t.Error("wait_url should not be present when empty")
+	}
+}
+
+func TestJoinConferenceFullOptions(t *testing.T) {
+	fr := NewFunctionResult("joining").
+		JoinConference("full-conf", &JoinConferenceOptions{
+			Record:                        "record-from-start",
+			Region:                        "us1",
+			Trim:                          "do-not-trim",
+			Coach:                         "call-sid-123",
+			StatusCallbackEvent:           "start end join",
+			StatusCallback:                "https://example.com/status",
+			StatusCallbackMethod:          "GET",
+			RecordingStatusCallback:       "https://example.com/rec-status",
+			RecordingStatusCallbackMethod: "GET",
+			RecordingStatusCallbackEvent:  "in-progress",
+			MaxParticipants:               50,
+		})
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	params := verb["join_conference"].(map[string]any)
+
+	if params["record"] != "record-from-start" {
+		t.Errorf("record = %v", params["record"])
+	}
+	if params["region"] != "us1" {
+		t.Errorf("region = %v", params["region"])
+	}
+	if params["trim"] != "do-not-trim" {
+		t.Errorf("trim = %v", params["trim"])
+	}
+	if params["coach"] != "call-sid-123" {
+		t.Errorf("coach = %v", params["coach"])
+	}
+	if params["max_participants"] != 50 {
+		t.Errorf("max_participants = %v, want 50", params["max_participants"])
 	}
 }
 
@@ -790,7 +934,7 @@ func TestSipRefer(t *testing.T) {
 
 func TestTap(t *testing.T) {
 	fr := NewFunctionResult("tapping").
-		Tap("rtp://192.168.1.1:5000", "tap-1", "speak", "PCMA")
+		Tap("rtp://192.168.1.1:5000", "tap-1", "speak", "PCMA", 0, "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -815,7 +959,7 @@ func TestTap(t *testing.T) {
 
 func TestTapDefaults(t *testing.T) {
 	fr := NewFunctionResult("tapping").
-		Tap("ws://example.com", "", "both", "PCMU")
+		Tap("ws://example.com", "", "both", "PCMU", 0, "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -832,6 +976,25 @@ func TestTapDefaults(t *testing.T) {
 	}
 	if _, ok := params["codec"]; ok {
 		t.Error("codec should not be present when 'PCMU' (default)")
+	}
+}
+
+func TestTapWithRtpPtimeAndStatusURL(t *testing.T) {
+	fr := NewFunctionResult("tapping").
+		Tap("rtp://192.168.1.1:5000", "", "both", "PCMU", 30, "https://example.com/tap-status")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	params := verb["tap"].(map[string]any)
+
+	if params["rtp_ptime"] != 30 {
+		t.Errorf("rtp_ptime = %v, want 30", params["rtp_ptime"])
+	}
+	if params["status_url"] != "https://example.com/tap-status" {
+		t.Errorf("status_url = %v", params["status_url"])
 	}
 }
 
@@ -867,7 +1030,7 @@ func TestStopTapNoControlID(t *testing.T) {
 
 func TestSendSms(t *testing.T) {
 	fr := NewFunctionResult("sms sent").
-		SendSms("+15551234567", "+15559876543", "Hello!", nil, nil)
+		SendSms("+15551234567", "+15559876543", "Hello!", nil, nil, "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -891,13 +1054,32 @@ func TestSendSms(t *testing.T) {
 	if _, ok := params["tags"]; ok {
 		t.Error("tags should not be present when nil")
 	}
+	if _, ok := params["region"]; ok {
+		t.Error("region should not be present when empty")
+	}
+}
+
+func TestSendSmsWithRegion(t *testing.T) {
+	fr := NewFunctionResult("sms sent").
+		SendSms("+15551234567", "+15559876543", "Hello!", nil, nil, "us-east")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	params := verb["send_sms"].(map[string]any)
+
+	if params["region"] != "us-east" {
+		t.Errorf("region = %v, want %q", params["region"], "us-east")
+	}
 }
 
 func TestSendSmsWithMediaAndTags(t *testing.T) {
 	fr := NewFunctionResult("sms sent").
 		SendSms("+15551234567", "+15559876543", "",
 			[]string{"https://example.com/image.jpg"},
-			[]string{"support", "urgent"})
+			[]string{"support", "urgent"}, "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -920,17 +1102,42 @@ func TestSendSmsWithMediaAndTags(t *testing.T) {
 }
 
 func TestPay(t *testing.T) {
+	// With nil opts, Python defaults are applied and the default ai_response set verb is included
 	fr := NewFunctionResult("processing payment").
-		Pay("https://example.com/pay", "dtmf", "", 5, 1)
+		Pay("https://example.com/pay", nil)
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
 	sections := swml["sections"].(map[string]any)
 	main := sections["main"].([]any)
 
-	// Without actionURL, no "set" verb should be prepended
+	// Default behavior includes the "set" verb with ai_response
+	if len(main) != 2 {
+		t.Fatalf("main verbs = %d, want 2 (set + pay)", len(main))
+	}
+	verb := main[1].(map[string]any)
+	params := verb["pay"].(map[string]any)
+	if params["payment_connector_url"] != "https://example.com/pay" {
+		t.Errorf("payment_connector_url = %v", params["payment_connector_url"])
+	}
+	if params["input"] != "dtmf" {
+		t.Errorf("input = %v, want %q", params["input"], "dtmf")
+	}
+}
+
+func TestPayNoAiResponse(t *testing.T) {
+	// Use AIResponse="-" to suppress the set verb
+	fr := NewFunctionResult("processing payment").
+		Pay("https://example.com/pay", &PayOptions{AIResponse: "-"})
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+
+	// No "set" verb when AIResponse is "-"
 	if len(main) != 1 {
-		t.Fatalf("main verbs = %d, want 1", len(main))
+		t.Fatalf("main verbs = %d, want 1 (pay only)", len(main))
 	}
 	verb := main[0].(map[string]any)
 	params := verb["pay"].(map[string]any)
@@ -939,9 +1146,9 @@ func TestPay(t *testing.T) {
 	}
 }
 
-func TestPayWithActionURL(t *testing.T) {
+func TestPayWithCustomAiResponse(t *testing.T) {
 	fr := NewFunctionResult("processing payment").
-		Pay("https://example.com/pay", "dtmf", "Payment complete", 5, 1)
+		Pay("https://example.com/pay", &PayOptions{AIResponse: "Payment complete"})
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -959,11 +1166,58 @@ func TestPayWithActionURL(t *testing.T) {
 	}
 }
 
+func TestPayWithFullOptions(t *testing.T) {
+	fr := NewFunctionResult("processing payment").
+		Pay("https://example.com/pay", &PayOptions{
+			InputMethod:     "voice",
+			PaymentMethod:   "credit-card",
+			Timeout:         10,
+			MaxAttempts:     3,
+			SecurityCode:    true,
+			SecurityCodeSet: true,
+			PostalCode:      false,
+			TokenType:       "one-time",
+			ChargeAmount:    "9.99",
+			Currency:        "eur",
+			Language:        "fr-FR",
+			Voice:           "man",
+			ValidCardTypes:  "visa",
+			StatusURL:       "https://example.com/status",
+			AIResponse:      "-",
+		})
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	params := verb["pay"].(map[string]any)
+
+	if params["input"] != "voice" {
+		t.Errorf("input = %v, want %q", params["input"], "voice")
+	}
+	if params["token_type"] != "one-time" {
+		t.Errorf("token_type = %v, want %q", params["token_type"], "one-time")
+	}
+	if params["charge_amount"] != "9.99" {
+		t.Errorf("charge_amount = %v, want %q", params["charge_amount"], "9.99")
+	}
+	if params["currency"] != "eur" {
+		t.Errorf("currency = %v, want %q", params["currency"], "eur")
+	}
+	if params["status_url"] != "https://example.com/status" {
+		t.Errorf("status_url = %v", params["status_url"])
+	}
+	if params["postal_code"] != "false" {
+		t.Errorf("postal_code = %v, want %q", params["postal_code"], "false")
+	}
+}
+
 // --- RPC Actions ---
 
 func TestExecuteRpc(t *testing.T) {
 	fr := NewFunctionResult("rpc").
-		ExecuteRpc("custom.method", map[string]any{"key": "value"})
+		ExecuteRpc("custom.method", map[string]any{"key": "value"}, "", "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -986,7 +1240,7 @@ func TestExecuteRpc(t *testing.T) {
 
 func TestExecuteRpcNoParams(t *testing.T) {
 	fr := NewFunctionResult("rpc").
-		ExecuteRpc("simple.method", nil)
+		ExecuteRpc("simple.method", nil, "", "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -1000,10 +1254,9 @@ func TestExecuteRpcNoParams(t *testing.T) {
 	}
 }
 
-func TestRpcDial(t *testing.T) {
-	timeout := 30
-	fr := NewFunctionResult("dialing").
-		RpcDial("+15551234567", "+15559876543", "https://example.com/swml", &timeout, "us-east")
+func TestExecuteRpcWithCallIDAndNodeID(t *testing.T) {
+	fr := NewFunctionResult("rpc").
+		ExecuteRpc("my.method", map[string]any{"key": "val"}, "call-123", "node-456")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -1012,19 +1265,33 @@ func TestRpcDial(t *testing.T) {
 	verb := main[0].(map[string]any)
 	rpc := verb["execute_rpc"].(map[string]any)
 
-	if rpc["method"] != "calling.dial" {
-		t.Errorf("method = %v, want %q", rpc["method"], "calling.dial")
+	if rpc["call_id"] != "call-123" {
+		t.Errorf("call_id = %v, want %q", rpc["call_id"], "call-123")
+	}
+	if rpc["node_id"] != "node-456" {
+		t.Errorf("node_id = %v, want %q", rpc["node_id"], "node-456")
+	}
+}
+
+func TestRpcDial(t *testing.T) {
+	fr := NewFunctionResult("dialing").
+		RpcDial("+15551234567", "+15559876543", "https://example.com/swml", "phone")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	rpc := verb["execute_rpc"].(map[string]any)
+
+	// Python uses bare "dial", not "calling.dial"
+	if rpc["method"] != "dial" {
+		t.Errorf("method = %v, want %q", rpc["method"], "dial")
 	}
 
 	params := rpc["params"].(map[string]any)
 	if params["dest_swml"] != "https://example.com/swml" {
 		t.Errorf("dest_swml = %v", params["dest_swml"])
-	}
-	if params["timeout"] != 30 {
-		t.Errorf("timeout = %v, want 30", params["timeout"])
-	}
-	if params["region"] != "us-east" {
-		t.Errorf("region = %v, want %q", params["region"], "us-east")
 	}
 
 	devices := params["devices"].(map[string]any)
@@ -1037,9 +1304,9 @@ func TestRpcDial(t *testing.T) {
 	}
 }
 
-func TestRpcDialNoOptional(t *testing.T) {
+func TestRpcDialDefaultDeviceType(t *testing.T) {
 	fr := NewFunctionResult("dialing").
-		RpcDial("+15551234567", "+15559876543", "https://example.com/swml", nil, "")
+		RpcDial("+15551234567", "+15559876543", "https://example.com/swml", "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -1049,17 +1316,16 @@ func TestRpcDialNoOptional(t *testing.T) {
 	rpc := verb["execute_rpc"].(map[string]any)
 	params := rpc["params"].(map[string]any)
 
-	if _, ok := params["timeout"]; ok {
-		t.Error("timeout should not be present when nil")
-	}
-	if _, ok := params["region"]; ok {
-		t.Error("region should not be present when empty")
+	devices := params["devices"].(map[string]any)
+	// Empty deviceType should default to "phone"
+	if devices["type"] != "phone" {
+		t.Errorf("type = %v, want %q (default)", devices["type"], "phone")
 	}
 }
 
 func TestRpcAiMessage(t *testing.T) {
 	fr := NewFunctionResult("messaging").
-		RpcAiMessage("call-abc-123", "Please take a message")
+		RpcAiMessage("call-abc-123", "Please take a message", "")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
 	swml := actions[0]["SWML"].(map[string]any)
@@ -1068,8 +1334,9 @@ func TestRpcAiMessage(t *testing.T) {
 	verb := main[0].(map[string]any)
 	rpc := verb["execute_rpc"].(map[string]any)
 
-	if rpc["method"] != "calling.ai_message" {
-		t.Errorf("method = %v, want %q", rpc["method"], "calling.ai_message")
+	// Python uses bare "ai_message", not "calling.ai_message"
+	if rpc["method"] != "ai_message" {
+		t.Errorf("method = %v, want %q", rpc["method"], "ai_message")
 	}
 	if rpc["call_id"] != "call-abc-123" {
 		t.Errorf("call_id = %v, want %q", rpc["call_id"], "call-abc-123")
@@ -1084,6 +1351,23 @@ func TestRpcAiMessage(t *testing.T) {
 	}
 }
 
+func TestRpcAiMessageCustomRole(t *testing.T) {
+	fr := NewFunctionResult("messaging").
+		RpcAiMessage("call-abc-123", "Hello", "user")
+
+	actions := fr.ToMap()["action"].([]map[string]any)
+	swml := actions[0]["SWML"].(map[string]any)
+	sections := swml["sections"].(map[string]any)
+	main := sections["main"].([]any)
+	verb := main[0].(map[string]any)
+	rpc := verb["execute_rpc"].(map[string]any)
+	params := rpc["params"].(map[string]any)
+
+	if params["role"] != "user" {
+		t.Errorf("role = %v, want %q", params["role"], "user")
+	}
+}
+
 func TestRpcAiUnhold(t *testing.T) {
 	fr := NewFunctionResult("unholding").
 		RpcAiUnhold("call-abc-123")
@@ -1095,8 +1379,9 @@ func TestRpcAiUnhold(t *testing.T) {
 	verb := main[0].(map[string]any)
 	rpc := verb["execute_rpc"].(map[string]any)
 
-	if rpc["method"] != "calling.ai_unhold" {
-		t.Errorf("method = %v, want %q", rpc["method"], "calling.ai_unhold")
+	// Python uses bare "ai_unhold", not "calling.ai_unhold"
+	if rpc["method"] != "ai_unhold" {
+		t.Errorf("method = %v, want %q", rpc["method"], "ai_unhold")
 	}
 	if rpc["call_id"] != "call-abc-123" {
 		t.Errorf("call_id = %v, want %q", rpc["call_id"], "call-abc-123")
@@ -1108,8 +1393,9 @@ func TestSimulateUserInput(t *testing.T) {
 		SimulateUserInput("I need help")
 
 	actions := fr.ToMap()["action"].([]map[string]any)
-	if actions[0]["simulate_user_input"] != "I need help" {
-		t.Errorf("simulate_user_input = %v, want %q", actions[0]["simulate_user_input"], "I need help")
+	// Python emits {"user_input": "..."} — not "simulate_user_input"
+	if actions[0]["user_input"] != "I need help" {
+		t.Errorf("user_input = %v, want %q", actions[0]["user_input"], "I need help")
 	}
 }
 
@@ -1202,7 +1488,7 @@ func TestCreatePaymentPrompt(t *testing.T) {
 		CreatePaymentAction("payment-card-number", "Please enter your card number"),
 		CreatePaymentAction("payment-expiration-date", "Enter expiration date"),
 	}
-	prompt := CreatePaymentPrompt("credit-card-payment", actions)
+	prompt := CreatePaymentPrompt("credit-card-payment", actions, "", "")
 
 	if prompt["for"] != "credit-card-payment" {
 		t.Errorf("for = %v, want %q", prompt["for"], "credit-card-payment")
@@ -1222,6 +1508,27 @@ func TestCreatePaymentPrompt(t *testing.T) {
 	}
 	if acts[1]["type"] != "payment-expiration-date" {
 		t.Errorf("action[1].type = %v, want %q", acts[1]["type"], "payment-expiration-date")
+	}
+	// No card_type or error_type when empty
+	if _, ok := prompt["card_type"]; ok {
+		t.Error("card_type should not be present when empty")
+	}
+	if _, ok := prompt["error_type"]; ok {
+		t.Error("error_type should not be present when empty")
+	}
+}
+
+func TestCreatePaymentPromptWithCardAndErrorType(t *testing.T) {
+	actions := []map[string]string{
+		CreatePaymentAction("Say", "Enter your card"),
+	}
+	prompt := CreatePaymentPrompt("card-entry", actions, "visa mastercard", "invalid-card-number")
+
+	if prompt["card_type"] != "visa mastercard" {
+		t.Errorf("card_type = %v, want %q", prompt["card_type"], "visa mastercard")
+	}
+	if prompt["error_type"] != "invalid-card-number" {
+		t.Errorf("error_type = %v, want %q", prompt["error_type"], "invalid-card-number")
 	}
 }
 
@@ -1254,7 +1561,7 @@ func TestCreatePaymentParameter(t *testing.T) {
 }
 
 func TestCreatePaymentPrompt_EmptyActions(t *testing.T) {
-	prompt := CreatePaymentPrompt("refund", []map[string]string{})
+	prompt := CreatePaymentPrompt("refund", []map[string]string{}, "", "")
 
 	if prompt["for"] != "refund" {
 		t.Errorf("for = %v, want %q", prompt["for"], "refund")


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: FunctionResult — wire-format + typed params (P1/P2)

Brings pkg/swaig.FunctionResult to parity with Python's
signalwire/core/function_result.py.

HIGH-IMPACT wire-format action key fixes (platform contract):
- SwmlChangeStep: emits "change_step" with plain string (was
  "context_switch" with struct payload).
- SwmlChangeContext: emits "change_context" with plain string (was
  "context_switch" with struct payload).
- SimulateUserInput: emits "user_input" (was "simulate_user_input").
- RpcDial/RpcAiMessage/RpcAiUnhold: method param emits bare "dial",
  "ai_message", "ai_unhold" (was "calling.*" prefixed).

Missing getters (P1 MISSING_PROPERTY):
- Response(), Actions(), PostProcess() — expose the underlying
  unexported fields that Python has as public attributes.

Typed-parameter replacements for missing kwargs (P1 MISSING_PARAM):
- SendSms: added region as 6th param.
- Pay: replaced 5-param signature with Pay(connectorURL, opts *PayOptions)
  — PayOptions struct covers all 19 Python params.
- RecordCall: added opts *RecordCallOptions (terminators, beep,
  input_sensitivity, initial_timeout, end_silence_timeout, max_length,
  status_url).
- JoinConference: replaced 4-param with JoinConference(name,
  opts *JoinConferenceOptions) covering all 18 Python params.
- Tap: added rtpPtime int, statusURL string (5th/6th params).
- ExecuteRpc: added callID, nodeID.
- RpcDial: replaced callTimeout/region Go extensions with deviceType
  matching Python.
- RpcAiMessage: added role string (defaults to "system" when empty).
- CreatePaymentPrompt: added cardType, errorType.

P2 convenience methods:
- RemoveGlobalDataKey(key), RemoveMetadataKey(key) — match Python's
  Union[str, List[str]] bare-string behavior.

2 P3 items left as intentional Go deviations per validated findings:
- SwitchContext.isolated — Go-only extension; documented in place.
- Constructor post_process — Go uses SetPostProcess() fluent setter
  (reclassified P3 in validated findings).

Tests updated across pkg/swaig/function_result_test.go and the
examples/call_flow/main.go SendSms call site.

Closes #38.

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #38

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
