### PR TITLE
Layer C: doc↔code alignment + fix phantom SDK surfaces

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -1,0 +1,111 @@
+name: Doc & example audit (Layer C)
+
+# Runs the porting-sdk audit_docs.py tool against the Go port so that every
+# method reference inside markdown or example source resolves to a real
+# symbol in port_surface_go.json (the Go-native sibling of port_surface.json
+# produced by cmd/enumerate-surface alongside the Python-reference surface).
+#
+# Also compile-checks every example file -- //go:build ignore files included
+# -- via ``go build -o /dev/null <file>`` to catch silent API breakage.
+#
+# This is the third layer of the porting-sdk drift contract:
+#
+#   Layer A (live in porting-sdk)   parity checklist
+#   Layer B (surface-audit.yml)     symbol-level surface parity with Python
+#   Layer C (this workflow)         docs/examples reference only real symbols
+#
+# A phantom API in a guide is just as dangerous as a missing method; both
+# lie to users about what the port supports.  This workflow catches the
+# former.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "relay/docs/**"
+      - "rest/docs/**"
+      - "examples/**"
+      - "relay/examples/**"
+      - "rest/examples/**"
+      - "pkg/**"
+      - "cmd/enumerate-surface/**"
+      - "DOC_AUDIT_IGNORE.md"
+      - "port_surface_go.json"
+      - ".github/workflows/doc-audit.yml"
+  push:
+    branches: [main]
+  schedule:
+    # Nightly re-run to catch upstream audit_docs.py rule tightening.
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  doc-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out signalwire-go
+        uses: actions/checkout@v4
+
+      - name: Check out porting-sdk (audit script)
+        uses: actions/checkout@v4
+        with:
+          repository: signalwire/porting-sdk
+          path: porting-sdk
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Enumerate Go surface (Python + Go shapes)
+        run: go run ./cmd/enumerate-surface
+
+      - name: Verify committed port_surface_go.json is fresh
+        run: go run ./cmd/enumerate-surface --check
+
+      - name: Compile-check every example
+        # Examples live in ``examples/**``, ``rest/examples`` and
+        # ``relay/examples``.  The latter two co-locate multiple
+        # ``package main`` files in the same directory under
+        # ``//go:build ignore`` — compile each file individually via
+        # ``go build -o /dev/null FILE.go`` so the ignore tag doesn't
+        # collide across the directory.
+        run: |
+          set -euo pipefail
+          total=0
+          failed=0
+          for f in $(find examples relay/examples rest/examples -name "*.go" -print 2>/dev/null); do
+            total=$((total + 1))
+            if ! go build -o /dev/null "$f" 2> /tmp/build_err; then
+              echo "::error file=$f::example failed to compile"
+              sed 's/^/    /' /tmp/build_err
+              failed=$((failed + 1))
+            fi
+          done
+          echo "compiled $((total - failed))/$total examples"
+          if [ "$failed" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Run doc/example audit
+        run: |
+          python3 porting-sdk/scripts/audit_docs.py \
+            --root . \
+            --surface port_surface_go.json \
+            --ignore DOC_AUDIT_IGNORE.md
+
+      - name: go vet ./...
+        run: go vet ./...
+
+      - name: go test ./...
+        run: go test ./...

--- a/DOC_AUDIT_IGNORE.md
+++ b/DOC_AUDIT_IGNORE.md
@@ -1,0 +1,299 @@
+# DOC_AUDIT_IGNORE
+
+Every identifier listed here is intentionally skipped by
+`porting-sdk/scripts/audit_docs.py`. Each line follows
+`<name>: <rationale>` — the rationale explains *why* the identifier is
+legitimately referenced in docs or examples without appearing in the Go
+port surface.
+
+Grouped by category. Keep the rationale concise.
+
+## Go standard library — `fmt`
+
+Printf: fmt.Printf formatted print to stdout
+Println: fmt.Println line print to stdout
+Sprintf: fmt.Sprintf formatted string
+Fprintf: fmt.Fprintf formatted writer output
+Fprintln: fmt.Fprintln writer line output
+
+## Go standard library — `log`
+
+Fatal: log.Fatal terminating error
+Fatalf: log.Fatalf formatted terminating error
+
+## Go standard library — `os` / `os/signal`
+
+Getenv: os.Getenv environment variable lookup
+Exit: os.Exit process termination
+
+## Go standard library — `strconv`
+
+Atoi: strconv.Atoi string-to-int conversion
+ParseFloat: strconv.ParseFloat string-to-float conversion
+
+## Go standard library — `strings`
+
+Split: strings.Split token splitter
+ToLower: strings.ToLower case conversion
+ToUpper: strings.ToUpper case conversion
+
+## Go standard library — `encoding/json`
+
+MarshalIndent: json.MarshalIndent pretty JSON serialisation
+
+## Go standard library — `time`
+
+Now: time.Now current-time getter
+Format: time.Time.Format timestamp formatting
+Duration: time.Duration constructor (e.g. time.Duration(n)*time.Second)
+
+## Go standard library — `context` / `os/signal`
+
+Background: context.Background root context
+WithTimeout: context.WithTimeout cancellable context
+WithCancel: context.WithCancel cancellable context
+NotifyContext: signal.NotifyContext signal-aware context
+
+## Go standard library — `math/rand`
+
+Intn: rand.Intn random integer in range
+
+## Go standard library — `sync`
+
+Add: sync.WaitGroup.Add counter increment
+Done: sync.WaitGroup.Done counter decrement
+
+## Go standard library — `errors`
+
+As: errors.As typed unwrap
+
+## Port-only illustrative references
+
+Publish: illustrative PubSub.Publish reference inside a comment in examples/rest_demo/main.go
+NewSignalWireClient: legacy pre-2.0 constructor kept as a "Before" example in docs/MIGRATION-2.0.md
+ToolHandler: swaig.ToolHandler and agent.ToolHandler type references inside a comment in examples/skills_demo/main.go
+fn: anonymous-struct field name (op.fn()) used to iterate a table-driven operation list in rest/examples/rest_calling_play_and_record.go
+
+## Python standard library referenced from legacy Python code blocks
+
+The top-level `docs/*.md` files carry over Python code blocks from the
+upstream Python SDK while the Go-native rewrite is in progress. These
+references are Python stdlib methods that appear inside those blocks.
+
+Thread: python threading.Thread (appears in docs/web_service.md Python code)
+abspath: python os.path.abspath
+basicConfig: python logging.basicConfig
+getLogger: python logging.getLogger
+setLevel: python logger.setLevel
+isoformat: python datetime.isoformat
+fromisoformat: python datetime.fromisoformat
+total_seconds: python timedelta.total_seconds
+
+## Python SDK dunder / protected helpers in legacy Python code blocks
+
+Names starting with `__` or `_` that appear in Python code blocks in the
+top-level `docs/*.md` files. These are internal Python-SDK conventions
+(dunder constructors, private helpers) and never surface in the Go port.
+
+__init__: python class constructor shown in Python code blocks
+_check_basic_auth: python-SDK private helper illustrated in docs/agent_guide.md
+_configure_instructions: python-SDK private helper illustrated in docs/agent_guide.md
+_get_new_messages: python-SDK private helper illustrated in docs/agent_guide.md
+_register_custom_tools: python-SDK private helper illustrated in docs/api_reference.md
+_register_default_tools: python-SDK private helper illustrated in docs/agent_guide.md
+_setup_contexts: python-SDK private helper illustrated in docs/api_reference.md
+_setup_static_config: python-SDK private helper illustrated in docs/agent_guide.md
+_test_api_connection: python-SDK private helper illustrated in docs/third_party_skills.md
+
+## Python SDK setter-style method names in legacy Python code blocks
+
+setGoal: python-SDK setter illustrated in docs/agent_guide.md Python code block
+setInstructions: python-SDK setter illustrated in docs/agent_guide.md Python code block
+setPersonality: python-SDK setter illustrated in docs/agent_guide.md Python code block
+
+## Python-SDK method names in legacy Python code blocks (top-level `docs/`)
+
+These are Python-SDK method names referenced in ```python``` fences inside
+the top-level `docs/*.md` files. The Go port implements the same behaviour
+under Go-idiomatic CamelCase identifiers (which the audit resolves against
+`port_surface_go.json`). Each line below documents that the snake_case
+name is the Python-reference equivalent of the corresponding Go method.
+The long-term fix is to rewrite each block to Go; see PORT_OMISSIONS.md for
+the subset deliberately not ported. Until that rewrite lands, these names
+are non-claims of Go API.
+
+add_action: Python AgentBase.add_action — Go SwaigFunctionResult.AddAction
+add_actions: Python AgentBase.add_actions — Go SwaigFunctionResult.AddActions
+add_answer_verb: Python AgentBase.add_answer_verb — Go AgentBase.AddAnswerVerb
+add_application: Python SWAIG method — referenced in docs/swaig_reference.md python block
+add_bullets: Python Section.add_bullets — Go Section.AddBullets
+add_context: Python ContextBuilder.add_context — Go ContextBuilder.AddContext
+add_directory: Python WebService.add_directory — Go WebService.AddDirectory equivalent
+add_function_include: Python AgentBase.add_function_include — Go AgentBase.AddFunctionInclude
+add_gather_question: Python GatherInfo.add_gather_question — Go GatherInfo.AddGatherQuestion
+add_hint: Python AgentBase.add_hint — Go AgentBase.AddHint
+add_hints: Python AgentBase.add_hints — Go AgentBase.AddHints
+add_internal_filler: Python AgentBase.add_internal_filler — Go AgentBase.AddInternalFiller
+add_language: Python AgentBase.add_language — Go AgentBase.AddLanguage
+add_mcp_server: Python AgentBase.add_mcp_server — Go AgentBase.AddMcpServer
+add_pattern_hint: Python AgentBase.add_pattern_hint — Go AgentBase.AddPatternHint
+add_post_ai_verb: Python AgentBase.add_post_ai_verb — Go AgentBase.AddPostAiVerb
+add_post_answer_verb: Python AgentBase.add_post_answer_verb — Go AgentBase.AddPostAnswerVerb
+add_pre_answer_verb: Python AgentBase.add_pre_answer_verb — Go AgentBase.AddPreAnswerVerb
+add_pronunciation: Python AgentBase.add_pronunciation — Go AgentBase.AddPronunciation
+add_section: Python PromptMixin.add_section — Go AgentBase.PromptAddSection
+add_skill: Python SkillMixin.add_skill — Go AgentBase.AddSkill
+add_step: Python Context.add_step — Go Context.AddStep
+add_swaig_query_params: Python AgentBase.add_swaig_query_params — Go AgentBase.AddSwaigQueryParams
+add_verb: Python SWMLService.add_verb — Go Service.ExecuteVerb
+add_verb_to_section: Python SWMLService.add_verb_to_section — Go Service.ExecuteVerbToSection
+alert_ops_team: Python user-defined function illustrated in docs/api_reference.md python block
+allow_functions: Python SWAIG param shown in docs/api_reference.md python block
+apply_custom_config: Python user-defined method illustrated in docs/agent_guide.md python block
+apply_default_config: Python user-defined method illustrated in docs/agent_guide.md python block
+as_router: Python WebMixin.as_router — Go AgentBase.AsRouter
+body: Python Section attribute name in docs/api_reference.md python block
+build_document: Python SWMLService.build_document — user hook in docs/swml_service_guide.md python block
+build_voicemail_document: Python user-defined method in docs/swml_service_guide.md python block
+clear_swaig_query_params: Python AgentBase.clear_swaig_query_params — Go AgentBase.ClearSwaigQueryParams
+connect: Python FunctionResult.connect — Go FunctionResult.Connect
+create_payment_action: Python FunctionResult.create_payment_action — Go FunctionResult.CreatePaymentAction
+create_payment_parameter: Python FunctionResult.create_payment_parameter — Go FunctionResult.CreatePaymentParameter
+create_payment_prompt: Python FunctionResult.create_payment_prompt — Go FunctionResult.CreatePaymentPrompt
+debug: Python logger.debug level method in docs/swml_service_guide.md python block
+define_contexts: Python AgentBase.define_contexts — Go AgentBase.DefineContexts
+define_tool: Python AgentBase.define_tool — Go AgentBase.DefineTool
+delete_state: Python state manager method in docs/agent_guide.md python block
+description: Python docstring keyword shown as a field in docs/api_reference.md
+enable_debug_events: Python AgentBase.enable_debug_events — Go AgentBase.EnableDebugEvents
+enable_extensive_data: Python FunctionResult.enable_extensive_data — Go FunctionResult.EnableExtensiveData
+enable_functions_on_timeout: Python FunctionResult.enable_functions_on_timeout — Go FunctionResult.EnableFunctionsOnTimeout
+enable_mcp_server: Python AgentBase.enable_mcp_server — Go AgentBase.EnableMcpServer
+enable_record_call: Python-only toggle illustrated in docs/sdk_features.md
+enable_sip_routing: Python AgentBase.enable_sip_routing — Go AgentBase.EnableSipRouting
+error: Python logger.error level method in docs/agent_guide.md python block
+error_keys: Python DataMap keyword shown in docs/api_reference.md
+execute_swml: Python FunctionResult.execute_swml — Go FunctionResult.ExecuteSwml
+expression: Python DataMap.expression keyword shown in docs/api_reference.md
+fallback_output: Python DataMap keyword shown in docs/api_reference.md
+foreach: Python DataMap.foreach keyword shown in docs/api_reference.md
+get_config: Python config helper illustrated in docs/configuration.md python block
+get_customer_config: Python user-defined helper in docs/agent_guide.md python block
+get_customer_settings: Python user-defined helper in docs/agent_guide.md python block
+get_customer_tier: Python user-defined helper in docs/agent_guide.md python block
+get_document: Python SWMLService.get_document — Go Service.GetDocument
+get_full_url: Python AgentBase.get_full_url — Python-only helper, see PORT_OMISSIONS.md
+get_parameter_schema: Python SkillBase.get_parameter_schema illustrated in docs/skills_parameter_schema.md
+get_section: Python config helper illustrated in docs/configuration.md python block
+get_state: Python state manager method in docs/agent_guide.md python block
+global_error_keys: Python DataMap keyword shown in docs/api_reference.md
+handle_serverless_request: Python AgentBase.handle_serverless_request — Python-only helper, see PORT_OMISSIONS.md
+hangup: Python FunctionResult.hangup — Go FunctionResult.Hangup
+has_config: Python config helper illustrated in docs/configuration.md python block
+has_skill: Python SkillMixin.has_skill — Go AgentBase.HasSkill
+hold: Python FunctionResult.hold — Go FunctionResult.Hold
+include_router: Python FastAPI router helper illustrated in docs/api_reference.md
+info: Python logger.info level method in docs/agent_guide.md python block
+is_valid_customer: Python user-defined helper in docs/agent_guide.md python block
+join_conference: Python FunctionResult.join_conference — Go FunctionResult.JoinConference
+join_room: Python FunctionResult.join_room — Go FunctionResult.JoinRoom
+list_all_skill_sources: Python skills helper illustrated in docs/third_party_skills.md
+list_skills: Python SkillMixin.list_skills — Go AgentBase.ListSkills
+load_skill: Python SkillManager.load_skill — Python-internal hook referenced in docs/architecture.md
+load_user_preferences: Python user-defined helper in docs/agent_guide.md python block
+on_completion_go_to: Python Context keyword shown in docs/api_reference.md
+on_debug_event: Python AgentBase.on_debug_event — Go AgentBase.OnDebugEvent
+on_function_call: Python ToolMixin.on_function_call — Go AgentBase.OnFunctionCall
+output: Python DataMap.output keyword shown in docs/api_reference.md
+parameter: Python DataMap keyword shown in docs/api_reference.md
+params: Python DataMap keyword shown in docs/api_reference.md
+pay: Python FunctionResult.pay — Go FunctionResult.Pay
+play_background_file: Python FunctionResult.play_background_file — Go FunctionResult.PlayBackgroundFile
+prompt_add_section: Python PromptMixin.prompt_add_section — Go AgentBase.PromptAddSection
+prompt_add_subsection: Python PromptMixin.prompt_add_subsection — Go AgentBase.PromptAddSubsection
+prompt_add_to_section: Python PromptMixin.prompt_add_to_section — Go AgentBase.PromptAddToSection
+purpose: Python DataMap field name shown in docs/api_reference.md
+record_call: Python FunctionResult.record_call — Go FunctionResult.RecordCall
+register: Python AgentServer.register — Go AgentServer.Register
+register_customer_route: Python user-defined route in docs/swml_service_guide.md python block
+register_default_tools: Python skills system hook referenced in docs/architecture.md
+register_knowledge_base_tool: Python user-defined helper in docs/agent_guide.md python block
+register_product_route: Python user-defined route in docs/swml_service_guide.md python block
+register_routing_callback: Python SWMLService.register_routing_callback — Go Service.RegisterRoutingCallback
+register_sip_username: Python AgentBase.register_sip_username — Go AgentBase.RegisterSipUsername
+register_swaig_function: Python ToolMixin.register_swaig_function — Go AgentBase.RegisterSwaigFunction
+register_tools: Python skills system hook referenced in docs/architecture.md
+register_verb_handler: Python SWMLService.register_verb_handler — Python-only helper, see PORT_OMISSIONS.md
+remove_directory: Python WebService.remove_directory — Go WebService equivalent
+remove_global_data: Python FunctionResult.remove_global_data — Go FunctionResult.RemoveGlobalData
+remove_metadata: Python FunctionResult.remove_metadata — Go FunctionResult.RemoveMetadata
+remove_skill: Python SkillMixin.remove_skill — Go AgentBase.RemoveSkill
+replace_in_history: Python FunctionResult.replace_in_history — Go FunctionResult.ReplaceInHistory
+reset_document: Python SWMLService.reset_document — Go Service.ResetDocument
+run: Python AgentBase.run — Go AgentBase.Run
+say: Python FunctionResult.say — Go FunctionResult.Say
+schedule_follow_up: Python user-defined helper in docs/api_reference.md python block
+send_sms: Python FunctionResult.send_sms — Go FunctionResult.SendSms
+send_to_analytics: Python user-defined helper in docs/agent_guide.md python block
+serve: Python AgentBase.serve — Go AgentBase.Serve
+set_consolidate: Python Context.set_consolidate — Go Context.SetConsolidate
+set_dynamic_config_callback: Python WebMixin.set_dynamic_config_callback — Go AgentBase.SetDynamicConfigCallback
+set_end_of_speech_timeout: Python FunctionResult.set_end_of_speech_timeout — Go FunctionResult.SetEndOfSpeechTimeout
+set_full_reset: Python Context.set_full_reset — Go Context.SetFullReset
+set_function_includes: Python AgentBase.set_function_includes — Go AgentBase.SetFunctionIncludes
+set_functions: Python SWAIG keyword shown in docs/api_reference.md
+set_gather_info: Python GatherInfo builder method — Go GatherInfo setter
+set_global_data: Python AgentBase.set_global_data — Go AgentBase.SetGlobalData
+set_internal_fillers: Python AgentBase.set_internal_fillers — Go AgentBase.SetInternalFillers
+set_languages: Python AgentBase.set_languages — Go AgentBase.SetLanguages
+set_metadata: Python FunctionResult.set_metadata — Go FunctionResult.SetMetadata
+set_native_functions: Python AgentBase.set_native_functions — Go AgentBase.SetNativeFunctions
+set_param: Python AgentBase.set_param — Go AgentBase.SetParam
+set_params: Python AgentBase.set_params — Go AgentBase.SetParams
+set_post_process: Python FunctionResult.set_post_process — Go FunctionResult.SetPostProcess
+set_post_prompt: Python PromptMixin.set_post_prompt — Go AgentBase.SetPostPrompt
+set_post_prompt_llm_params: Python AgentBase.set_post_prompt_llm_params — Go AgentBase.SetPostPromptLlmParams
+set_post_prompt_url: Python AgentBase.set_post_prompt_url — Go AgentBase.SetPostPromptUrl
+set_prompt: Python PromptMixin.set_prompt — Go AgentBase.SetPromptText (renamed)
+set_prompt_llm_params: Python AgentBase.set_prompt_llm_params — Go AgentBase.SetPromptLlmParams
+set_prompt_text: Python PromptMixin.set_prompt_text — Go AgentBase.SetPromptText
+set_pronunciations: Python AgentBase.set_pronunciations — Go AgentBase.SetPronunciations
+set_response: Python FunctionResult.set_response — Go FunctionResult.SetResponse
+set_speech_event_timeout: Python FunctionResult.set_speech_event_timeout — Go FunctionResult.SetSpeechEventTimeout
+set_step_criteria: Python Step.set_step_criteria — Go Step.SetStepCriteria equivalent
+set_system_prompt: Python Context.set_system_prompt — Go Context.SetSystemPrompt
+set_text: Python Section.set_text — Go Section.SetText
+set_user_prompt: Python Context.set_user_prompt — Go Context.SetUserPrompt
+set_valid_contexts: Python Context.set_valid_contexts — Go Context.SetValidContexts
+set_valid_steps: Python Context.set_valid_steps — Go Context.SetValidSteps
+set_web_hook_url: Python AgentBase.set_web_hook_url — Go AgentBase.SetWebHookUrl
+setup: Python skills system hook referenced in docs/architecture.md
+setup_google_search: Python skills helper illustrated in docs/skills_system.md
+setup_sip_routing: Python AgentServer.setup_sip_routing — Go AgentServer.SetupSipRouting
+simulate_user_input: Python FunctionResult.simulate_user_input — Go FunctionResult.SimulateUserInput
+sip_refer: Python FunctionResult.sip_refer — Go FunctionResult.SipRefer
+start: Python web-service start — FastAPI/uvicorn illustrated in docs/security.md
+stop: Python FunctionResult.stop — Go FunctionResult.Stop
+stop_background_file: Python FunctionResult.stop_background_file — Go FunctionResult.StopBackgroundFile
+stop_record_call: Python FunctionResult.stop_record_call — Go FunctionResult.StopRecordCall
+stop_tap: Python FunctionResult.stop_tap — Go FunctionResult.StopTap
+switch_context: Python FunctionResult.switch_context — Go FunctionResult.SwitchContext
+swml_change_context: Python FunctionResult.swml_change_context — Go FunctionResult.SwmlChangeContext
+swml_change_step: Python FunctionResult.swml_change_step — Go FunctionResult.SwmlChangeStep
+swml_transfer: Python FunctionResult.swml_transfer — Go FunctionResult.SwmlTransfer
+tap: Python FunctionResult.tap — Go FunctionResult.Tap
+to_dict: Python object.to_dict — Python convention; Go port marshals via encoding/json
+to_swaig_function: Python SWAIG tool method illustrated in docs/api_reference.md
+toggle_functions: Python FunctionResult.toggle_functions — Go FunctionResult.ToggleFunctions
+tool: Python @tool decorator reference in docs/agent_guide.md python block
+unload_skill: Python SkillManager.unload_skill — Python-internal hook referenced in docs/architecture.md
+update: Python skill update method illustrated in docs/skills_parameter_schema.md
+update_global_data: Python FunctionResult.update_global_data — Go FunctionResult.UpdateGlobalData
+update_settings: Python FunctionResult.update_settings — Go FunctionResult.UpdateSettings
+update_state: Python state manager method in docs/agent_guide.md python block
+validate_env_vars: Python SkillBase.validate_env_vars — Python-only helper, see PORT_OMISSIONS.md
+validate_packages: Python SkillBase.validate_packages — Python-only helper, see PORT_OMISSIONS.md
+wait_for_user: Python FunctionResult.wait_for_user — Go FunctionResult.WaitForUser
+warning: Python logger.warning level method in docs/agent_guide.md python block
+webhook: Python SWAIG.webhook field name in docs/api_reference.md
+webhook_expressions: Python DataMap keyword shown in docs/api_reference.md

--- a/cmd/enumerate-surface/main.go
+++ b/cmd/enumerate-surface/main.go
@@ -1509,6 +1509,82 @@ func build(structs map[string]*goStructFacts, funcs map[string]struct{}) surface
 	return out
 }
 
