### PR TITLE
Align infra utilities (datamap, logging) with Python SDK

### DIFF
--- a/pkg/datamap/datamap.go
+++ b/pkg/datamap/datamap.go
@@ -14,6 +14,7 @@
 package datamap
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/signalwire/signalwire-go/pkg/swaig"
@@ -74,6 +75,13 @@ func New(functionName string) *DataMap {
 	return &DataMap{
 		functionName: functionName,
 	}
+}
+
+// FunctionName returns the function name this DataMap was built for.
+// Useful for logging, deduplication checks, and introspection by callers
+// that hold a *DataMap reference but need to identify which tool it represents.
+func (dm *DataMap) FunctionName() string {
+	return dm.functionName
 }
 
 // Purpose sets the LLM-facing tool description — this is an alias for
@@ -149,6 +157,19 @@ func (dm *DataMap) Expression(testValue, pattern string, output *swaig.FunctionR
 		nomatchOutput: nomatchOutput,
 	})
 	return dm
+}
+
+// ExpressionRegexp adds a pattern-matching expression using a compiled *regexp.Regexp.
+// This mirrors Python's expression() which accepts either a plain string or a compiled
+// re.Pattern object — when a compiled pattern is passed, Python extracts pattern.pattern
+// (the raw string). Here, pattern.String() serves the same role.
+//
+// testValue is the template string to test (e.g., "${args.command}").
+// pattern is a compiled regexp whose string representation is used as the match pattern.
+// output is the FunctionResult returned when the pattern matches.
+// nomatchOutput is an optional FunctionResult returned when the pattern does not match (can be nil).
+func (dm *DataMap) ExpressionRegexp(testValue string, pattern *regexp.Regexp, output *swaig.FunctionResult, nomatchOutput *swaig.FunctionResult) *DataMap {
+	return dm.Expression(testValue, pattern.String(), output, nomatchOutput)
 }
 
 // flushCurrentWebhook saves the current webhook and its associated config
@@ -277,7 +298,8 @@ func (dm *DataMap) GlobalErrorKeys(keys []string) *DataMap {
 }
 
 // ToSwaigFunction converts the DataMap to a complete SWAIG function definition map.
-// The returned map contains "function", "purpose", "argument", and "data_map" keys.
+// The returned map contains "function", "description", "parameters", and "data_map" keys,
+// matching the canonical SWML/SWAIG schema consumed by the SignalWire AI platform.
 func (dm *DataMap) ToSwaigFunction() map[string]any {
 	// Build parameter schema
 	properties := make(map[string]any)
@@ -297,12 +319,12 @@ func (dm *DataMap) ToSwaigFunction() map[string]any {
 		}
 	}
 
-	argument := map[string]any{
+	parameters := map[string]any{
 		"type":       "object",
 		"properties": properties,
 	}
 	if len(requiredParams) > 0 {
-		argument["required"] = requiredParams
+		parameters["required"] = requiredParams
 	}
 
 	// Build data_map
@@ -350,10 +372,10 @@ func (dm *DataMap) ToSwaigFunction() map[string]any {
 	}
 
 	return map[string]any{
-		"function": dm.functionName,
-		"purpose":  desc,
-		"argument": argument,
-		"data_map": dataMap,
+		"function":    dm.functionName,
+		"description": desc,
+		"parameters":  parameters,
+		"data_map":    dataMap,
 	}
 }
 
