### PR TITLE
fix(relay): align EventCallingCallError wire format with Python ("calling.error")

### DIFF
--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -768,9 +768,18 @@ func TestConstants_EventTypes(t *testing.T) {
 		if e == "" {
 			t.Error("found empty calling event constant")
 		}
-		if !contains(e, "calling.call.") {
-			t.Errorf("calling event %q should start with 'calling.call.'", e)
+		if !contains(e, "calling.") {
+			t.Errorf("calling event %q should start with 'calling.'", e)
 		}
+	}
+
+	// Wire-format alignment with signalwire-python: most calling events use
+	// the "calling.call.<verb>" prefix, but EVENT_CALLING_ERROR and
+	// EVENT_CONFERENCE in Python use bare "calling.error" / "calling.conference"
+	// (relay/constants.py:69-70). The constants below must match what the
+	// SignalWire server emits — ParseEvent routes on the literal value.
+	if EventCallingCallError != "calling.error" {
+		t.Errorf("EventCallingCallError = %q, want %q (matches Python EVENT_CALLING_ERROR)", EventCallingCallError, "calling.error")
 	}
 
 	messagingEvents := []string{EventMessagingReceive, EventMessagingState}

--- a/pkg/relay/constants.go
+++ b/pkg/relay/constants.go
@@ -63,7 +63,7 @@ const (
 	EventCallingCallTranscribe = "calling.call.transcribe"
 	EventCallingCallHold       = "calling.call.hold"
 	EventCallingCallConference = "calling.call.conference"
-	EventCallingCallError      = "calling.call.error"
+	EventCallingCallError      = "calling.error"
 	EventCallingCallAI         = "calling.call.ai"
 )
 


### PR DESCRIPTION
## Summary

- `EventCallingCallError` was `"calling.call.error"`; should be `"calling.error"` to match the value the SignalWire server actually emits (Python: `relay/constants.py:70`).
- `ParseEvent`'s switch at `event.go:873` consumes the constant directly, so updating it routes correctly to `NewCallingErrorEvent` automatically — no call-site changes needed.
- Update `TestConstants_EventTypes` which had codified the old (incorrect) `"calling.call."` prefix invariant; replaced with explicit assertion of the corrected wire value.

## Test plan

- [x] `go build ./pkg/relay/` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes
- [x] `go test ./...` passes (whole module)

## Verification against Python

- [`signalwire-python` @ `572ec08`, `relay/constants.py:70`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/constants.py#L70):
  ```python
  EVENT_CALLING_ERROR = "calling.error"
  ```

Closes #128
Refs #3