### PR TITLE
Align SessionManager with Python SDK

### DIFF
--- a/pkg/security/session_manager.go
+++ b/pkg/security/session_manager.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -17,19 +18,43 @@ import (
 )
 
 // SessionManager creates and validates HMAC-SHA256 tokens for SWAIG function
-// calls. Each manager instance generates its own random secret on creation.
+// calls. The secret can be supplied at construction time (for cross-process
+// validation) or auto-generated (default, single-process use).
 type SessionManager struct {
 	secret          []byte
 	tokenExpirySecs int
+	debugMode       bool
 	logger          *logging.Logger
 }
 
-// NewSessionManager creates a new SessionManager with a randomly generated
-// 32-byte secret. If tokenExpirySecs is <= 0, a default of 3600 seconds
-// (1 hour) is used.
-func NewSessionManager(tokenExpirySecs int) *SessionManager {
+// Option is a functional option for NewSessionManager.
+type Option func(*SessionManager)
+
+// WithSecret injects a fixed secret key into the SessionManager. Use this when
+// you need multiple processes or instances to validate each other's tokens.
+// Pass nil to keep the default behaviour (auto-generate a random 32-byte secret).
+func WithSecret(key []byte) Option {
+	return func(sm *SessionManager) {
+		if key != nil {
+			sm.secret = key
+		}
+	}
+}
+
+// WithDebugMode enables the DebugToken method. Off by default to prevent
+// accidental token introspection in production.
+func WithDebugMode(enabled bool) Option {
+	return func(sm *SessionManager) {
+		sm.debugMode = enabled
+	}
+}
+
+// NewSessionManager creates a new SessionManager. If tokenExpirySecs is <= 0,
+// a default of 900 seconds (15 minutes) is used, matching the Python SDK
+// default. Provide functional options (e.g. WithSecret) to customise behaviour.
+func NewSessionManager(tokenExpirySecs int, opts ...Option) *SessionManager {
 	if tokenExpirySecs <= 0 {
-		tokenExpirySecs = 3600
+		tokenExpirySecs = 900
 	}
 
 	secret := make([]byte, 32)
@@ -38,11 +63,34 @@ func NewSessionManager(tokenExpirySecs int) *SessionManager {
 		panic("security: failed to generate random secret: " + err.Error())
 	}
 
-	return &SessionManager{
+	sm := &SessionManager{
 		secret:          secret,
 		tokenExpirySecs: tokenExpirySecs,
+		debugMode:       false,
 		logger:          logging.New("SessionManager"),
 	}
+
+	for _, opt := range opts {
+		opt(sm)
+	}
+
+	return sm
+}
+
+// CreateSession returns callID unchanged if it is non-empty; otherwise it
+// generates a cryptographically random URL-safe string (matches Python
+// secrets.token_urlsafe(16) — 16 bytes of entropy, base64url-encoded without
+// padding).
+func (sm *SessionManager) CreateSession(callID string) string {
+	if callID != "" {
+		return callID
+	}
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("security: failed to generate session ID: " + err.Error())
+	}
+	// RawURLEncoding omits padding, matching Python's token_urlsafe behaviour.
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 // CreateToken generates an HMAC-SHA256 signed token for the given function
@@ -137,4 +185,98 @@ func (sm *SessionManager) ValidateToken(functionName string, token string, callI
 	}
 
 	return true
+}
+
+// DebugToken decodes a token and returns a map of its components and status
+// without performing signature validation. This is intended for development
+// and debugging only. It requires debug mode to be enabled via WithDebugMode;
+// if not, it returns map["error": "debug mode not enabled"].
+func (sm *SessionManager) DebugToken(token string) map[string]any {
+	if !sm.debugMode {
+		return map[string]any{"error": "debug mode not enabled"}
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return map[string]any{
+			"valid_format": false,
+			"error":        err.Error(),
+			"token_length": len(token),
+		}
+	}
+
+	// Go token format: "functionName:callID:expiry.hexsig"
+	// Split on the single dot separator between message and signature.
+	dotParts := strings.SplitN(string(decoded), ".", 2)
+	if len(dotParts) != 2 {
+		return map[string]any{
+			"valid_format": false,
+			"parts_count":  len(dotParts),
+			"token_length": len(token),
+		}
+	}
+
+	message := dotParts[0]
+	tokenSignature := dotParts[1]
+
+	// Parse "functionName:callID:expiry"
+	msgParts := strings.SplitN(message, ":", 3)
+	if len(msgParts) != 3 {
+		return map[string]any{
+			"valid_format": false,
+			"parts_count":  len(msgParts),
+			"token_length": len(token),
+		}
+	}
+
+	tokenFunction := msgParts[0]
+	tokenCallID := msgParts[1]
+	tokenExpiryStr := msgParts[2]
+
+	currentTime := time.Now().Unix()
+
+	var isExpired any
+	var expiresIn any
+	var expiryDate any
+	var expiryRaw any = tokenExpiryStr
+
+	expiryUnix, parseErr := strconv.ParseInt(tokenExpiryStr, 10, 64)
+	if parseErr == nil {
+		expired := expiryUnix < currentTime
+		isExpired = expired
+		if !expired {
+			expiresIn = expiryUnix - currentTime
+		} else {
+			expiresIn = int64(0)
+		}
+		expiryDate = fmt.Sprintf("%s", time.Unix(expiryUnix, 0).Format(time.RFC3339))
+		expiryRaw = tokenExpiryStr
+	}
+
+	// Truncate call_id and signature for safety, matching Python behaviour.
+	callIDDisplay := tokenCallID
+	if len(callIDDisplay) > 8 {
+		callIDDisplay = callIDDisplay[:8] + "..."
+	}
+	sigDisplay := tokenSignature
+	if len(sigDisplay) > 8 {
+		sigDisplay = sigDisplay[:8] + "..."
+	}
+
+	return map[string]any{
+		"valid_format": true,
+		"components": map[string]any{
+			"call_id":     callIDDisplay,
+			"function":    tokenFunction,
+			"expiry":      expiryRaw,
+			"expiry_date": expiryDate,
+			"nonce":       nil, // Go token format has no nonce field
+			"signature":   sigDisplay,
+		},
+		"status": map[string]any{
+			"current_time":       currentTime,
+			"is_expired":         isExpired,
+			"expires_in_seconds": expiresIn,
+		},
+	}
 }

--- a/pkg/security/session_manager_test.go
+++ b/pkg/security/session_manager_test.go
@@ -13,15 +13,15 @@ import (
 
 func TestNewSessionManager_DefaultExpiry(t *testing.T) {
 	sm := NewSessionManager(0)
-	if sm.tokenExpirySecs != 3600 {
-		t.Errorf("expected default expiry 3600, got %d", sm.tokenExpirySecs)
+	if sm.tokenExpirySecs != 900 {
+		t.Errorf("expected default expiry 900, got %d", sm.tokenExpirySecs)
 	}
 }
 
 func TestNewSessionManager_NegativeExpiry(t *testing.T) {
 	sm := NewSessionManager(-10)
-	if sm.tokenExpirySecs != 3600 {
-		t.Errorf("expected default expiry 3600 for negative input, got %d", sm.tokenExpirySecs)
+	if sm.tokenExpirySecs != 900 {
+		t.Errorf("expected default expiry 900 for negative input, got %d", sm.tokenExpirySecs)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Part of the Go SDK alignment epic (#3). Brings one or more interfaces in `signalwire-go` to behavioral parity with the Python reference SDK, implementing gaps surfaced by the cross-SDK alignment audit (LSP-verified with pyright + gopls, every claim source-verified).

## Changes

The first commit's message is the authoritative per-gap descriptor:

<details>
<summary>Full commit message</summary>

```
align: SessionManager — secret injection, CreateSession, DebugToken (P2)

Brings pkg/security/SessionManager to parity with Python's SessionManager
in signalwire/core/session_manager.py.

- NewSessionManager accepts functional options (...Option); WithSecret(key)
  allows fixed secret injection for cross-process token validation. Existing
  zero-option callers are unaffected.
- CreateSession(callID) returns callID unchanged when non-empty, otherwise
  generates crypto/rand 16-byte base64url entropy (matches Python
  secrets.token_urlsafe(16)).
- DebugToken(token) map[string]any — diagnostic decoder gated on
  WithDebugMode(true); returns sentinel map with error when debug off;
  otherwise returns valid_format, components (call_id/function/expiry/
  expiry_date/signature truncated), and status (current_time/is_expired/
  expires_in_seconds).
- tokenExpirySecs <= 0 fallback changed 3600 → 900 to match Python's
  15-minute default. Tests updated.

Closes #64.

go build ./... and go test ./... pass.
```

</details>

## Verification

- [x] `go build ./...` passes in clean worktree
- [x] `go test ./...` passes (including any tests updated in this PR)
- [x] LSP hover on every new/changed symbol confirms the signature matches Python parity
- [x] No `TODO`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched

## Python reference

Python reference SDK: [`signalwire-python`](https://github.com/signalwire/signalwire-python) @ `f0f272b0660777ddbaf3bbd263b99096582b4489` (v3.0.1)

## Auto-closes

Closes #64

When this PR merges, GitHub auto-closes each linked interface issue above via the `Closes #N` keyword.

Part of epic: #3
