### PR TITLE
fix(agent): align AgentBase + AgentServer with Python (re-audit follow-ups)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -360,6 +361,13 @@ type AgentBase struct {
 	sipRoutingEnabled bool
 	sipUsernames      map[string]bool
 
+	// SIP redirect callbacks. Distinct from swml.Service.routingCallbacks:
+	// these callbacks return a route string and trigger an HTTP 307 redirect,
+	// matching Python web_mixin.register_routing_callback semantics
+	// (web_mixin.py:621-635). The swml.Service callbacks return a document
+	// override (richer Go-only semantics).
+	sipRoutingCallbacks map[string]func(r *http.Request, body map[string]any) string
+
 	// MCP integration
 	mcpServers        []map[string]any // external MCP server configs
 	mcpServerEnabled  bool             // expose /mcp endpoint
@@ -408,6 +416,7 @@ func NewAgentBase(opts ...AgentOption) *AgentBase {
 		answerConfig:       make(map[string]any),
 		swaigQueryParams:   make(map[string]string),
 		sipUsernames:       make(map[string]bool),
+		sipRoutingCallbacks: make(map[string]func(r *http.Request, body map[string]any) string),
 		mcpServers:         make([]map[string]any, 0),
 	}
 
@@ -479,6 +488,19 @@ func (a *AgentBase) GetName() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.name
+}
+
+// GetFullURL returns the full URL for this agent's endpoint, optionally
+// embedding basic-auth credentials.
+//
+// Python equivalent: AgentBase.get_full_url(include_auth=False) (agent_base.py:325)
+//
+// The Python implementation handles serverless URL construction (CGI / Lambda /
+// Cloud Functions / Azure) inline. In the Go SDK, serverless URL construction
+// lives in pkg/lambda; this method delegates server-mode URL building to the
+// embedded swml.Service and matches Python's server-mode behavior.
+func (a *AgentBase) GetFullURL(includeAuth bool) string {
+	return a.swmlService.GetFullURL(includeAuth)
 }
 
 // ---------------------------------------------------------------------------