+// buildGoSurface turns (goStructs, goFuncs) into a surface file keyed on the
+// **native** Go struct + method names.  Unlike ``build`` — which translates
+// everything onto the Python reference's dotted path — this captures the
+// exact identifiers a Go doc or example would use (``AgentBase.DefineTool``,
+// ``RestClient``, ``RunAgent``).  Used by ``audit_docs.py`` on the Go port
+// so that method-call references resolve against the actual surface.
+//
+// Shape matches ``port_surface.json`` but the module name is the short Go
+// package, the class is the exported struct, and methods are the exported
+// Go method names.
+func buildGoSurface(structs map[string]*goStructFacts, funcs map[string]struct{}) surface {
+	out := surface{
+		Version: "1",
+		Modules: map[string]moduleInventory{},
+	}
+	ensure := func(mod string) moduleInventory {
+		if inv, ok := out.Modules[mod]; ok {
+			return inv
+		}
+		inv := moduleInventory{
+			Classes:   map[string][]string{},
+			Functions: []string{},
+		}
+		out.Modules[mod] = inv
+		return inv
+	}
+	// Every exported struct becomes a class; every exported method becomes
+	// a member.  Unexported or port-only symbols are included — ``audit_docs.py``
+	// only cares that *some* reference resolves, not that the inventory
+	// matches a reference layout.
+	for key, facts := range structs {
+		_ = key
+		inv := ensure(facts.pkg)
+		methods, present := inv.Classes[facts.name]
+		if !present || methods == nil {
+			methods = []string{}
+		}
+		for m := range facts.methods {
+			methods = append(methods, m)
+		}
+		sort.Strings(methods)
+		inv.Classes[facts.name] = methods
+		out.Modules[facts.pkg] = inv
+	}
+	// Every exported free function becomes a module-level function.
+	for key := range funcs {
+		parts := strings.SplitN(key, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		pkg, name := parts[0], parts[1]
+		inv := ensure(pkg)
+		// de-dup
+		present := false
+		for _, existing := range inv.Functions {
+			if existing == name {
+				present = true
+				break
+			}
+		}
+		if !present {
+			inv.Functions = append(inv.Functions, name)
+		}
+		out.Modules[pkg] = inv
+	}
+	for mod, inv := range out.Modules {
+		sort.Strings(inv.Functions)
+		for cls, methods := range inv.Classes {
+			sort.Strings(methods)
+			inv.Classes[cls] = methods
+		}
+		out.Modules[mod] = inv
+	}
+	return out
+}
+
 // --- CLI --------------------------------------------------------------------
 
 // goSHA returns the signalwire-go repo HEAD SHA (or "N/A").
@@ -1533,9 +1609,10 @@ func findRepoRoot(cwd string) (string, error) {
 
 func run() error {
 	var (
-		outputPath = flag.String("output", "port_surface.json", "Write JSON to this path")
-		stdout     = flag.Bool("stdout", false, "Print JSON to stdout instead of --output")
-		check      = flag.Bool("check", false, "Compare against existing --output file; exit 1 on drift")
+		outputPath   = flag.String("output", "port_surface.json", "Write JSON to this path")
+		goOutputPath = flag.String("go-output", "port_surface_go.json", "Write Go-native surface JSON to this path (used by audit_docs.py)")
+		stdout       = flag.Bool("stdout", false, "Print Python-shape JSON to stdout instead of --output")
+		check        = flag.Bool("check", false, "Compare against existing --output / --go-output files; exit 1 on drift")
 	)
 	flag.Parse()
 
@@ -1554,8 +1631,10 @@ func run() error {
 		return fmt.Errorf("walk: %w", err)
 	}
 
+	sha := goSHA(repoRoot)
+
 	snapshot := build(structs, funcs)
-	snapshot.GeneratedFrom = fmt.Sprintf("signalwire-go @ %s", goSHA(repoRoot))
+	snapshot.GeneratedFrom = fmt.Sprintf("signalwire-go @ %s", sha)
 
 	rendered, err := json.MarshalIndent(snapshot, "", "  ")
 	if err != nil {
@@ -1563,13 +1642,29 @@ func run() error {
 	}
 	rendered = append(rendered, '\n')
 
+	goSnapshot := buildGoSurface(structs, funcs)
+	goSnapshot.GeneratedFrom = fmt.Sprintf("signalwire-go (go-native) @ %s", sha)
+	goRendered, err := json.MarshalIndent(goSnapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	goRendered = append(goRendered, '\n')
+
 	if *check {
 		existing, err := os.ReadFile(*outputPath)
 		if err != nil {
-			return fmt.Errorf("check: read existing: %w", err)
+			return fmt.Errorf("check: read existing %s: %w", *outputPath, err)
 		}
 		if stripGen(rendered) != stripGen(existing) {
 			fmt.Fprintln(os.Stderr, "DRIFT: port_surface.json is stale; regenerate with go run ./cmd/enumerate-surface")
+			return fmt.Errorf("drift detected")
+		}
+		existingGo, err := os.ReadFile(*goOutputPath)
+		if err != nil {
+			return fmt.Errorf("check: read existing %s: %w", *goOutputPath, err)
+		}
+		if stripGen(goRendered) != stripGen(existingGo) {
+			fmt.Fprintln(os.Stderr, "DRIFT: port_surface_go.json is stale; regenerate with go run ./cmd/enumerate-surface")
 			return fmt.Errorf("drift detected")
 		}
 		return nil
@@ -1579,7 +1674,10 @@ func run() error {
 		_, err := os.Stdout.Write(rendered)
 		return err
 	}
-	return os.WriteFile(*outputPath, rendered, 0o644)
+	if err := os.WriteFile(*outputPath, rendered, 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(*goOutputPath, goRendered, 0o644)
 }
 
 func stripGen(b []byte) string {

--- a/examples/dynamic_info_gatherer/main.go
+++ b/examples/dynamic_info_gatherer/main.go
@@ -2,72 +2,69 @@
 
 // Example: dynamic_info_gatherer
 //
-// InfoGathererAgent with a callback function that dynamically selects
-// questions based on request parameters (?set=support, ?set=medical, etc.).
+// Builds an InfoGathererAgent question set dynamically from the
+// INFO_GATHERER_SET env var, selecting between several predefined
+// intake flows (default, support, medical, onboarding).
+//
+// Run with:
+//
+//	INFO_GATHERER_SET=support go run ./examples/dynamic_info_gatherer/
 package main
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/signalwire/signalwire-go/pkg/agent"
 	"github.com/signalwire/signalwire-go/pkg/prefabs"
 )
 
 func main() {
-	questionSets := map[string][]prefabs.GatherField{
+	questionSets := map[string][]prefabs.Question{
 		"default": {
-			{Name: "name", Description: "Full name", Required: true},
-			{Name: "phone", Description: "Phone number", Required: true},
-			{Name: "reason", Description: "How can I help you today?"},
+			{KeyName: "name", QuestionText: "What is your full name?"},
+			{KeyName: "phone", QuestionText: "What is the best phone number to reach you?"},
+			{KeyName: "reason", QuestionText: "How can I help you today?"},
 		},
 		"support": {
-			{Name: "customer_name", Description: "Your name", Required: true},
-			{Name: "account_number", Description: "Account number", Required: true},
-			{Name: "issue", Description: "Describe the issue"},
-			{Name: "priority", Description: "Urgency: Low, Medium, or High"},
+			{KeyName: "customer_name", QuestionText: "What is your name?"},
+			{KeyName: "account_number", QuestionText: "What is your account number?", Confirm: true},
+			{KeyName: "issue", QuestionText: "Can you describe the issue you are experiencing?"},
+			{KeyName: "priority", QuestionText: "What is the urgency: Low, Medium, or High?"},
 		},
 		"medical": {
-			{Name: "patient_name", Description: "Patient full name", Required: true},
-			{Name: "symptoms", Description: "Current symptoms", Required: true},
-			{Name: "duration", Description: "Symptom duration"},
-			{Name: "medications", Description: "Current medications"},
+			{KeyName: "patient_name", QuestionText: "What is the patient's full name?", Confirm: true},
+			{KeyName: "symptoms", QuestionText: "What symptoms are you experiencing?"},
+			{KeyName: "duration", QuestionText: "How long have you had these symptoms?"},
+			{KeyName: "medications", QuestionText: "What medications are you currently taking?"},
 		},
 		"onboarding": {
-			{Name: "full_name", Description: "Your full name", Required: true},
-			{Name: "email", Description: "Email address", Required: true},
-			{Name: "company", Description: "Company name"},
-			{Name: "department", Description: "Department"},
-			{Name: "start_date", Description: "Start date"},
+			{KeyName: "full_name", QuestionText: "What is your full name?"},
+			{KeyName: "email", QuestionText: "What is your email address?", Confirm: true},
+			{KeyName: "company", QuestionText: "What company do you work for?"},
+			{KeyName: "department", QuestionText: "Which department will you be joining?"},
+			{KeyName: "start_date", QuestionText: "When will you be starting?"},
 		},
 	}
 
-	ig := prefabs.NewInfoGathererAgent(
-		agent.WithName("DynamicInfoGatherer"),
-		agent.WithRoute("/contact"),
-		agent.WithPort(3033),
-	)
+	set := os.Getenv("INFO_GATHERER_SET")
+	if set == "" {
+		set = "default"
+	}
+	questions, ok := questionSets[set]
+	if !ok {
+		fmt.Printf("Unknown INFO_GATHERER_SET=%q; falling back to default.\n", set)
+		questions = questionSets["default"]
+		set = "default"
+	}
 
-	ig.SetQuestionCallback(func(queryParams map[string]string) []prefabs.GatherField {
-		set := queryParams["set"]
-		if set == "" {
-			set = "default"
-		}
-		fmt.Printf("Dynamic question set: %s\n", set)
-		if fields, ok := questionSets[set]; ok {
-			return fields
-		}
-		return questionSets["default"]
+	ig := prefabs.NewInfoGathererAgent(prefabs.InfoGathererOptions{
+		Name:      "DynamicInfoGatherer",
+		Route:     "/contact",
+		Questions: questions,
 	})
 
-	ig.SetOnComplete(func(data map[string]any) {
-		fmt.Printf("All fields collected: %v\n", data)
-	})
-
-	fmt.Println("Starting DynamicInfoGatherer on :3033/contact ...")
-	fmt.Println("  /contact            (default: name, phone, reason)")
-	fmt.Println("  /contact?set=support (customer support intake)")
-	fmt.Println("  /contact?set=medical (medical intake)")
-	fmt.Println("  /contact?set=onboarding (employee onboarding)")
+	fmt.Printf("Starting DynamicInfoGatherer (%s set) on :3000/contact ...\n", set)
+	fmt.Println("  Select a different set with INFO_GATHERER_SET=support|medical|onboarding")
 
 	if err := ig.Run(); err != nil {
 		fmt.Printf("Agent error: %v\n", err)

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "generated_from": "signalwire-go @ 826063e3e34ffe4fb2b2c0226d5e6654ef644a5d",
+  "generated_from": "signalwire-go @ ac772128ab1ab5f31f08aa870237c34f5f0148a8",
   "modules": {
     "signalwire": {
       "classes": {},

--- a/port_surface_go.json
+++ b/port_surface_go.json
@@ -1,0 +1,1256 @@
+{
+  "version": "1",
+  "generated_from": "signalwire-go (go-native) @ ac772128ab1ab5f31f08aa870237c34f5f0148a8",
+  "modules": {
+    "agent": {
+      "classes": {
+        "AgentBase": [
+          "AddAnswerVerb",
+          "AddFunctionInclude",
+          "AddHint",
+          "AddHints",
+          "AddInternalFiller",
+          "AddLanguage",
+          "AddMcpServer",
+          "AddPatternHint",
+          "AddPostAiVerb",
+          "AddPostAnswerVerb",
+          "AddPreAnswerVerb",
+          "AddPronunciation",
+          "AddSkill",
+          "AddSwaigQueryParams",
+          "AsRouter",
+          "ClearPostAiVerbs",
+          "ClearPostAnswerVerbs",
+          "ClearPreAnswerVerbs",
+          "ClearSwaigQueryParams",
+          "Contexts",
+          "DefineContexts",
+          "DefineTool",
+          "DefineTools",
+          "EnableDebugEvents",
+          "EnableDebugRoutes",
+          "EnableMcpServer",
+          "EnableSipRouting",
+          "GetName",
+          "GetPrompt",
+          "GetRoute",
+          "HasSkill",
+          "ListSkills",
+          "ListToolNames",
+          "ManualSetProxyUrl",
+          "OnDebugEvent",
+          "OnFunctionCall",
+          "OnSummary",
+          "PromptAddSection",
+          "PromptAddSubsection",
+          "PromptAddToSection",
+          "PromptHasSection",
+          "RegisterSipUsername",
+          "RegisterSwaigFunction",
+          "RemoveSkill",
+          "RenderSWML",
+          "ResetContexts",
+          "Run",
+          "Serve",
+          "SetDynamicConfigCallback",
+          "SetFunctionIncludes",
+          "SetGlobalData",
+          "SetInternalFillers",
+          "SetLanguages",
+          "SetNativeFunctions",
+          "SetParam",
+          "SetParams",
+          "SetPostPrompt",
+          "SetPostPromptLlmParams",
+          "SetPostPromptUrl",
+          "SetPromptLlmParams",
+          "SetPromptPom",
+          "SetPromptText",
+          "SetPronunciations",
+          "SetWebHookUrl",
+          "UpdateGlobalData"
+        ],
+        "MCPServerConfig": [],
+        "ToolDefinition": []
+      },
+      "functions": [
+        "NewAgentBase",
+        "WithAutoAnswer",
+        "WithBasicAuth",
+        "WithHost",
+        "WithName",
+        "WithPort",
+        "WithRecordCall",
+        "WithRecordFormat",
+        "WithRecordStereo",
+        "WithRoute",
+        "WithTokenExpiry"
+      ]
+    },
+    "builtin": {
+      "classes": {
+        "APINinjasTriviaSkill": [
+          "GetHints",
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "ClaudeSkillsSkill": [
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup"
+        ],
+        "CustomSkillsSkill": [
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "DataSphereServerlessSkill": [
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "DataSphereSkill": [
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "DateTimeSkill": [
+          "GetHints",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup"
+        ],
+        "GoogleMapsSkill": [
+          "GetHints",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup"
+        ],
+        "InfoGathererSkill": [
+          "GetGlobalData",
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "JokeSkill": [
+          "GetHints",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup"
+        ],
+        "MCPGatewaySkill": [
+          "GetHints",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup"
+        ],
+        "MathSkill": [
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup"
+        ],
+        "NativeVectorSearchSkill": [
+          "GetHints",
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "PlayBackgroundFileSkill": [
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "SWMLTransferSkill": [
+          "GetHints",
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "SpiderSkill": [
+          "GetHints",
+          "GetInstanceKey",
+          "RegisterTools",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "WeatherAPISkill": [
+          "GetHints",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup"
+        ],
+        "WebSearchSkill": [
+          "GetInstanceKey",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "RegisterTools",
+          "RequiredEnvVars",
+          "Setup",
+          "SupportsMultipleInstances"
+        ],
+        "WikipediaSearchSkill": [
+          "GetPromptSections",
+          "RegisterTools",
+          "Setup"
+        ]
+      },
+      "functions": [
+        "NewAPINinjasTrivia",
+        "NewClaudeSkills",
+        "NewCustomSkills",
+        "NewDataSphere",
+        "NewDataSphereServerless",
+        "NewDateTime",
+        "NewGoogleMaps",
+        "NewInfoGatherer",
+        "NewJoke",
+        "NewMCPGateway",
+        "NewMath",
+        "NewNativeVectorSearch",
+        "NewPlayBackgroundFile",
+        "NewSWMLTransfer",
+        "NewSpider",
+        "NewWeatherAPI",
+        "NewWebSearch",
+        "NewWikipediaSearch"
+      ]
+    },
+    "contexts": {
+      "classes": {
+        "Context": [
+          "AddBullets",
+          "AddEnterFiller",
+          "AddExitFiller",
+          "AddSection",
+          "AddStep",
+          "AddSystemBullets",
+          "AddSystemSection",
+          "GetStep",
+          "MoveStep",
+          "Name",
+          "RemoveStep",
+          "SetConsolidate",
+          "SetEnterFillers",
+          "SetExitFillers",
+          "SetFullReset",
+          "SetInitialStep",
+          "SetIsolated",
+          "SetPostPrompt",
+          "SetPrompt",
+          "SetSystemPrompt",
+          "SetUserPrompt",
+          "SetValidContexts",
+          "SetValidSteps",
+          "ToMap"
+        ],
+        "ContextBuilder": [
+          "AddContext",
+          "AttachAgent",
+          "GetContext",
+          "Reset",
+          "ToMap",
+          "Validate"
+        ],
+        "GatherInfo": [
+          "AddQuestion",
+          "ToMap"
+        ],
+        "GatherQuestion": [
+          "ToMap"
+        ],
+        "Step": [
+          "AddBullets",
+          "AddGatherQuestion",
+          "AddSection",
+          "ClearSections",
+          "Name",
+          "SetEnd",
+          "SetFunctions",
+          "SetGatherInfo",
+          "SetResetConsolidate",
+          "SetResetFullReset",
+          "SetResetSystemPrompt",
+          "SetResetUserPrompt",
+          "SetSkipToNextStep",
+          "SetSkipUserTurn",
+          "SetStepCriteria",
+          "SetText",
+          "SetValidContexts",
+          "SetValidSteps",
+          "ToMap"
+        ]
+      },
+      "functions": [
+        "CreateSimpleContext",
+        "NewContextBuilder",
+        "WithConfirm",
+        "WithFunctions",
+        "WithPrompt",
+        "WithType"
+      ]
+    },
+    "datamap": {
+      "classes": {
+        "DataMap": [
+          "Body",
+          "Description",
+          "ErrorKeys",
+          "Expression",
+          "FallbackOutput",
+          "Foreach",
+          "GlobalErrorKeys",
+          "Output",
+          "Parameter",
+          "Params",
+          "Purpose",
+          "ToSwaigFunction",
+          "Webhook",
+          "WebhookExpressions"
+        ]
+      },
+      "functions": [
+        "CreateExpressionTool",
+        "CreateSimpleApiTool",
+        "New"
+      ]
+    },
+    "lambda": {
+      "classes": {
+        "Handler": [
+          "HandleAPIGatewayV2",
+          "HandleFunctionURL"
+        ]
+      },
+      "functions": [
+        "NewHandler"
+      ]
+    },
+    "livewire": {
+      "classes": {
+        "Agent": [
+          "FunctionTool"
+        ],
+        "AgentHandoff": [],
+        "AgentSession": [
+          "GenerateReply",
+          "GetSwAgent",
+          "Interrupt",
+          "Say",
+          "Start",
+          "UpdateInstructions"
+        ],
+        "CartesiaTTS": [],
+        "DeepgramSTT": [],
+        "ElevenLabsTTS": [],
+        "GoogleSTT": [],
+        "JobContext": [
+          "Connect"
+        ],
+        "JobProcess": [],
+        "LiveServer": [
+          "RTCSession",
+          "SetSetupFunc"
+        ],
+        "OpenAILLM": [],
+        "OpenAITTS": [],
+        "Room": [],
+        "RunContext": [],
+        "SileroVAD": [
+          "Load"
+        ],
+        "StopResponse": []
+      },
+      "functions": [
+        "NewAgent",
+        "NewAgentServer",
+        "NewAgentSession",
+        "NewCartesiaTTS",
+        "NewDeepgramSTT",
+        "NewElevenLabsTTS",
+        "NewGoogleSTT",
+        "NewOpenAILLM",
+        "NewOpenAITTS",
+        "NewSileroVAD",
+        "RunApp",
+        "WithAgentName",
+        "WithAllowInterruptions",
+        "WithDescription",
+        "WithLLM",
+        "WithMaxEndpointingDelay",
+        "WithMaxToolSteps",
+        "WithMinEndpointingDelay",
+        "WithParameters",
+        "WithReplyInstructions",
+        "WithSTT",
+        "WithServerType",
+        "WithTTS",
+        "WithTools",
+        "WithTurnDetection",
+        "WithUserdata",
+        "WithVAD"
+      ]
+    },
+    "logging": {
+      "classes": {
+        "Logger": [
+          "Debug",
+          "Error",
+          "Info",
+          "Warn"
+        ]
+      },
+      "functions": [
+        "GetGlobalLevel",
+        "IsSuppressed",
+        "New",
+        "ParseLevel",
+        "SetGlobalLevel",
+        "Suppress",
+        "Unsuppress"
+      ]
+    },
+    "namespaces": {
+      "classes": {
+        "AddressesNamespace": [
+          "Create",
+          "Delete",
+          "Get",
+          "List"
+        ],
+        "AutoMaterializedWebhookResource": [
+          "Create"
+        ],
+        "CallFlowOptions": [],
+        "CallFlowsResource": [
+          "DeployVersion",
+          "ListAddresses",
+          "ListVersions"
+        ],
+        "CallingNamespace": [
+          "AIHold",
+          "AIMessage",
+          "AIStop",
+          "AIUnhold",
+          "Collect",
+          "CollectStartInputTimers",
+          "CollectStop",
+          "Denoise",
+          "DenoiseStop",
+          "Detect",
+          "DetectStop",
+          "Dial",
+          "Disconnect",
+          "End",
+          "LiveTranscribe",
+          "LiveTranslate",
+          "Play",
+          "PlayPause",
+          "PlayResume",
+          "PlayStop",
+          "PlayVolume",
+          "ReceiveFaxStop",
+          "Record",
+          "RecordPause",
+          "RecordResume",
+          "RecordStop",
+          "Refer",
+          "SendFaxStop",
+          "Stream",
+          "StreamStop",
+          "Tap",
+          "TapStop",
+          "Transcribe",
+          "TranscribeStop",
+          "Transfer",
+          "Update",
+          "UserEvent"
+        ],
+        "ChatNamespace": [
+          "CreateToken"
+        ],
+        "CompatAccounts": [
+          "Create",
+          "Get",
+          "List",
+          "Update"
+        ],
+        "CompatApplications": [
+          "Update"
+        ],
+        "CompatCalls": [
+          "StartRecording",
+          "StartStream",
+          "StopStream",
+          "Update",
+          "UpdateRecording"
+        ],
+        "CompatConferences": [
+          "DeleteRecording",
+          "Get",
+          "GetParticipant",
+          "GetRecording",
+          "List",
+          "ListParticipants",
+          "ListRecordings",
+          "RemoveParticipant",
+          "StartStream",
+          "StopStream",
+          "Update",
+          "UpdateParticipant",
+          "UpdateRecording"
+        ],
+        "CompatFaxes": [
+          "DeleteMedia",
+          "GetMedia",
+          "ListMedia",
+          "Update"
+        ],
+        "CompatLamlBins": [
+          "Update"
+        ],
+        "CompatMessages": [
+          "DeleteMedia",
+          "GetMedia",
+          "ListMedia",
+          "Update"
+        ],
+        "CompatNamespace": [],
+        "CompatPhoneNumbers": [
+          "Delete",
+          "Get",
+          "ImportNumber",
+          "List",
+          "ListAvailableCountries",
+          "Purchase",
+          "SearchLocal",
+          "SearchTollFree",
+          "Update"
+        ],
+        "CompatQueues": [
+          "DequeueMember",
+          "GetMember",
+          "ListMembers",
+          "Update"
+        ],
+        "CompatRecordings": [
+          "Delete",
+          "Get",
+          "List"
+        ],
+        "CompatTokens": [
+          "Create",
+          "Delete",
+          "Update"
+        ],
+        "CompatTranscriptions": [
+          "Delete",
+          "Get",
+          "List"
+        ],
+        "ConferenceLogs": [
+          "List"
+        ],
+        "ConferenceRoomsResource": [
+          "ListAddresses"
+        ],
+        "CrudResource": [
+          "Create",
+          "Delete",
+          "Get",
+          "List",
+          "ListAddresses",
+          "Update"
+        ],
+        "CxmlWebhookOptions": [],
+        "DatasphereDocuments": [
+          "DeleteChunk",
+          "GetChunk",
+          "ListChunks",
+          "Search"
+        ],
+        "DatasphereNamespace": [],
+        "FabricAddresses": [
+          "Get",
+          "List"
+        ],
+        "FabricNamespace": [],
+        "FabricTokens": [
+          "CreateEmbedToken",
+          "CreateGuestToken",
+          "CreateInviteToken",
+          "CreateSubscriberToken",
+          "RefreshSubscriberToken"
+        ],
+        "FaxLogs": [
+          "Get",
+          "List"
+        ],
+        "GenericResources": [
+          "AssignDomainApplication",
+          "AssignPhoneRoute",
+          "Delete",
+          "Get",
+          "List",
+          "ListAddresses"
+        ],
+        "ImportedNumbersNamespace": [
+          "Create"
+        ],
+        "LogsNamespace": [],
+        "LookupNamespace": [
+          "PhoneNumber"
+        ],
+        "MFANamespace": [
+          "Call",
+          "SMS",
+          "Verify"
+        ],
+        "MessageLogs": [
+          "Get",
+          "List"
+        ],
+        "NumberGroupsNamespace": [
+          "AddMembership",
+          "DeleteMembership",
+          "GetMembership",
+          "ListMemberships"
+        ],
+        "PhoneNumbersNamespace": [
+          "Search",
+          "SetAiAgent",
+          "SetCallFlow",
+          "SetCxmlApplication",
+          "SetCxmlWebhook",
+          "SetRelayApplication",
+          "SetRelayTopic",
+          "SetSwmlWebhook"
+        ],
+        "ProjectNamespace": [],
+        "ProjectTokens": [
+          "Create",
+          "Delete",
+          "Update"
+        ],
+        "PubSubNamespace": [
+          "CreateToken"
+        ],
+        "QueuesNamespace": [
+          "GetMember",
+          "GetNextMember",
+          "ListMembers"
+        ],
+        "RecordingsNamespace": [
+          "Delete",
+          "Get",
+          "List"
+        ],
+        "RegistryBrands": [
+          "Create",
+          "CreateCampaign",
+          "Get",
+          "List",
+          "ListCampaigns"
+        ],
+        "RegistryCampaigns": [
+          "CreateOrder",
+          "Get",
+          "ListNumbers",
+          "ListOrders",
+          "Update"
+        ],
+        "RegistryNamespace": [],
+        "RegistryNumbers": [
+          "Delete"
+        ],
+        "RegistryOrders": [
+          "Get"
+        ],
+        "RelayTopicOptions": [],
+        "Resource": [
+          "Path"
+        ],
+        "ShortCodesNamespace": [
+          "Get",
+          "List",
+          "Update"
+        ],
+        "SipProfileNamespace": [
+          "Get",
+          "Update"
+        ],
+        "SubscribersResource": [
+          "CreateSIPEndpoint",
+          "DeleteSIPEndpoint",
+          "GetSIPEndpoint",
+          "ListSIPEndpoints",
+          "UpdateSIPEndpoint"
+        ],
+        "VerifiedCallersNamespace": [
+          "RedialVerification",
+          "SubmitVerification"
+        ],
+        "VideoConferenceTokens": [
+          "Get",
+          "Reset"
+        ],
+        "VideoConferences": [
+          "CreateStream",
+          "ListConferenceTokens",
+          "ListStreams"
+        ],
+        "VideoNamespace": [],
+        "VideoRoomRecordings": [
+          "Delete",
+          "Get",
+          "List",
+          "ListEvents"
+        ],
+        "VideoRoomSessions": [
+          "Get",
+          "List",
+          "ListEvents",
+          "ListMembers",
+          "ListRecordings"
+        ],
+        "VideoRoomTokens": [
+          "Create"
+        ],
+        "VideoRooms": [
+          "CreateStream",
+          "ListStreams"
+        ],
+        "VideoStreams": [
+          "Delete",
+          "Get",
+          "Update"
+        ],
+        "VoiceLogs": [
+          "Get",
+          "List",
+          "ListEvents"
+        ]
+      },
+      "functions": [
+        "AllPhoneCallHandlers",
+        "NewAddressesNamespace",
+        "NewCallingNamespace",
+        "NewChatNamespace",
+        "NewCompatNamespace",
+        "NewCrudResource",
+        "NewCrudResourcePUT",
+        "NewDatasphereNamespace",
+        "NewFabricNamespace",
+        "NewImportedNumbersNamespace",
+        "NewLogsNamespace",
+        "NewLookupNamespace",
+        "NewMFANamespace",
+        "NewNumberGroupsNamespace",
+        "NewPhoneNumbersNamespace",
+        "NewProjectNamespace",
+        "NewPubSubNamespace",
+        "NewQueuesNamespace",
+        "NewRecordingsNamespace",
+        "NewRegistryNamespace",
+        "NewShortCodesNamespace",
+        "NewSipProfileNamespace",
+        "NewVerifiedCallersNamespace",
+        "NewVideoNamespace",
+        "ResetDeprecationWarnOnce",
+        "SetDeprecationLogger"
+      ]
+    },
+    "prefabs": {
+      "classes": {
+        "Amenity": [],
+        "ConciergeAgent": [],
+        "ConciergeOptions": [],
+        "Department": [],
+        "FAQ": [],
+        "FAQBotAgent": [],
+        "FAQBotOptions": [],
+        "InfoGathererAgent": [],
+        "InfoGathererOptions": [],
+        "Question": [],
+        "ReceptionistAgent": [],
+        "ReceptionistOptions": [],
+        "SurveyAgent": [],
+        "SurveyOptions": [],
+        "SurveyQuestion": []
+      },
+      "functions": [
+        "NewConciergeAgent",
+        "NewFAQBotAgent",
+        "NewInfoGathererAgent",
+        "NewReceptionistAgent",
+        "NewSurveyAgent"
+      ]
+    },
+    "relay": {
+      "classes": {
+        "AIAction": [],
+        "AIEvent": [],
+        "Action": [
+          "Completed",
+          "ControlID",
+          "IsDone",
+          "OnCompleted",
+          "Result",
+          "Stop",
+          "Wait"
+        ],
+        "Call": [
+          "AI",
+          "AIHold",
+          "AIMessage",
+          "AIUnhold",
+          "AmazonBedrock",
+          "Answer",
+          "BindDigit",
+          "CallID",
+          "ClearDigitBindings",
+          "Collect",
+          "Connect",
+          "Denoise",
+          "DenoiseStop",
+          "Detect",
+          "Disconnect",
+          "Echo",
+          "Hangup",
+          "Hold",
+          "JoinConference",
+          "JoinRoom",
+          "LeaveConference",
+          "LeaveRoom",
+          "NodeID",
+          "On",
+          "Pass",
+          "Pay",
+          "Play",
+          "PlayAndCollect",
+          "QueueEnter",
+          "QueueLeave",
+          "ReceiveFax",
+          "Record",
+          "SendDigits",
+          "SendFax",
+          "State",
+          "Stream",
+          "String",
+          "Tag",
+          "Tap",
+          "Transcribe",
+          "Transfer",
+          "Unhold",
+          "UserEvent",
+          "WaitFor"
+        ],
+        "CallReceiveEvent": [],
+        "CallStateEvent": [],
+        "CallingErrorEvent": [],
+        "Client": [
+          "Dial",
+          "OnCall",
+          "OnMessage",
+          "Run",
+          "SendMessage",
+          "Stop"
+        ],
+        "CollectAction": [],
+        "CollectEvent": [],
+        "ConferenceEvent": [],
+        "ConnectEvent": [],
+        "DenoiseEvent": [],
+        "DetectAction": [],
+        "DetectEvent": [],
+        "DialEvent": [],
+        "EchoEvent": [],
+        "FaxAction": [],
+        "FaxEvent": [],
+        "HoldEvent": [],
+        "Message": [
+          "Body",
+          "Direction",
+          "FromNumber",
+          "IsDone",
+          "Media",
+          "MessageID",
+          "On",
+          "Reason",
+          "Segments",
+          "State",
+          "Tags",
+          "ToNumber",
+          "Wait"
+        ],
+        "MessageReceiveEvent": [],
+        "MessageStateEvent": [],
+        "PayAction": [],
+        "PayEvent": [],
+        "PlayAction": [
+          "Pause",
+          "Resume",
+          "Volume"
+        ],
+        "PlayEvent": [],
+        "QueueEvent": [],
+        "RecordAction": [],
+        "RecordEvent": [],
+        "ReferEvent": [],
+        "RelayEvent": [
+          "GetBool",
+          "GetInt",
+          "GetMap",
+          "GetString"
+        ],
+        "SendDigitsEvent": [],
+        "StandaloneCollectAction": [],
+        "StreamAction": [],
+        "StreamEvent": [],
+        "TapAction": [],
+        "TapEvent": [],
+        "TranscribeAction": [],
+        "TranscribeEvent": []
+      },
+      "functions": [
+        "NewAIEvent",
+        "NewCallReceiveEvent",
+        "NewCallStateEvent",
+        "NewCallingErrorEvent",
+        "NewCollectEvent",
+        "NewConferenceEvent",
+        "NewConnectEvent",
+        "NewDenoiseEvent",
+        "NewDetectEvent",
+        "NewDialEvent",
+        "NewEchoEvent",
+        "NewFaxEvent",
+        "NewHoldEvent",
+        "NewMessageReceiveEvent",
+        "NewMessageStateEvent",
+        "NewPayEvent",
+        "NewPlayEvent",
+        "NewQueueEvent",
+        "NewRecordEvent",
+        "NewReferEvent",
+        "NewRelayClient",
+        "NewRelayEvent",
+        "NewSendDigitsEvent",
+        "NewStreamEvent",
+        "NewTapEvent",
+        "NewTranscribeEvent",
+        "WithAIEngine",
+        "WithAIParams",
+        "WithAIPostPrompt",
+        "WithAIPrompt",
+        "WithConferenceBeep",
+        "WithConferenceDeaf",
+        "WithConferenceMuted",
+        "WithConnectRingback",
+        "WithContexts",
+        "WithDialFromNumber",
+        "WithDialTimeout",
+        "WithJWT",
+        "WithMaxActiveCalls",
+        "WithMessageMedia",
+        "WithMessageRegion",
+        "WithMessageTags",
+        "WithPlayVolume",
+        "WithProject",
+        "WithRecordBeep",
+        "WithRecordDirection",
+        "WithRecordEndSilenceTimeout",
+        "WithRecordFormat",
+        "WithRecordInitialTimeout",
+        "WithRecordStereo",
+        "WithRecordTerminators",
+        "WithSpace",
+        "WithStreamCodec",
+        "WithStreamDirection",
+        "WithToken"
+      ]
+    },
+    "rest": {
+      "classes": {
+        "CrudResource": [
+          "Create",
+          "Delete",
+          "Get",
+          "List",
+          "Update"
+        ],
+        "HttpClient": [
+          "BaseURL",
+          "Delete",
+          "Get",
+          "Patch",
+          "Post",
+          "Put"
+        ],
+        "PaginatedIterator": [
+          "Next"
+        ],
+        "RestClient": [],
+        "SignalWireRestError": [
+          "Error"
+        ]
+      },
+      "functions": [
+        "NewCrudResource",
+        "NewCrudResourcePUT",
+        "NewHttpClient",
+        "NewPaginatedIterator",
+        "NewRestClient"
+      ]
+    },
+    "security": {
+      "classes": {
+        "SessionManager": [
+          "CreateToken",
+          "ValidateToken"
+        ]
+      },
+      "functions": [
+        "NewSessionManager"
+      ]
+    },
+    "server": {
+      "classes": {
+        "AgentEntry": [],
+        "AgentServer": [
+          "GetAgent",
+          "GetAgents",
+          "Register",
+          "RegisterSipUsername",
+          "Run",
+          "ServeStaticFiles",
+          "SetupSipRouting",
+          "Unregister"
+        ]
+      },
+      "functions": [
+        "NewAgentServer",
+        "WithRunHost",
+        "WithRunPort",
+        "WithServerHost",
+        "WithServerPort"
+      ]
+    },
+    "skills": {
+      "classes": {
+        "BaseSkill": [
+          "Cleanup",
+          "Description",
+          "GetGlobalData",
+          "GetHints",
+          "GetInstanceKey",
+          "GetParam",
+          "GetParamBool",
+          "GetParamFloat",
+          "GetParamInt",
+          "GetParamString",
+          "GetParameterSchema",
+          "GetPromptSections",
+          "Name",
+          "RequiredEnvVars",
+          "SupportsMultipleInstances",
+          "Version"
+        ],
+        "SkillManager": [
+          "GetSkill",
+          "HasSkill",
+          "ListLoadedSkills",
+          "LoadSkill",
+          "UnloadSkill"
+        ],
+        "ToolRegistration": []
+      },
+      "functions": [
+        "GetSkillFactory",
+        "ListSkills",
+        "NewSkillManager",
+        "RegisterSkill"
+      ]
+    },
+    "swaig": {
+      "classes": {
+        "FunctionResult": [
+          "AddAction",
+          "AddActions",
+          "AddDynamicHints",
+          "ClearDynamicHints",
+          "Connect",
+          "EnableExtensiveData",
+          "EnableFunctionsOnTimeout",
+          "ExecuteRpc",
+          "ExecuteSwml",
+          "Hangup",
+          "Hold",
+          "JoinConference",
+          "JoinRoom",
+          "Pay",
+          "PlayBackgroundFile",
+          "RecordCall",
+          "RemoveGlobalData",
+          "RemoveMetadata",
+          "ReplaceInHistory",
+          "RpcAiMessage",
+          "RpcAiUnhold",
+          "RpcDial",
+          "Say",
+          "SendSms",
+          "SetEndOfSpeechTimeout",
+          "SetMetadata",
+          "SetPostProcess",
+          "SetResponse",
+          "SetSpeechEventTimeout",
+          "SimulateUserInput",
+          "SipRefer",
+          "Stop",
+          "StopBackgroundFile",
+          "StopRecordCall",
+          "StopTap",
+          "String",
+          "SwitchContext",
+          "SwmlChangeContext",
+          "SwmlChangeStep",
+          "SwmlTransfer",
+          "SwmlUserEvent",
+          "Tap",
+          "ToMap",
+          "ToggleFunctions",
+          "UpdateGlobalData",
+          "UpdateSettings",
+          "WaitForUser"
+        ]
+      },
+      "functions": [
+        "CreatePaymentAction",
+        "CreatePaymentParameter",
+        "CreatePaymentPrompt",
+        "NewFunctionResult"
+      ]
+    },
+    "swml": {
+      "classes": {
+        "Document": [
+          "AddSection",
+          "AddVerb",
+          "AddVerbToSection",
+          "GetVerbs",
+          "HasSection",
+          "MarshalJSON",
+          "Render",
+          "RenderPretty",
+          "Reset",
+          "ToMap"
+        ],
+        "Schema": [
+          "GetAllVerbNames",
+          "GetVerb",
+          "IsValidVerb",
+          "VerbCount"
+        ],
+        "Service": [
+          "AI",
+          "AmazonBedrock",
+          "Answer",
+          "Cond",
+          "Connect",
+          "Denoise",
+          "DetectMachine",
+          "EnterQueue",
+          "Execute",
+          "ExecuteVerb",
+          "ExecuteVerbToSection",
+          "GetBasicAuthCredentials",
+          "GetDocument",
+          "GetFullURL",
+          "Goto",
+          "Hangup",
+          "JoinConference",
+          "JoinRoom",
+          "Label",
+          "LiveTranscribe",
+          "LiveTranslate",
+          "OnRequest",
+          "Pay",
+          "Play",
+          "Prompt",
+          "ReceiveFax",
+          "Record",
+          "RecordCall",
+          "RegisterRoutingCallback",
+          "Render",
+          "RenderPretty",
+          "Request",
+          "ResetDocument",
+          "Return",
+          "SIPRefer",
+          "SendDigits",
+          "SendFax",
+          "SendSMS",
+          "Serve",
+          "Set",
+          "Sleep",
+          "Stop",
+          "StopDenoise",
+          "StopRecordCall",
+          "StopTap",
+          "Switch",
+          "Tap",
+          "Transfer",
+          "Unset",
+          "UserEvent"
+        ],
+        "VerbInfo": []
+      },
+      "functions": [
+        "ExtractSIPUsername",
+        "GetExecutionMode",
+        "GetSchema",
+        "NewDocument",
+        "NewService",
+        "WithBasicAuth",
+        "WithHost",
+        "WithName",
+        "WithPort",
+        "WithRoute"
+      ]
+    }
+  }
+}

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -139,7 +139,9 @@ Record the call. Returns a `*RecordAction` with `Stop()`, `Pause()`, `Resume()`,
 
 ```go
 action := call.Record(
-	relay.WithRecordAudio(map[string]any{"format": "wav", "stereo": true, "direction": "both"}),
+	relay.WithRecordFormat("wav"),
+	relay.WithRecordStereo(true),
+	relay.WithRecordDirection("both"),
 )
 // ... later ...
 action.Stop()
@@ -166,16 +168,17 @@ params, _ := result["params"].(map[string]any)
 digit, _ := params["digits"].(string)
 ```
 
-### `Collect(opts ...CollectOption) *StandaloneCollectAction`
+### `Collect(collect map[string]any) *StandaloneCollectAction`
 
-Collect input without playing audio.
+Collect input without playing audio. Pass a collect-config map describing
+the digit and/or speech recognition to perform.
 
 ```go
-action := call.Collect(
-	relay.WithCollectDigits(map[string]any{"max": 4, "terminators": "#"}),
-	relay.WithCollectSpeech(map[string]any{"language": "en-US"}),
-	relay.WithCollectPartialResults(true),
-)
+action := call.Collect(map[string]any{
+	"digits":          map[string]any{"max": 4, "terminators": "#"},
+	"speech":          map[string]any{"language": "en-US"},
+	"partial_results": true,
+})
 event := action.Wait(context.Background())
 ```
 
@@ -214,14 +217,15 @@ call.SendDigits("1234#")
 
 ## Detection
 
-### `Detect(detect map[string]any, opts ...DetectOption) *DetectAction`
+### `Detect(detect map[string]any, timeout int) *DetectAction`
 
-Detect machine, fax, or digits.
+Detect machine, fax, or digits. `timeout` is in seconds; pass `0` for the
+server default.
 
 ```go
 action := call.Detect(
 	map[string]any{"type": "machine"},
-	relay.WithDetectTimeout(30.0),
+	30, // seconds
 )
 event := action.Wait(context.Background())
 ```
@@ -248,11 +252,12 @@ call.Transfer("https://example.com/swml-endpoint")
 
 ## Fax
 
-### `SendFax(document string, opts ...FaxOption) *FaxAction`
+### `SendFax(document, identity string) *FaxAction`
 
 ```go
-action := call.SendFax("https://example.com/document.pdf",
-	relay.WithFaxIdentity("+15551234567"),
+action := call.SendFax(
+	"https://example.com/document.pdf",
+	"+15551234567", // caller identity
 )
 event := action.Wait(context.Background())
 ```
@@ -266,7 +271,7 @@ event := action.Wait(context.Background())
 
 ## Tap (Media Interception)
 
-### `Tap(tap, device map[string]any, opts ...TapOption) *TapAction`
+### `Tap(tap, device map[string]any) *TapAction`
 
 Intercept call media and stream to an RTP endpoint.
 
@@ -285,9 +290,8 @@ Stream call audio to a WebSocket endpoint.
 
 ```go
 action := call.Stream("wss://example.com/audio",
-	relay.WithStreamName("my_stream"),
 	relay.WithStreamCodec("PCMU"),
-	relay.WithStreamTrack("inbound_track"),
+	relay.WithStreamDirection("inbound"),
 )
 // Stop streaming
 action.Stop()
@@ -295,15 +299,15 @@ action.Stop()
 
 ## Payment
 
-### `Pay(connectorURL string, opts ...PayOption) *PayAction`
+### `Pay(connectorURL, amount, currency string) *PayAction`
 
 Collect a payment via DTMF.
 
 ```go
-action := call.Pay("https://pay.example.com",
-	relay.WithPayChargeAmount("25.99"),
-	relay.WithPayCurrency("usd"),
-	relay.WithPayInputMethod("dtmf"),
+action := call.Pay(
+	"https://pay.example.com",
+	"25.99",
+	"usd",
 )
 event := action.Wait(context.Background())
 ```
@@ -347,12 +351,10 @@ call.DenoiseStop()
 
 ## Transcription
 
-### `Transcribe(opts ...TranscribeOption) *TranscribeAction`
+### `Transcribe(statusURL string) *TranscribeAction`
 
 ```go
-action := call.Transcribe(
-	relay.WithTranscribeStatusURL("https://example.com/transcription"),
-)
+action := call.Transcribe("https://example.com/transcription")
 // ... later ...
 action.Stop()
 ```
@@ -373,12 +375,13 @@ call.LiveTranslate(map[string]any{"start": map[string]any{"source": "en-US", "ta
 
 ## Echo
 
-### `Echo(opts ...EchoOption) (map[string]any, error)`
+### `Echo(timeout int) (map[string]any, error)`
 
-Echo audio back to the caller (useful for testing).
+Echo audio back to the caller (useful for testing). `timeout` is in seconds
+(pass `0` for the server default).
 
 ```go
-call.Echo(relay.WithEchoTimeout(30.0))
+call.Echo(30)
 ```
 
 ## AI Agent
@@ -390,7 +393,6 @@ Start an AI agent session on the call.
 ```go
 action := call.AI(
 	relay.WithAIPrompt(map[string]any{"text": "You are a helpful support agent."}),
-	relay.WithAISWAIG(map[string]any{"functions": []any{...}}),
 	relay.WithAIParams(map[string]any{"end_of_speech_timeout": 3000}),
 )
 event := action.Wait(context.Background())
@@ -430,27 +432,25 @@ call.LeaveRoom()
 call.QueueEnter("support")
 ```
 
-### `QueueLeave(queueName string, opts ...QueueOption) (map[string]any, error)`
+### `QueueLeave(queueName string) (map[string]any, error)`
 
 ```go
-call.QueueLeave("support", relay.WithQueueID("q-123"))
+call.QueueLeave("support")
 ```
 
 ## Digit Bindings
 
-### `BindDigit(digits, bindMethod string, opts ...BindDigitOption) (map[string]any, error)`
+### `BindDigit(digits, method string, params map[string]any) (map[string]any, error)`
 
 Bind a DTMF sequence to trigger a RELAY method.
 
 ```go
-call.BindDigit("*1", "calling.play",
-	relay.WithBindParams(map[string]any{
-		"play": []map[string]any{{"type": "tts", "params": map[string]any{"text": "You pressed star-1"}}},
-	}),
-)
+call.BindDigit("*1", "calling.play", map[string]any{
+	"play": []map[string]any{{"type": "tts", "params": map[string]any{"text": "You pressed star-1"}}},
+})
 ```
 
-### `ClearDigitBindings(opts ...BindDigitOption) (map[string]any, error)`
+### `ClearDigitBindings() (map[string]any, error)`
 
 ```go
 call.ClearDigitBindings()
@@ -458,15 +458,15 @@ call.ClearDigitBindings()
 
 ## User Events
 
-### `UserEvent(opts ...UserEventOption) (map[string]any, error)`
+### `UserEvent(event map[string]any) (map[string]any, error)`
 
 Send a custom event.
 
 ```go
-call.UserEvent(
-	relay.WithUserEventName("order_placed"),
-	relay.WithUserEventData(map[string]any{"order_id": "12345"}),
-)
+call.UserEvent(map[string]any{
+	"name": "order_placed",
+	"data": map[string]any{"order_id": "12345"},
+})
 ```
 
 ## Event Handling
@@ -481,21 +481,29 @@ call.On("calling.call.play", func(event *relay.RelayEvent) {
 })
 ```
 
-### `WaitFor(eventType string, opts ...WaitOption) (*relay.RelayEvent, error)`
+### `WaitFor(ctx context.Context, eventType string, predicate func(*relay.RelayEvent) bool) (*relay.RelayEvent, error)`
 
-Wait for a specific event.
+Wait for a specific event. Pass a `nil` predicate to match any event of
+`eventType`, or a custom function for additional filtering. Timeout is
+handled via the context.
 
 ```go
-event, err := call.WaitFor("calling.call.play",
-	relay.WithWaitTimeout(30 * time.Second),
-)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+event, err := call.WaitFor(ctx, "calling.call.play", nil)
 ```
 
-### `WaitForEnded(opts ...WaitOption) (*relay.RelayEvent, error)`
+### End-of-call event
 
-Wait for the call to end.
+`Call` only exposes an explicit `WaitFor` helper; to wait for the call to
+end, filter on the state-change event:
 
 ```go
-event, err := call.WaitForEnded()
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+defer cancel()
+event, err := call.WaitFor(ctx, "calling.call.state", func(e *relay.RelayEvent) bool {
+	state, _ := e.Params["call_state"].(string)
+	return state == "ended"
+})
 fmt.Printf("End reason: %v\n", event.Params["end_reason"])
 ```

--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -12,12 +12,12 @@ client := relay.NewRelayClient(opts ...ClientOption)
 |--------|---------|-------------|
 | `WithProject(id)` | `SIGNALWIRE_PROJECT_ID` | Project ID for authentication |
 | `WithToken(token)` | `SIGNALWIRE_API_TOKEN` | API token for authentication |
-| `WithJWTToken(jwt)` | `SIGNALWIRE_JWT_TOKEN` | JWT token (alternative to project/token) |
+| `WithJWT(jwt)` | `SIGNALWIRE_JWT_TOKEN` | JWT token (alternative to project/token) |
 | `WithSpace(host)` | `SIGNALWIRE_SPACE` | Space hostname (default: `relay.signalwire.com`) |
 | `WithContexts(ctx...)` | -- | Topics to subscribe to |
 | `WithMaxActiveCalls(n)` | `RELAY_MAX_ACTIVE_CALLS` | Max concurrent calls (default: 1000) |
 
-Authentication requires either `WithProject()` + `WithToken()` (legacy) or `WithJWTToken()` (faster, no server roundtrip). All parameters fall back to their corresponding environment variables.
+Authentication requires either `WithProject()` + `WithToken()` (legacy) or `WithJWT()` (faster, no server roundtrip). All parameters fall back to their corresponding environment variables.
 
 ## Methods
 
@@ -29,17 +29,17 @@ Blocking entry point. Connects, authenticates, and runs the event loop with auto
 client.Run()
 ```
 
-### `Connect(ctx) error` / `Disconnect() error`
+### `Stop()`
 
-Manual lifecycle control for use within an existing application.
+Signal a running client to tear down its WebSocket and exit `Run()`. Safe to
+call from another goroutine.
 
 ```go
-ctx := context.Background()
-if err := client.Connect(ctx); err != nil {
-	log.Fatalf("Connect failed: %v", err)
-}
-defer client.Disconnect()
-// ... use client ...
+go func() {
+	time.Sleep(5 * time.Minute)
+	client.Stop()
+}()
+client.Run() // blocks until Stop() is called
 ```
 
 ### `OnCall(handler func(*relay.Call))`
@@ -66,9 +66,8 @@ call, err := client.Dial(
 			"to_number": "+15551234567", "from_number": "+15559876543",
 		}}},
 	},
-	relay.WithDialTag("my-tag"),
-	relay.WithDialMaxDuration(30),
-	relay.WithDialTimeout(120 * time.Second),
+	relay.WithDialFromNumber("+15559876543"),
+	relay.WithDialTimeout(30), // seconds
 )
 if err != nil {
 	fmt.Printf("Dial failed: %v\n", err)
@@ -86,15 +85,17 @@ client.OnMessage(func(message *relay.Message) {
 })
 ```
 
-### `SendMessage(opts ...MessageOption) (*Message, error)`
+### `SendMessage(to, from, body string, opts ...MessageOption) (*Message, error)`
 
 Send an outbound SMS/MMS. Returns a `*Message` that tracks delivery state.
+The three required parameters are positional; additional `MessageOption`
+values configure media, region, and tags.
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Hello!"),
+	"+15552222222",
+	"+15551111111",
+	"Hello!",
 )
 if err != nil {
 	fmt.Printf("Send failed: %v\n", err)
@@ -105,27 +106,12 @@ event := message.Wait(context.Background()) // block until delivered/failed
 
 See [Messaging](messaging.md) for full details.
 
-### `Execute(method string, params map[string]any) (map[string]any, error)`
+## Context Subscriptions
 
-Send a raw JSON-RPC request. Used internally by Call methods, but available for custom commands.
-
-### `Receive(contexts []string) error` / `Unreceive(contexts []string) error`
-
-Dynamically subscribe to or unsubscribe from contexts after connecting.
-
-```go
-client.Receive([]string{"new-context"})
-client.Unreceive([]string{"old-context"})
-```
-
-## Properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `RelayProtocol()` | `string` | Server-assigned protocol string from connect response |
-| `Project()` | `string` | Project ID |
-| `Host()` | `string` | Relay host |
-| `Contexts()` | `[]string` | Initial contexts |
+The RELAY contexts the client listens on are fixed at construction time via
+`WithContexts(...)`. Dynamic subscribe/unsubscribe is not currently exposed
+in the Go port — recreate the client with the desired contexts if they need
+to change.
 
 ## Connection Behavior
 
@@ -159,7 +145,8 @@ if err != nil {
 
 ## Graceful Shutdown
 
-Use a context with cancellation or handle OS signals to shut down cleanly:
+Use a cancellable context or OS signal handler to call `client.Stop()` when
+the process should exit:
 
 ```go
 ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -172,11 +159,13 @@ client.OnCall(func(call *relay.Call) {
 	call.Hangup("")
 })
 
-if err := client.Connect(ctx); err != nil {
+go func() {
+	<-ctx.Done()
+	fmt.Println("Shutting down...")
+	client.Stop()
+}()
+
+if err := client.Run(); err != nil {
 	log.Fatal(err)
 }
-defer client.Disconnect()
-
-<-ctx.Done()
-fmt.Println("Shutting down...")
 ```

--- a/relay/docs/events.md
+++ b/relay/docs/events.md
@@ -13,13 +13,14 @@ client.OnCall(func(call *relay.Call) {
 		fmt.Printf("Play: %v\n", event.Params)
 	})
 
-	// Or wait for a specific event
-	event, err := call.WaitFor("calling.call.state",
-		relay.WithWaitPredicate(func(e *relay.RelayEvent) bool {
+	// Or wait for a specific event with a predicate + deadline
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	event, err := call.WaitFor(ctx, "calling.call.state",
+		func(e *relay.RelayEvent) bool {
 			state, _ := e.Params["call_state"].(string)
 			return state == "ended"
-		}),
-		relay.WithWaitTimeout(60 * time.Second),
+		},
 	)
 	if err != nil {
 		fmt.Printf("Wait error: %v\n", err)
@@ -75,14 +76,13 @@ Raw events are always `*RelayEvent` with a `Params` map. For convenience, typed 
 ```go
 import "github.com/signalwire/signalwire-go/pkg/relay"
 
-// Automatic parsing
-event := relay.ParseEvent(rawPayload)
-
-// Or construct directly via type assertion
+// The event arrives as a *RelayEvent with an EventType and Params map.
 if event.EventType == relay.EventCallState {
-	stateEvent := relay.CallStateEventFromPayload(rawPayload)
-	fmt.Println(stateEvent.CallState)  // "answered"
-	fmt.Println(stateEvent.EndReason)  // "hangup" (only on ended)
+	// Promote the generic event to its typed struct by passing the
+	// Params map to the matching New<EventName> factory.
+	stateEvent := relay.NewCallStateEvent(event.Params)
+	fmt.Println(stateEvent.CallState) // "answered"
+	fmt.Println(stateEvent.EndReason) // "hangup" (only on ended)
 }
 ```
 
@@ -155,9 +155,9 @@ client.OnCall(func(call *relay.Call) {
 	// Listen for events in a separate goroutine
 	go func() {
 		for {
-			event, err := call.WaitFor(relay.EventCallState,
-				relay.WithWaitTimeout(120 * time.Second),
-			)
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			event, err := call.WaitFor(ctx, relay.EventCallState, nil)
+			cancel()
 			if err != nil {
 				return // timeout or call ended
 			}

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -98,11 +98,10 @@ Contexts are topics your client subscribes to for receiving inbound calls. When 
 client := relay.NewRelayClient(
 	relay.WithContexts("sales", "support"),
 )
-
-// Or dynamically after connecting
-client.Receive([]string{"billing"})
-client.Unreceive([]string{"sales"})
 ```
+
+Contexts are fixed at client construction time in the Go port; to change the
+subscription set, construct a new `RelayClient`.
 
 ## Making Outbound Calls
 
@@ -145,21 +144,22 @@ export SIGNALWIRE_LOG_LEVEL=debug
 
 ## Manual Lifecycle Control
 
-For use within an existing application where you need explicit connect/disconnect:
+`Run()` blocks the current goroutine; use `Stop()` from another goroutine to
+tear the client down early. `Dial()` and `SendMessage()` connect implicitly
+the first time they are called.
 
 ```go
-ctx, cancel := context.WithCancel(context.Background())
-defer cancel()
-
 client := relay.NewRelayClient(relay.WithContexts("default"))
 
-if err := client.Connect(ctx); err != nil {
-	fmt.Printf("Connect failed: %v\n", err)
+go func() {
+	time.Sleep(5 * time.Minute)
+	client.Stop()
+}()
+
+if err := client.Run(); err != nil {
+	fmt.Printf("Client error: %v\n", err)
 	os.Exit(1)
 }
-defer client.Disconnect()
-
-call, err := client.Dial([][]map[string]any{...})
 ```
 
 ## Next Steps

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -4,13 +4,15 @@ Send and receive SMS/MMS messages through the RELAY client.
 
 ## Sending Messages
 
-Use `client.SendMessage()` to send an outbound SMS or MMS.
+Use `client.SendMessage()` to send an outbound SMS or MMS. The three required
+parameters (to, from, body) are positional; everything else is a
+`MessageOption`.
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Hello from SignalWire!"),
+	"+15552222222",                 // to (E.164)
+	"+15551111111",                 // from (E.164)
+	"Hello from SignalWire!",       // body
 )
 if err != nil {
 	fmt.Printf("Send failed: %v\n", err)
@@ -22,9 +24,9 @@ if err != nil {
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Hello!"),
+	"+15552222222",
+	"+15551111111",
+	"Hello!",
 )
 if err != nil {
 	fmt.Printf("Send failed: %v\n", err)
@@ -41,9 +43,9 @@ if message.Reason() != "" {
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Hello!"),
+	"+15552222222",
+	"+15551111111",
+	"Hello!",
 )
 // don't call message.Wait() -- continue immediately
 ```
@@ -52,9 +54,9 @@ message, err := client.SendMessage(
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Hello!"),
+	"+15552222222",
+	"+15551111111",
+	"Hello!",
 )
 if err != nil {
 	fmt.Printf("Send failed: %v\n", err)
@@ -72,24 +74,23 @@ go func() {
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),
-	relay.WithMessageFrom("+15551111111"),
-	relay.WithMessageBody("Check this out!"),
+	"+15552222222",
+	"+15551111111",
+	"Check this out!",
 	relay.WithMessageMedia([]string{"https://example.com/image.jpg"}),
 )
 ```
 
-### All parameters
+### All options
 
 ```go
 message, err := client.SendMessage(
-	relay.WithMessageTo("+15552222222"),         // required -- E.164 format
-	relay.WithMessageFrom("+15551111111"),       // required -- E.164 format
-	relay.WithMessageBody("Message text"),       // required if no media
-	relay.WithMessageMedia([]string{"https://..."}), // required if no body
-	relay.WithMessageContext("my_context"),       // context for state events
-	relay.WithMessageTags([]string{"vip", "support"}), // optional tags
-	relay.WithMessageRegion("us"),               // optional origination region
+	"+15552222222",                                       // to   (required -- E.164)
+	"+15551111111",                                       // from (required -- E.164)
+	"Message text",                                       // body (required if no media)
+	relay.WithMessageMedia([]string{"https://..."}),      // required if no body
+	relay.WithMessageTags([]string{"vip", "support"}),    // optional tags
+	relay.WithMessageRegion("us"),                        // optional origination region
 )
 ```
 
@@ -125,9 +126,9 @@ func main() {
 
 		// Reply back
 		client.SendMessage(
-			relay.WithMessageTo(message.FromNumber),
-			relay.WithMessageFrom(message.ToNumber),
-			relay.WithMessageBody(fmt.Sprintf("You said: %s", message.Body)),
+			message.FromNumber,
+			message.ToNumber,
+			fmt.Sprintf("You said: %s", message.Body),
 		)
 	})
 

--- a/scripts/compile_examples.sh
+++ b/scripts/compile_examples.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# compile_examples.sh -- compile-check every example file, one by one.
+#
+# Go's ``package main`` means that two examples living side-by-side in the
+# same directory (as ``rest/examples/*.go`` and ``relay/examples/*.go`` do)
+# cannot be built by ``go build ./rest/examples/...``.  Each file also
+# carries a ``//go:build ignore`` tag so ``go build ./...`` skips them.
+#
+# This script compiles each file independently via
+# ``go build -o /dev/null FILE.go``; that form honours even
+# ``//go:build ignore``-tagged files because a single .go target overrides
+# the directory's build-tag filter.
+#
+# Fails (exit 1) if any example doesn't compile.  Keep this green --
+# it's wired into the Layer C CI workflow at
+# ``.github/workflows/doc-audit.yml``.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+total=0
+failed=0
+failed_files=()
+
+for f in $(find examples relay/examples rest/examples -name "*.go" -print 2>/dev/null | sort); do
+    total=$((total + 1))
+    if ! go build -o /dev/null "$f" 2> /tmp/compile_examples_err; then
+        failed=$((failed + 1))
+        failed_files+=("$f")
+        echo "FAIL: $f"
+        sed 's/^/    /' /tmp/compile_examples_err
+        echo
+    fi
+done
+
+echo
+if [ "$failed" -gt 0 ]; then
+    echo "FAILED: $failed of $total example(s) did not compile:"
+    for f in "${failed_files[@]}"; do
+        echo "    $f"
+    done
+    exit 1
+fi
+echo "OK: all $total examples compile"


### PR DESCRIPTION
## Summary

Wires Layer C of the porting-sdk audit stack — doc↔code alignment. Every method or class reference in docs and examples now resolves to a real symbol, or lives in `DOC_AUDIT_IGNORE.md` with rationale.

**Phantom APIs fixed in-repo (relay docs had widespread drift):**

- `relay/docs/messaging.md`: `SendMessage` was documented with nonexistent `WithMessageTo/From/Body` options → rewrote to use the real positional `SendMessage(to, from, body, opts...)` signature
- `relay/docs/client-reference.md`: removed phantom `WithJWTToken` (actual: `WithJWT`), `WithDialTag`/`WithDialMaxDuration` (don't exist), client methods `Connect`/`Disconnect`/`Execute`/`Receive`/`Unreceive` that don't exist → documents real lifecycle via `Run()`/`Stop()`
- `relay/docs/call-methods.md`: corrected `Collect`, `Detect`, `SendFax`, `Tap`, `Stream`, `Pay`, `Transcribe`, `Echo`, `BindDigit`, `UserEvent`, `QueueLeave`, `WaitFor`, `Record` signatures; removed ~15 phantom `With*` option constructors
- `relay/docs/events.md`: replaced phantom `ParseEvent` / `CallStateEventFromPayload` with real `NewCallStateEvent(params)` factory; fixed `WaitFor` signature
- `relay/docs/getting-started.md`: removed phantom client `Connect`/`Disconnect`/`Receive`/`Unreceive`; documented fixed-at-construction context subscriptions
- `examples/dynamic_info_gatherer/main.go`: removed nonexistent `prefabs.GatherField`, `SetQuestionCallback`, `SetOnComplete` → rewrote with real `prefabs.Question`/`InfoGathererOptions` API

## Architecture note

`cmd/enumerate-surface/main.go` extended to emit `port_surface_go.json` with Go-native identifiers (16 modules, 178 classes, 686 methods, 188 free functions). Layer B's `port_surface.json` stays Python-reference-shaped for Phase 8 diffing.

## Test plan

- [x] `python3 audit_docs.py --surface port_surface_go.json --ignore DOC_AUDIT_IGNORE.md` — `1423 resolved / 3883 total`, exit 0
- [x] `scripts/compile_examples.sh` — 64 of 64 examples compile (`go build -o /dev/null`)
- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] 200+ entries in DOC_AUDIT_IGNORE.md, every line has a rationale: Go stdlib, Python code blocks from upstream docs (flagged for eventual Go rewrite), Python helpers, port-only illustrative refs

## CI

`.github/workflows/doc-audit.yml` runs on PR + nightly. Clones porting-sdk alongside, enumerates, compiles examples, runs audit_docs, runs go vet + go test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)