### PR TITLE
fix(relay): remove base Action.Stop() — fabricated calling.stop verb

### DIFF
--- a/pkg/relay/action.go
+++ b/pkg/relay/action.go
@@ -45,19 +45,6 @@ func (a *Action) Wait(ctx context.Context) (*RelayEvent, error) {
 	}
 }
 
-// Stop sends a stop command to the SignalWire server for this action.
-func (a *Action) Stop() error {
-	if a.call == nil || a.call.client == nil {
-		return fmt.Errorf("action not associated with a call or client")
-	}
-	_, err := a.call.client.execute("calling.stop", map[string]any{
-		"node_id":    a.call.nodeID,
-		"call_id":    a.call.callID,
-		"control_id": a.controlID,
-	})
-	return err
-}
-
 // IsDone returns true if the action has completed.
 func (a *Action) IsDone() bool {
 	a.mu.Lock()


### PR DESCRIPTION
## Summary

- Delete `func (a *Action) Stop() error` at `pkg/relay/action.go:48-59`.
- The method emitted `"calling.stop"` — a verb that exists **nowhere** in `signalwire-python` and has **zero callers** in `signalwire-go` (every constructor produces a typed subclass whose own `Stop()` override shadows the base).
- Aligns Go with Python, where `class Action` deliberately has no `stop` — every subclass declares its own (`PlayAction.stop`, `RecordAction.stop`, etc.).

## Test plan

- [x] `go build ./pkg/relay/` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes
- [x] `go test ./...` passes

## Verification against Python

- [`signalwire-python` @ `572ec08`, `relay/call.py:43-88`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/call.py#L43-L88) — base `class Action` has no `stop`. Every subclass (lines 91, 113, 133, 151, 184, 209, 222, 233, 244, 255, 266) defines its own `async def stop`.
- `grep -r "calling.stop" temp/signalwire-python/` → 0 hits.
- `grep -r "calling.stop" temp/signalwire-go/` → 1 hit (the deleted line).

## Impact assessment

- No public API consumers will break: every action is constructed as a typed subclass via `newPlayAction`, `newRecordAction`, etc. — Go's struct embedding means existing `.Stop()` calls resolve to the subclass override, not the base.
- Removes a foot-gun: any future code that handled `[]*Action` and called `.Stop()` would have silently emitted the bogus verb that the platform rejects.

Closes #132
Refs #3