@@ -1736,11 +1758,61 @@ func (a *AgentBase) EnableSipRouting(autoMap bool, path string) *AgentBase {
 // The callback receives the HTTP request and the parsed body. It should return
 // a non-nil map to override the response, or nil to let normal processing continue.
 // This method delegates to swml.Service.RegisterRoutingCallback.
+//
+// For Python-aligned redirect semantics (callback returns a route string and
+// the framework issues an HTTP 307 redirect), use RegisterSipRoutingCallback.
 func (a *AgentBase) RegisterRoutingCallback(callbackFn func(r *http.Request, body map[string]any) map[string]any, path string) {
 	if path == "" {
 		path = "/sip"
 	}
 	a.swmlService.RegisterRoutingCallback(path, callbackFn)
+}
+
+// RegisterSipRoutingCallback registers a callback whose string return value
+// triggers an HTTP 307 Temporary Redirect to that route. An empty return
+// value (or a GET / non-POST request) lets normal SWML processing continue.
+//
+// Python equivalent: web_mixin.WebMixin.register_routing_callback
+// Python signature: register_routing_callback(callback_fn, path="/sip")
+//
+// The Python callback returns Optional[str]; on a non-None return the
+// framework responds with HTTP 307 + Location: route (web_mixin.py:628-635).
+// This method preserves that behavior, in contrast to RegisterRoutingCallback
+// which returns a response document override (a richer Go-only mechanism).
+//
+// Use this form when porting Python code that relies on redirect-based SIP
+// or route-dispatch patterns.
+func (a *AgentBase) RegisterSipRoutingCallback(
+	callbackFn func(r *http.Request, body map[string]any) string,
+	path string,
+) {
+	if path == "" {
+		path = "/sip"
+	}
+	path = strings.TrimRight(path, "/")
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	a.mu.Lock()
+	if a.sipRoutingCallbacks == nil {
+		a.sipRoutingCallbacks = make(map[string]func(r *http.Request, body map[string]any) string)
+	}
+	a.sipRoutingCallbacks[path] = callbackFn
+	a.mu.Unlock()
+}
+
+// sipRoutingCallbackPaths returns the paths registered for SIP-redirect
+// callbacks, sorted for deterministic HTTP endpoint registration.
+func (a *AgentBase) sipRoutingCallbackPaths() []string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	paths := make([]string, 0, len(a.sipRoutingCallbacks))
+	for p := range a.sipRoutingCallbacks {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 // AutoMapSipUsernames automatically registers common SIP usernames derived
@@ -2351,6 +2423,23 @@ func (a *AgentBase) buildMux() *http.ServeMux {
 		mux.HandleFunc(path+"/", a.withAuth(a.handleSWML))
 	}
 
+	// SIP redirect-routing endpoints. Python registers these alongside swml
+	// routing callbacks (single _routing_callbacks map). Go separates them
+	// because the return semantics differ (string→307 redirect vs document
+	// override). handleSWML inspects sipRoutingCallbacks first and emits the
+	// redirect when the callback returns a non-empty string.
+	for _, cbPath := range a.sipRoutingCallbackPaths() {
+		if cbPath == "/" || cbPath == swmlRoute {
+			continue
+		}
+		path := strings.TrimRight(cbPath, "/")
+		if path == "" {
+			continue
+		}
+		mux.HandleFunc(path, a.withAuth(a.handleSWML))
+		mux.HandleFunc(path+"/", a.withAuth(a.handleSWML))
+	}
+
 	return mux
 }
 
@@ -2363,6 +2452,26 @@ func (a *AgentBase) handleSWML(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		r.Body = http.MaxBytesReader(w, r.Body, maxAgentRequestBody)
 		json.NewDecoder(r.Body).Decode(&body)
+	}
+
+	// SIP redirect-routing dispatch. Python web_mixin._handle_request
+	// (web_mixin.py:621-635) checks _routing_callbacks; on a non-None string
+	// return, responds with HTTP 307 Temporary Redirect. Mirror that here
+	// using sipRoutingCallbacks (the parallel string-return registration).
+	// On an empty string return, fall through to the normal SWML pipeline so
+	// the same endpoint can serve as both a redirector and a document source.
+	sipMatchPath := strings.TrimRight(r.URL.Path, "/")
+	if sipMatchPath == "" {
+		sipMatchPath = "/"
+	}
+	a.mu.RLock()
+	sipCb, sipMatched := a.sipRoutingCallbacks[sipMatchPath]
+	a.mu.RUnlock()
+	if sipMatched && r.Method == http.MethodPost && body != nil {
+		if route := sipCb(r, body); route != "" {
+			http.Redirect(w, r, route, http.StatusTemporaryRedirect)
+			return
+		}
 	}
 
 	// Routing-callback dispatch. Python web_mixin._handle_request (line 620)

--- a/pkg/agent/sip_routing_callback_test.go
+++ b/pkg/agent/sip_routing_callback_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Tests covering AgentBase.GetFullURL forwarding and
+// AgentBase.RegisterSipRoutingCallback (Python web_mixin
+// register_routing_callback semantics: string return → HTTP 307 redirect).
+
+func TestGetFullURLForwardsToSwmlService(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithHost("example.com"), WithPort(8080))
+
+	got := a.GetFullURL(false)
+	want := a.swmlService.GetFullURL(false)
+	if got != want {
+		t.Errorf("GetFullURL(false) = %q, want %q (matching swml.Service.GetFullURL)", got, want)
+	}
+
+	gotAuth := a.GetFullURL(true)
+	wantAuth := a.swmlService.GetFullURL(true)
+	if gotAuth != wantAuth {
+		t.Errorf("GetFullURL(true) = %q, want %q", gotAuth, wantAuth)
+	}
+}
+
+func TestSipRoutingCallbackEmitsRedirectOnString(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithBasicAuth("u", "p"))
+
+	const target = "https://elsewhere.example/handoff"
+	a.RegisterSipRoutingCallback(func(r *http.Request, body map[string]any) string {
+		return target
+	}, "/sip")
+
+	req := httptest.NewRequest(http.MethodPost, "/sip", strings.NewReader(`{"call":{"from":"+15555550000"}}`))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d (307); body=%s", rec.Code, http.StatusTemporaryRedirect, rec.Body.String())
+	}
+	if loc := rec.Header().Get("Location"); loc != target {
+		t.Errorf("Location header = %q, want %q", loc, target)
+	}
+}
+
+func TestSipRoutingCallbackFallsThroughOnEmptyString(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithBasicAuth("u", "p"))
+
+	called := false
+	a.RegisterSipRoutingCallback(func(r *http.Request, body map[string]any) string {
+		called = true
+		return "" // fall through to normal SWML pipeline
+	}, "/sip")
+
+	req := httptest.NewRequest(http.MethodPost, "/sip", strings.NewReader(`{"call":{"from":"+15555550000"}}`))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("callback was not invoked")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fall-through to SWML); body=%s", rec.Code, rec.Body.String())
+	}
+	// Empty-string return must not surface as a redirect.
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Errorf("Location header = %q, want empty (no redirect on empty return)", loc)
+	}
+	// Body should be a JSON SWML document, not empty.
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("response body is not JSON: %v\nbody=%s", err, rec.Body.String())
+	}
+	if _, ok := doc["sections"]; !ok {
+		t.Errorf("response body lacks 'sections' key (not a SWML doc); got keys=%v", keys(doc))
+	}
+}
+
+func TestSipRoutingCallbackPathNormalization(t *testing.T) {
+	cases := []struct {
+		name       string
+		registered string
+		want       string
+	}{
+		{"trailing-slash-stripped", "/sip/", "/sip"},
+		{"leading-slash-added", "sip", "/sip"},
+		{"empty-defaults-to-sip", "", "/sip"},
+		{"already-canonical", "/sip", "/sip"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAgentBase(WithName("t"), WithRoute("/svc"))
+			a.RegisterSipRoutingCallback(func(r *http.Request, body map[string]any) string {
+				return ""
+			}, tc.registered)
+
+			paths := a.sipRoutingCallbackPaths()
+			if len(paths) != 1 || paths[0] != tc.want {
+				t.Errorf("registered %q → paths=%v, want [%q]", tc.registered, paths, tc.want)
+			}
+		})
+	}
+}
+
+func TestSipRoutingCallbackIgnoresGetRequests(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithBasicAuth("u", "p"))
+
+	called := false
+	a.RegisterSipRoutingCallback(func(r *http.Request, body map[string]any) string {
+		called = true
+		return "https://elsewhere.example/handoff"
+	}, "/sip")
+
+	// GET should not invoke the SIP callback (Python web_mixin.py:624 only
+	// runs the callback when request.method == "POST" and body is set).
+	req := httptest.NewRequest(http.MethodGet, "/sip", nil)
+	req.SetBasicAuth("u", "p")
+
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if called {
+		t.Error("SIP callback was invoked on GET; should only fire on POST")
+	}
+	if rec.Code == http.StatusTemporaryRedirect {
+		t.Error("GET produced a 307 redirect; should fall through to normal handling")
+	}
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -274,6 +274,34 @@ func (s *AgentServer) RegisterGlobalRoutingCallback(path string, cb swml.Routing
 	s.logger.Info("registered global routing callback at %s on %d agent(s)", path, len(s.agents))
 }
 
