### PR TITLE
fix(relay): align EventCallingCallConference wire format with Python ("calling.conference")

### DIFF
--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -781,6 +781,9 @@ func TestConstants_EventTypes(t *testing.T) {
 	if EventCallingCallError != "calling.error" {
 		t.Errorf("EventCallingCallError = %q, want %q (matches Python EVENT_CALLING_ERROR)", EventCallingCallError, "calling.error")
 	}
+	if EventCallingCallConference != "calling.conference" {
+		t.Errorf("EventCallingCallConference = %q, want %q (matches Python EVENT_CONFERENCE)", EventCallingCallConference, "calling.conference")
+	}
 
 	messagingEvents := []string{EventMessagingReceive, EventMessagingState}
 	if len(messagingEvents) != 2 {

--- a/pkg/relay/constants.go
+++ b/pkg/relay/constants.go
@@ -62,7 +62,7 @@ const (
 	EventCallingCallEcho       = "calling.call.echo"
 	EventCallingCallTranscribe = "calling.call.transcribe"
 	EventCallingCallHold       = "calling.call.hold"
-	EventCallingCallConference = "calling.call.conference"
+	EventCallingCallConference = "calling.conference"
 	EventCallingCallError      = "calling.error"
 	EventCallingCallAI         = "calling.call.ai"
 )


### PR DESCRIPTION
## Summary

- `EventCallingCallConference` was `"calling.call.conference"`; should be `"calling.conference"` to match the value the SignalWire server actually emits (Python: `relay/constants.py:69`).
- `ParseEvent`'s switch at `event.go:871` consumes the constant directly, so updating it routes correctly to `NewConferenceEvent` automatically — no call-site changes needed.
- Update `TestConstants_EventTypes` to assert the corrected wire value.

## Test plan

- [x] `go build ./pkg/relay/` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

- [`signalwire-python` @ `572ec08`, `relay/constants.py:69`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/constants.py#L69):
  ```python
  EVENT_CONFERENCE = "calling.conference"
  ```

Closes #130
Refs #3

> Note: this PR conflicts with #129 (same file, same `for _, e := range callingEvents` block in `client_test.go`). Whichever lands second will need a trivial rebase — both PRs converge to a `for !contains(e, "calling.") {...}` loop plus a per-constant explicit assertion.