@@ -403,12 +425,20 @@ func CreateSimpleApiTool(name, url, responseTemplate string, parameters map[stri
 	return dm
 }
 
+// ExpressionPattern pairs a regex pattern string with a FunctionResult
+// to execute when test_value matches the pattern. Go equivalent of
+// Python's Tuple[str, FunctionResult] entry in create_expression_tool patterns.
+type ExpressionPattern struct {
+	Pattern string
+	Result  *swaig.FunctionResult
+}
+
 // CreateExpressionTool creates a DataMap configured for expression-based pattern matching.
 // name is the function name.
-// patterns maps test values to a two-element array where [0] is the pattern string
-// and [1] is a *swaig.FunctionResult.
+// patterns maps test values to an ExpressionPattern where Pattern is the regex string
+// and Result is the *swaig.FunctionResult to return on match.
 // parameters maps parameter names to their definitions (each with "type", "description", "required" keys).
-func CreateExpressionTool(name string, patterns map[string][2]any, parameters map[string]map[string]any) *DataMap {
+func CreateExpressionTool(name string, patterns map[string]ExpressionPattern, parameters map[string]map[string]any) *DataMap {
 	dm := New(name)
 
 	// Add parameters
@@ -427,12 +457,8 @@ func CreateExpressionTool(name string, patterns map[string][2]any, parameters ma
 	}
 
 	// Add expressions
-	for testValue, patternPair := range patterns {
-		patternStr, _ := patternPair[0].(string)
-		result, _ := patternPair[1].(*swaig.FunctionResult)
-		if result != nil {
-			dm.Expression(testValue, patternStr, result, nil)
-		}
+	for testValue, ep := range patterns {
+		dm.Expression(testValue, ep.Pattern, ep.Result, nil)
 	}
 
 	return dm

--- a/pkg/datamap/datamap_test.go
+++ b/pkg/datamap/datamap_test.go
@@ -77,17 +77,17 @@ func TestToSwaigFunctionBasic(t *testing.T) {
 	if result["function"] != "greet" {
 		t.Errorf("expected function %q, got %v", "greet", result["function"])
 	}
-	if result["purpose"] != "Greet user" {
-		t.Errorf("expected purpose %q, got %v", "Greet user", result["purpose"])
+	if result["description"] != "Greet user" {
+		t.Errorf("expected description %q, got %v", "Greet user", result["description"])
 	}
 
-	// Check argument schema
-	argument, ok := result["argument"].(map[string]any)
+	// Check parameters schema
+	argument, ok := result["parameters"].(map[string]any)
 	if !ok {
-		t.Fatal("expected argument to be map[string]any")
+		t.Fatal("expected parameters to be map[string]any")
 	}
 	if argument["type"] != "object" {
-		t.Errorf("expected argument type %q, got %v", "object", argument["type"])
+		t.Errorf("expected parameters type %q, got %v", "object", argument["type"])
 	}
 
 	properties, ok := argument["properties"].(map[string]any)
@@ -144,8 +144,8 @@ func TestToSwaigFunctionDefaultDescription(t *testing.T) {
 	dm := New("my_tool")
 	result := dm.ToSwaigFunction()
 
-	if result["purpose"] != "Execute my_tool" {
-		t.Errorf("expected default purpose %q, got %v", "Execute my_tool", result["purpose"])
+	if result["description"] != "Execute my_tool" {
+		t.Errorf("expected default description %q, got %v", "Execute my_tool", result["description"])
 	}
 }
 
@@ -156,7 +156,7 @@ func TestParametersWithEnum(t *testing.T) {
 
 	result := dm.ToSwaigFunction()
 
-	argument := result["argument"].(map[string]any)
+	argument := result["parameters"].(map[string]any)
 	properties := argument["properties"].(map[string]any)
 	modeProp := properties["mode"].(map[string]any)
 
@@ -181,7 +181,7 @@ func TestParametersNoEnum(t *testing.T) {
 
 	result := dm.ToSwaigFunction()
 
-	argument := result["argument"].(map[string]any)
+	argument := result["parameters"].(map[string]any)
 	properties := argument["properties"].(map[string]any)
 	queryProp := properties["query"].(map[string]any)
 
@@ -361,8 +361,8 @@ func TestCreateSimpleApiTool(t *testing.T) {
 	}
 
 	// Should have default purpose since none was set
-	if result["purpose"] != "Execute get_stock" {
-		t.Errorf("expected default purpose, got %v", result["purpose"])
+	if result["description"] != "Execute get_stock" {
+		t.Errorf("expected default description, got %v", result["description"])
 	}
 
 	dataMap := result["data_map"].(map[string]any)
@@ -434,10 +434,10 @@ func TestCreateSimpleApiToolWithBody(t *testing.T) {
 func TestCreateExpressionTool(t *testing.T) {
 	dm := CreateExpressionTool(
 		"playback_control",
-		map[string][2]any{
+		map[string]ExpressionPattern{
 			"${args.command}": {
-				"play.*",
-				swaig.NewFunctionResult("Playing now"),
+				Pattern: "play.*",
+				Result:  swaig.NewFunctionResult("Playing now"),
 			},
 		},
 		map[string]map[string]any{
@@ -588,7 +588,7 @@ func TestEmptyDataMap(t *testing.T) {
 		t.Errorf("expected empty data_map, got %d entries", len(dataMap))
 	}
 
-	argument := result["argument"].(map[string]any)
+	argument := result["parameters"].(map[string]any)
 	properties := argument["properties"].(map[string]any)
 	if len(properties) != 0 {
 		t.Errorf("expected empty properties, got %d entries", len(properties))

--- a/pkg/datamap/public_symbols_test.go
+++ b/pkg/datamap/public_symbols_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package datamap
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/signalwire/signalwire-go/pkg/swaig"
+)
+
+// Tests for the public symbols added in this PR that the alignment
+// review flagged as untested: FunctionName getter and ExpressionRegexp
+// compiled-regexp convenience wrapper. Mirrors Python data_map.DataMap
+// surface in tests/unit/core/test_data_map.py.
+
+func TestFunctionNameReturnsConstructorValue(t *testing.T) {
+	dm := New("lookup_weather")
+	if got := dm.FunctionName(); got != "lookup_weather" {
+		t.Fatalf("FunctionName = %q, want %q", got, "lookup_weather")
+	}
+}
+
+func TestFunctionNameEmpty(t *testing.T) {
+	dm := New("")
+	if got := dm.FunctionName(); got != "" {
+		t.Fatalf("FunctionName = %q for empty name, want empty string", got)
+	}
+}
+
+func TestExpressionRegexpStoresPatternString(t *testing.T) {
+	// ExpressionRegexp should mirror Expression() but accept a compiled
+	// *regexp.Regexp and store its .String() as the pattern — matches
+	// Python's expression() handling of a compiled re.Pattern.
+	dm := New("cmd")
+	pat := regexp.MustCompile(`^ping\s*$`)
+	out := swaig.NewFunctionResult("pong")
+	dm.ExpressionRegexp("${args.command}", pat, out, nil)
+
+	body, err := json.Marshal(dm.ToSwaigFunction())
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	s := string(body)
+	if !strings.Contains(s, `^ping`) {
+		t.Fatalf("expected compiled regexp's string form in data_map output, got: %s", s)
+	}
+	if !strings.Contains(s, "${args.command}") {
+		t.Fatalf("expected test value to be preserved, got: %s", s)
+	}
+}
+
+func TestExpressionRegexpEquivalentToExpression(t *testing.T) {
+	// ExpressionRegexp("${x}", regexp.MustCompile("p"), out, nil)
+	// should produce identical output to Expression("${x}", "p", out, nil).
+	out := swaig.NewFunctionResult("match")
+
+	dmA := New("a")
+	dmA.Expression("${args.x}", "^foo$", out, nil)
+
+	dmB := New("a")
+	dmB.ExpressionRegexp("${args.x}", regexp.MustCompile("^foo$"), out, nil)
+
+	aBytes, _ := json.Marshal(dmA.ToSwaigFunction())
+	bBytes, _ := json.Marshal(dmB.ToSwaigFunction())
+	if string(aBytes) != string(bBytes) {
+		t.Fatalf("ExpressionRegexp and Expression should produce equivalent output\nExpression:\n%s\nExpressionRegexp:\n%s",
+			aBytes, bBytes)
+	}
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -56,14 +56,33 @@ var (
 	suppressed  bool
 )
 
-func init() {
-	// Check environment for log level and mode
+// configureFromEnv reads SIGNALWIRE_LOG_LEVEL and SIGNALWIRE_LOG_MODE from the
+// environment and applies them to globalLevel and suppressed. Must be called
+// with globalMu held for writing, or before any goroutines are started (i.e.
+// from init or ResetLoggingConfiguration).
+func configureFromEnv() {
+	globalLevel = LevelInfo
+	suppressed = false
 	if envLevel := os.Getenv("SIGNALWIRE_LOG_LEVEL"); envLevel != "" {
 		globalLevel = ParseLevel(envLevel)
 	}
 	if envMode := os.Getenv("SIGNALWIRE_LOG_MODE"); strings.ToLower(envMode) == "off" {
 		suppressed = true
 	}
+}
+
+func init() {
+	configureFromEnv()
+}
+
+// ResetLoggingConfiguration re-reads SIGNALWIRE_LOG_LEVEL and SIGNALWIRE_LOG_MODE
+// from the environment and resets globalLevel and suppressed to the env-derived
+// defaults. It is the Go equivalent of Python's reset_logging_configuration() and
+// is intended for test teardown and env-var-driven reconfiguration at runtime.
+func ResetLoggingConfiguration() {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	configureFromEnv()
 }
 
 // SetGlobalLevel sets the minimum log level for all loggers.

--- a/pkg/logging/reset_config_test.go
+++ b/pkg/logging/reset_config_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package logging
+
+import (
+	"testing"
+)
+
+// Tests for ResetLoggingConfiguration added in this PR. Mirrors Python
+// reset_logging_configuration() semantics: re-read SIGNALWIRE_LOG_LEVEL
+// and SIGNALWIRE_LOG_MODE from the environment and replace the current
+// global level + suppression state.
+
+func TestResetLoggingConfigurationRestoresInfoDefault(t *testing.T) {
+	// Ensure env is clean.
+	t.Setenv("SIGNALWIRE_LOG_LEVEL", "")
+	t.Setenv("SIGNALWIRE_LOG_MODE", "")
+
+	// Mutate global state via SetGlobalLevel + Suppress...
+	SetGlobalLevel(LevelDebug)
+	Suppress()
+	if GetGlobalLevel() != LevelDebug {
+		t.Fatalf("precondition: expected LevelDebug after SetGlobalLevel")
+	}
+	if !IsSuppressed() {
+		t.Fatalf("precondition: expected suppressed=true after Suppress()")
+	}
+
+	// Reset should restore Info + unsuppressed from an env-clean environment.
+	ResetLoggingConfiguration()
+
+	if GetGlobalLevel() != LevelInfo {
+		t.Errorf("after reset: level = %v, want LevelInfo", GetGlobalLevel())
+	}
+	if IsSuppressed() {
+		t.Errorf("after reset: suppressed should be false with clean env")
+	}
+}
+
+func TestResetLoggingConfigurationHonorsLogLevelEnv(t *testing.T) {
+	t.Setenv("SIGNALWIRE_LOG_LEVEL", "error")
+	t.Setenv("SIGNALWIRE_LOG_MODE", "")
+
+	SetGlobalLevel(LevelInfo)
+	ResetLoggingConfiguration()
+
+	if GetGlobalLevel() != LevelError {
+		t.Errorf("expected reset to pick up SIGNALWIRE_LOG_LEVEL=error, got %v", GetGlobalLevel())
+	}
+}
+
+func TestResetLoggingConfigurationHonorsLogModeOff(t *testing.T) {
+	t.Setenv("SIGNALWIRE_LOG_LEVEL", "")
+	t.Setenv("SIGNALWIRE_LOG_MODE", "off")
+
+	Unsuppress()
+	ResetLoggingConfiguration()
+
+	if !IsSuppressed() {
+		t.Errorf("expected reset to set suppressed=true when SIGNALWIRE_LOG_MODE=off")
+	}
+}
+
+// Restore to clean state so other tests in the package start fresh.
+func TestResetLoggingConfigurationCleanup(t *testing.T) {
+	t.Setenv("SIGNALWIRE_LOG_LEVEL", "")
+	t.Setenv("SIGNALWIRE_LOG_MODE", "")
+	ResetLoggingConfiguration()
+}


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: infra utilities — datamap, logging (P1/P2)

Brings signalwire-go to parity with three low-level utility modules.

pkg/datamap:
- DataMap.FunctionName() getter (matches Python's public function_name attr).
- ExpressionRegexp method accepting *regexp.Regexp (Python accepts Union[str,
  re.Pattern]; Go offers a sibling method that calls pattern.String()).
- ToSwaigFunction now emits canonical SWAIG keys "description" and
  "parameters" instead of the deprecated "purpose"/"argument" (wire-format
  alignment with Python + SWML schema.json). Tests updated accordingly.
- CreateExpressionTool: patterns param retyped from map[string][2]any to
  map[string]ExpressionPattern (struct with Pattern string + Result
  *swaig.FunctionResult). Eliminates silent-drop runtime type assertions.

pkg/logging:
- ResetLoggingConfiguration() added. Re-reads SIGNALWIRE_LOG_LEVEL and
  SIGNALWIRE_LOG_MODE env vars and resets the global logger state. Mirrors
  Python's reset_logging_configuration; enables test teardown and runtime
  reconfiguration. init() refactored to share a configureFromEnv helper.

Closes #7 (__functions__datamap), #8 (__functions__logging), #31 (DataMap).

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #7
Closes #8
Closes #31

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
