### PR TITLE
Fix relay.QueueEnter/QueueLeave: include control_id in wire params

### DIFF
--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -686,21 +686,33 @@ func (c *Call) LeaveRoom() error {
 }
 
 // QueueEnter places the call in a named queue.
+//
+// A per-request control_id is generated and included in the wire params,
+// matching Python QueueEnterAction (signalwire/relay/call.py queue_enter
+// line 1268): the server uses control_id to correlate this action with its
+// subsequent events. Previously omitted, which forced the server to
+// synthesize an ID or reject the request.
 func (c *Call) QueueEnter(name string) error {
 	_, err := c.client.execute("calling.queue.enter", map[string]any{
-		"node_id": c.nodeID,
-		"call_id": c.callID,
-		"name":    name,
+		"node_id":    c.nodeID,
+		"call_id":    c.callID,
+		"control_id": newControlID(),
+		"name":       name,
 	})
 	return err
 }
 
 // QueueLeave removes the call from the named queue.
+//
+// A per-request control_id is generated and included in the wire params,
+// matching Python QueueLeaveAction (signalwire/relay/call.py queue_leave
+// line 1287).
 func (c *Call) QueueLeave(name string) error {
 	_, err := c.client.execute("calling.queue.leave", map[string]any{
-		"node_id": c.nodeID,
-		"call_id": c.callID,
-		"name":    name,
+		"node_id":    c.nodeID,
+		"call_id":    c.callID,
+		"control_id": newControlID(),
+		"name":       name,
 	})
 	return err
 }


### PR DESCRIPTION
## Summary

Adds `control_id` to the wire params of `pkg/relay.Call.QueueEnter` and `QueueLeave`. Python's equivalent (`signalwire/relay/call.py` `queue_enter` line 1268 and `queue_leave` line 1287) always sends a `control_id` so the server can correlate the action with its subsequent events. Without it, the server has to synthesize one or reject the request.

## Changes

- `pkg/relay/call.go` — `QueueEnter` and `QueueLeave` now generate a per-request `control_id` via the existing `newControlID()` helper (matching the pattern every other `Call.<Action>` method in this file uses) and include it in the `execute` params.

## Context

This was surfaced during the review of PR #91 (`fix/align-relay-call`) but is out of scope there — #91 covers the call namespace interface, whereas this is a pre-existing wire-format omission that predates the alignment epic (#3). Filing it as a standalone PR keeps #91's diff focused.

Closes #122.

## Verification

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Compared diff against Python `QueueEnterAction.params` / `QueueLeaveAction.params` — same `control_id` shape