+// RegisterGlobalSipRoutingCallback registers a SIP redirect-routing callback
+// across all currently-registered agents at the given path. The callback
+// returns a route string; on a non-empty return the framework responds with
+// HTTP 307 Temporary Redirect (matching Python register_routing_callback
+// semantics — see AgentBase.RegisterSipRoutingCallback for details).
+//
+// Use this form when porting Python AgentServer code that registers a
+// redirect-style global routing callback. For a global response-document
+// override (the richer Go-only mechanism), use RegisterGlobalRoutingCallback.
+func (s *AgentServer) RegisterGlobalSipRoutingCallback(
+	path string,
+	cb func(r *http.Request, body map[string]any) string,
+) {
+	path = strings.TrimRight(path, "/")
+	if len(path) == 0 || path[0] != '/' {
+		path = "/" + path
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, a := range s.agents {
+		a.RegisterSipRoutingCallback(cb, path)
+	}
+
+	s.logger.Info("registered global SIP routing callback at %s on %d agent(s)", path, len(s.agents))
+}
+
 // ---------------------------------------------------------------------------
 // HTTP server
 // ---------------------------------------------------------------------------

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -520,3 +520,106 @@ func TestExtractSipUsername_Empty(t *testing.T) {
 		t.Errorf("expected empty string, got %q", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// RegisterGlobalSipRoutingCallback (Python register_global_routing_callback
+// with redirect-string semantics)
+// ---------------------------------------------------------------------------
+
+func TestRegisterGlobalSipRoutingCallback_FansOutToAllAgents(t *testing.T) {
+	s := NewAgentServer()
+
+	a1 := agent.NewAgentBase(agent.WithName("a1"), agent.WithBasicAuth("u", "p"))
+	a2 := agent.NewAgentBase(agent.WithName("a2"), agent.WithBasicAuth("u", "p"))
+	s.Register(a1, "/a1")
+	s.Register(a2, "/a2")
+
+	const target = "https://elsewhere.example/global"
+	s.RegisterGlobalSipRoutingCallback("/sip", func(r *http.Request, body map[string]any) string {
+		return target
+	})
+
+	// Hit each agent's /sip endpoint and confirm both produce the redirect.
+	for _, route := range []string{"/a1/sip", "/a2/sip"} {
+		req := httptest.NewRequest(http.MethodPost, route, strings.NewReader("{}"))
+		req.SetBasicAuth("u", "p")
+		req.Header.Set("Content-Type", "application/json")
+
+		rec := httptest.NewRecorder()
+		s.buildMux().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusTemporaryRedirect {
+			t.Errorf("%s: status = %d, want 307; body=%s", route, rec.Code, rec.Body.String())
+			continue
+		}
+		if loc := rec.Header().Get("Location"); loc != target {
+			t.Errorf("%s: Location = %q, want %q", route, loc, target)
+		}
+	}
+}
+
+func TestRegisterGlobalSipRoutingCallback_NormalizesPath(t *testing.T) {
+	s := NewAgentServer()
+	a := agent.NewAgentBase(agent.WithName("a"), agent.WithBasicAuth("u", "p"))
+	s.Register(a, "/a")
+
+	// Trailing slash should be stripped; leading slash should be added.
+	s.RegisterGlobalSipRoutingCallback("sip/", func(r *http.Request, body map[string]any) string {
+		return "https://x.example"
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/a/sip", strings.NewReader("{}"))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.buildMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("normalized path did not register correctly; status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// Ensure response-document override (RegisterGlobalRoutingCallback) and
+// redirect-string (RegisterGlobalSipRoutingCallback) variants do not collide
+// when registered on different paths.
+func TestRegisterGlobalSipRoutingCallback_CoexistsWithDocumentVariant(t *testing.T) {
+	s := NewAgentServer()
+	a := agent.NewAgentBase(agent.WithName("a"), agent.WithBasicAuth("u", "p"))
+	s.Register(a, "/a")
+
+	const docMarker = "__doc_override__"
+	s.RegisterGlobalRoutingCallback("/override", func(r *http.Request, body map[string]any) map[string]any {
+		return map[string]any{
+			"version":  docMarker,
+			"sections": map[string]any{"main": []any{}},
+		}
+	})
+	s.RegisterGlobalSipRoutingCallback("/sip", func(r *http.Request, body map[string]any) string {
+		return "https://elsewhere.example"
+	})
+
+	// Document-override path returns SWML doc.
+	req := httptest.NewRequest(http.MethodPost, "/a/override", strings.NewReader("{}"))
+	req.SetBasicAuth("u", "p")
+	rec := httptest.NewRecorder()
+	s.buildMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("override path: status=%d, want 200", rec.Code)
+	} else {
+		var doc map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+			t.Errorf("override path: body not JSON: %v", err)
+		} else if doc["version"] != docMarker {
+			t.Errorf("override path: version=%v, want %q", doc["version"], docMarker)
+		}
+	}
+
+	// SIP path returns 307.
+	req = httptest.NewRequest(http.MethodPost, "/a/sip", strings.NewReader("{}"))
+	req.SetBasicAuth("u", "p")
+	rec = httptest.NewRecorder()
+	s.buildMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Errorf("sip path: status=%d, want 307", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Re-audit of the Go SDK's agents namespace against Python (2026-04-27, post-epic-3 merges) surfaced two open gaps in `AgentBase` + `AgentServer`. Both are addressed here with idiomatic Go that mirrors Python **semantics**, not Python shape.

## Changes

### 1. `AgentBase.GetFullURL(includeAuth bool) string` — P1

Three-line forwarder over `swml.Service.GetFullURL`. Python's `get_full_url` (`agent_base.py:325`) handles serverless URL construction (CGI / Lambda / Cloud Functions / Azure) inline; the Go SDK places that logic in `pkg/lambda`, so the AgentBase forwarder need only delegate the server-mode call.

### 2. `AgentBase.RegisterSipRoutingCallback(fn, path)` + `AgentServer.RegisterGlobalSipRoutingCallback(path, fn)` — P2

String-return variants that issue `HTTP 307 Temporary Redirect`, matching Python `web_mixin.register_routing_callback` semantics (`web_mixin.py:621-635` — non-`None` string return → `307` with `Location: route`).

The existing `RegisterRoutingCallback` (which returns `map[string]any` for response document override) is preserved. The new method is a parallel, narrower API that ports cleanly from Python redirect-style code:

| Method | Callback returns | Behavior on truthy return |
|--------|------------------|---------------------------|
| `RegisterRoutingCallback` (existing) | `map[string]any` | Replaces SWML response document |
| `RegisterSipRoutingCallback` (new) | `string` | HTTP 307 redirect with `Location: <route>` |

Stored in a separate `sipRoutingCallbacks` map on `AgentBase`. `handleSWML` inspects it before the document-override path; on a non-empty string return it issues the redirect, on an empty string it falls through to normal SWML processing (matching Python's `None` semantics).

### Note on prior audit's third gap

The 2026-04-27 audit also flagged `AgentServer.Run()` for missing serverless dispatch documentation. **That is already in place** at `server.go:281-287` from a prior PR — the audit miss was a false positive caused by reading only the LSP-extracted signature, not the doc comment. No change needed.

## Tests

- `pkg/agent/sip_routing_callback_test.go` — 5 new tests:
  - `TestGetFullURLForwardsToSwmlService` — delegation correctness
  - `TestSipRoutingCallbackEmitsRedirectOnString` — 307 + `Location` header
  - `TestSipRoutingCallbackFallsThroughOnEmptyString` — empty return → SWML doc
  - `TestSipRoutingCallbackPathNormalization` — leading/trailing slash + empty default
  - `TestSipRoutingCallbackIgnoresGetRequests` — POST-only invocation (matches Python)
- `pkg/server/server_test.go` — 3 new tests:
  - `TestRegisterGlobalSipRoutingCallback_FansOutToAllAgents`
  - `TestRegisterGlobalSipRoutingCallback_NormalizesPath`
  - `TestRegisterGlobalSipRoutingCallback_CoexistsWithDocumentVariant`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./pkg/agent/... ./pkg/server/...` — all pass (8 new tests + existing)
- [x] `go test ./...` — full SDK suite green, no regressions

## Audit context

This PR closes the two outstanding items from the scoped re-audit at `temp/sdk-alignment/_report-go-agents.md`. Independent of (and not conflicting with) any open PR in epic #3.