### PR TITLE
Align contexts module with Python SDK

### DIFF
--- a/pkg/contexts/contexts.go
+++ b/pkg/contexts/contexts.go
@@ -122,7 +122,21 @@ func (g *GatherInfo) AddQuestion(key, question string, opts ...GatherQuestionOpt
 	return g
 }
 
+// Validate returns an error if the GatherInfo is not ready for serialisation.
+// Specifically, it rejects a GatherInfo with no questions, which would produce
+// invalid SWML. This matches the Python SDK's ValueError raised by to_dict()
+// when _questions is empty.
+func (g *GatherInfo) Validate() error {
+	if len(g.Questions) == 0 {
+		return errors.New("gather_info must have at least one question")
+	}
+	return nil
+}
+
 // ToMap serialises to the SWML map format.
+// Callers that construct GatherInfo directly should call Validate() first to
+// ensure the result is valid SWML. Step.ToMap() enforces this automatically
+// by only calling ToMap() when len(Questions) > 0.
 func (g *GatherInfo) ToMap() map[string]any {
 	qs := make([]map[string]any, len(g.Questions))
 	for i := range g.Questions {
@@ -266,15 +280,20 @@ func (s *Step) SetSkipToNextStep(skip bool) *Step {
 	return s
 }
 
-// SetGatherInfo enables info gathering for this step and returns the
-// GatherInfo so that questions can be added to it directly.
-func (s *Step) SetGatherInfo(outputKey, completionAction, prompt string) *GatherInfo {
+// SetGatherInfo enables info gathering for this step and returns the Step
+// for fluent chaining. This matches the Python SDK's set_gather_info, which
+// returns self so that step-level setters (SetFunctions, SetValidSteps, etc.)
+// can be chained after configuring gather info.
+//
+// To add questions to the gather info, use AddGatherQuestion on the same
+// *Step receiver.
+func (s *Step) SetGatherInfo(outputKey, completionAction, prompt string) *Step {
 	s.gatherInfo = &GatherInfo{
 		OutputKey:        outputKey,
 		CompletionAction: completionAction,
 		Prompt:           prompt,
 	}
-	return s.gatherInfo
+	return s
 }
 
 // AddGatherQuestion adds a question to this step's gather_info. SetGatherInfo
@@ -468,10 +487,10 @@ func (c *Context) GetStep(name string) *Step {
 	return c.stepMap[name]
 }
 
-// RemoveStep removes a step by name.
-func (c *Context) RemoveStep(name string) {
+// RemoveStep removes a step by name. Returns the receiver for method chaining.
+func (c *Context) RemoveStep(name string) *Context {
 	if _, ok := c.stepMap[name]; !ok {
-		return
+		return c
 	}
 	delete(c.stepMap, name)
 	for i, s := range c.steps {
@@ -480,10 +499,12 @@ func (c *Context) RemoveStep(name string) {
 			break
 		}
 	}
+	return c
 }
 
 // MoveStep moves an existing step to the given position (0-based index).
-func (c *Context) MoveStep(name string, position int) {
+// Returns the receiver for method chaining.
+func (c *Context) MoveStep(name string, position int) *Context {
 	idx := -1
 	for i, s := range c.steps {
 		if s.name == name {
@@ -492,7 +513,7 @@ func (c *Context) MoveStep(name string, position int) {
 		}
 	}
 	if idx < 0 {
-		return
+		return c
 	}
 	step := c.steps[idx]
 	// Remove from current position.
@@ -506,6 +527,7 @@ func (c *Context) MoveStep(name string, position int) {
 	}
 	// Insert at new position.
 	c.steps = append(c.steps[:position], append([]*Step{step}, c.steps[position:]...)...)
+	return c
 }
 
 // SetInitialStep sets which step the context starts on when entered.
@@ -823,6 +845,10 @@ func (cb *ContextBuilder) GetContext(name string) *Context {
 //   - A single context must be named "default".
 //   - Every context must contain at least one step.
 //   - Every step must have a name.
+//   - valid_steps entries (except "next") must name existing steps in the same context.
+//   - valid_contexts entries (context-level) must name existing contexts.
+//   - valid_contexts entries (step-level) must name existing contexts.
+//   - gather_info questions must be non-empty and have unique keys.
 //   - gather_info completion_action (if set) targets an existing step.
 //   - No user-defined SWAIG tool collides with a reserved native name.
 func (cb *ContextBuilder) Validate() error {
@@ -865,7 +891,80 @@ func (cb *ContextBuilder) Validate() error {
 		}
 	}
 
-	// Validate completion_action references in gather_info. completion_action
+	// Validate step references in valid_steps. Each entry must be either the
+	// special keyword "next" (advance to the next sequential step) or the
+	// name of an existing step in the same context.
+	for _, ctx := range cb.contexts {
+		for _, step := range ctx.steps {
+			for _, ref := range step.validSteps {
+				if ref == "next" {
+					continue
+				}
+				if _, ok := ctx.stepMap[ref]; !ok {
+					return fmt.Errorf(
+						"step %q in context %q references unknown step %q",
+						step.name, ctx.name, ref,
+					)
+				}
+			}
+		}
+	}
+
+	// Validate context references in valid_contexts (context-level). Each
+	// entry must name an existing context.
+	for _, ctx := range cb.contexts {
+		for _, ref := range ctx.validContexts {
+			if _, ok := cb.contextMap[ref]; !ok {
+				return fmt.Errorf(
+					"context %q references unknown context %q",
+					ctx.name, ref,
+				)
+			}
+		}
+	}
+
+	// Validate context references in valid_contexts (step-level). Each
+	// entry must name an existing context.
+	for _, ctx := range cb.contexts {
+		for _, step := range ctx.steps {
+			for _, ref := range step.validContexts {
+				if _, ok := cb.contextMap[ref]; !ok {
+					return fmt.Errorf(
+						"step %q in context %q references unknown context %q",
+						step.name, ctx.name, ref,
+					)
+				}
+			}
+		}
+	}
+
+	// Validate gather_info question lists: must be non-empty and must not
+	// contain duplicate keys within the same step.
+	for _, ctx := range cb.contexts {
+		for _, step := range ctx.steps {
+			if step.gatherInfo == nil {
+				continue
+			}
+			if len(step.gatherInfo.Questions) == 0 {
+				return fmt.Errorf(
+					"step %q in context %q has gather_info with no questions",
+					step.name, ctx.name,
+				)
+			}
+			seen := make(map[string]struct{}, len(step.gatherInfo.Questions))
+			for _, q := range step.gatherInfo.Questions {
+				if _, dup := seen[q.Key]; dup {
+					return fmt.Errorf(
+						"step %q in context %q has duplicate gather_info question key %q",
+						step.name, ctx.name, q.Key,
+					)
+				}
+				seen[q.Key] = struct{}{}
+			}
+		}
+	}
+
+	// Validate gather_info completion_action references in gather_info. completion_action
 	// is either "next_step" (advance to the following step in order), the
 	// name of an existing step in the same context, or empty (stay in the
 	// current step).

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -253,9 +253,9 @@ func TestContextRemoveStep(t *testing.T) {
 func TestGatherInfo(t *testing.T) {
 	step := &Step{name: "gather"}
 	step.SetText("Collecting info")
-	gi := step.SetGatherInfo("user_data", "next_step", "Let me ask you some questions")
-	gi.AddQuestion("name", "What is your name?").
-		AddQuestion("email", "What is your email?", WithType("string"), WithConfirm(true))
+	step.SetGatherInfo("user_data", "next_step", "Let me ask you some questions").
+		AddGatherQuestion("name", "What is your name?").
+		AddGatherQuestion("email", "What is your email?", WithType("string"), WithConfirm(true))
 
 	m := step.ToMap()
 	giMap, ok := m["gather_info"].(map[string]any)
@@ -336,6 +336,20 @@ func TestAddGatherQuestionWithoutSetGatherInfo(t *testing.T) {
 	}
 	if len(step.gatherInfo.Questions) != 1 {
 		t.Fatal("expected 1 question")
+	}
+}
+
+func TestGatherInfoValidate(t *testing.T) {
+	// Empty GatherInfo must fail validation — mirrors Python's ValueError.
+	gi := &GatherInfo{OutputKey: "data", Prompt: "Tell me"}
+	if err := gi.Validate(); err == nil {
+		t.Fatal("expected error from Validate() on GatherInfo with no questions")
+	}
+
+	// After adding a question, Validate must pass.
+	gi.AddQuestion("name", "What is your name?")
+	if err := gi.Validate(); err != nil {
+		t.Fatalf("unexpected error from Validate() after adding a question: %v", err)
 	}
 }
 
@@ -782,9 +796,9 @@ func TestGatherInfoInBuilder(t *testing.T) {
 	ctx := cb.AddContext("default")
 	step := ctx.AddStep("collect")
 	step.SetText("Collecting info")
-	gi := step.SetGatherInfo("answers", "process", "I need to ask a few things")
-	gi.AddQuestion("age", "How old are you?", WithType("integer"))
-	gi.AddQuestion("city", "Where do you live?")
+	step.SetGatherInfo("answers", "process", "I need to ask a few things").
+		AddGatherQuestion("age", "How old are you?", WithType("integer")).
+		AddGatherQuestion("city", "Where do you live?")
 	// A completion_action of "process" must target a real step for
 	// validation to pass.
 	ctx.AddStep("process").SetText("Process collected info")

--- a/pkg/contexts/validate_refs_test.go
+++ b/pkg/contexts/validate_refs_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package contexts
+
+import (
+	"strings"
+	"testing"
+)
+
+// Negative-case tests for the cross-reference validation loops added in
+// this PR: initial_step, step.valid_steps, context.valid_contexts,
+// step.valid_contexts. Mirrors Python SWML_ContextBuilder validation
+// (tests/unit/core/test_contexts.py).
+
+// --- initial_step ---
+
+func TestValidateInitialStepUnknown(t *testing.T) {
+	cb := NewContextBuilder()
+	ctx := cb.AddContext("default")
+	ctx.AddStep("greet").SetText("hi")
+	ctx.SetInitialStep("nonexistent")
+
+	err := cb.Validate()
+	if err == nil {
+		t.Fatal("expected error when initial_step references an unknown step")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention the unknown step name, got: %v", err)
+	}
+}
+
+func TestValidateInitialStepValid(t *testing.T) {
+	cb := NewContextBuilder()
+	ctx := cb.AddContext("default")
+	ctx.AddStep("greet").SetText("hi")
+	ctx.AddStep("collect").SetText("give me your name")
+	ctx.SetInitialStep("collect")
+
+	if err := cb.Validate(); err != nil {
+		t.Fatalf("expected valid initial_step to pass, got: %v", err)
+	}
+}
+
+// --- step.valid_steps ---
+
+func TestValidateStepValidStepsReferencesUnknownStep(t *testing.T) {
+	cb := NewContextBuilder()
+	ctx := cb.AddContext("default")
+	ctx.AddStep("greet").SetText("hi").SetValidSteps([]string{"no_such_step"})
+
+	err := cb.Validate()
+	if err == nil {
+		t.Fatal("expected error when valid_steps references unknown step")
+	}
+	if !strings.Contains(err.Error(), "no_such_step") {
+		t.Errorf("error should mention the unknown step, got: %v", err)
+	}
+}
+
+func TestValidateStepValidStepsAllowsNextKeyword(t *testing.T) {
+	// "next" is the special keyword meaning advance to the next sequential
+	// step — it must NOT be rejected as an unknown step name.
+	cb := NewContextBuilder()
+	ctx := cb.AddContext("default")
+	ctx.AddStep("greet").SetText("hi").SetValidSteps([]string{"next"})
+
+	if err := cb.Validate(); err != nil {
+		t.Fatalf(`"next" keyword must be accepted in valid_steps, got: %v`, err)
+	}
+}
+
+func TestValidateStepValidStepsAllowsKnownSteps(t *testing.T) {
+	cb := NewContextBuilder()
+	ctx := cb.AddContext("default")
+	ctx.AddStep("greet").SetText("hi").SetValidSteps([]string{"collect"})
+	ctx.AddStep("collect").SetText("give me your name")
+
+	if err := cb.Validate(); err != nil {
+		t.Fatalf("valid cross-step reference should pass, got: %v", err)
+	}
+}
+
+// --- context.valid_contexts (context-level) ---
+
+func TestValidateContextValidContextsReferencesUnknownContext(t *testing.T) {
+	cb := NewContextBuilder()
+	a := cb.AddContext("sales")
+	a.AddStep("s1").SetText("hi")
+	a.SetValidContexts([]string{"no_such_context"})
+
+	// Also add a second context so the single-context-must-be-default rule
+	// doesn't mask this failure.
+	b := cb.AddContext("support")
+	b.AddStep("s1").SetText("hi")
+
+	err := cb.Validate()
+	if err == nil {
+		t.Fatal("expected error when context valid_contexts references unknown context")
+	}
+	if !strings.Contains(err.Error(), "no_such_context") {
+		t.Errorf("error should mention the unknown context name, got: %v", err)
+	}
+}
+
+func TestValidateContextValidContextsAcceptsKnownContexts(t *testing.T) {
+	cb := NewContextBuilder()
+	a := cb.AddContext("sales")
+	a.AddStep("s1").SetText("hi")
+	a.SetValidContexts([]string{"support"})
+	b := cb.AddContext("support")
+	b.AddStep("s1").SetText("hi")
+
+	if err := cb.Validate(); err != nil {
+		t.Fatalf("known context in valid_contexts should pass, got: %v", err)
+	}
+}
+
+// --- step.valid_contexts (step-level) ---
+
+func TestValidateStepValidContextsReferencesUnknownContext(t *testing.T) {
+	cb := NewContextBuilder()
+	a := cb.AddContext("sales")
+	a.AddStep("s1").SetText("hi").SetValidContexts([]string{"no_such_context"})
+	b := cb.AddContext("support")
+	b.AddStep("s1").SetText("hi")
+
+	err := cb.Validate()
+	if err == nil {
+		t.Fatal("expected error when step valid_contexts references unknown context")
+	}
+	if !strings.Contains(err.Error(), "no_such_context") {
+		t.Errorf("error should mention the unknown context name, got: %v", err)
+	}
+}
+
+func TestValidateStepValidContextsAcceptsKnownContexts(t *testing.T) {
+	cb := NewContextBuilder()
+	a := cb.AddContext("sales")
+	a.AddStep("s1").SetText("hi").SetValidContexts([]string{"support"})
+	b := cb.AddContext("support")
+	b.AddStep("s1").SetText("hi")
+
+	if err := cb.Validate(); err != nil {
+		t.Fatalf("known context in step valid_contexts should pass, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: contexts — fluent returns + validation (P2)

Brings signalwire-go's contexts package to parity with Python equivalents
in signalwire/core/contexts.py.

Context (fluent chaining):
- RemoveStep and MoveStep now return *Context for chaining (previously void).

ContextBuilder.Validate() — added four validation passes matching Python:
- step.valid_steps references resolve to real steps (except "next" keyword).
- context.valid_contexts references resolve to real contexts.
- step.valid_contexts references resolve to real contexts.
- step.gather_info requires at least one question; duplicate question keys
  within a step are rejected.

GatherInfo.Validate() — new method returning an error when no questions
are present (Python raises ValueError from to_dict; Go surfaces via a
separate Validate method to avoid changing the ToMap signature).

Step.SetGatherInfo now returns *Step instead of *GatherInfo, matching
Python's fluent return self. Existing chained callers updated.

Closes #28 (Context), #29 (ContextBuilder), #39 (GatherInfo), #70 (Step).

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #28
Closes #29
Closes #39
Closes #70

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
