### PR TITLE
fix(relay): make RecordAction.Pause behavior parameter optional (variadic)

### DIFF
--- a/pkg/relay/action.go
+++ b/pkg/relay/action.go
@@ -196,7 +196,9 @@ func (ra *RecordAction) Stop() error {
 
 // Pause pauses the active recording. An optional behavior string may be
 // provided (e.g. "silence" or "skip") to control how the gap is handled.
-func (ra *RecordAction) Pause(behavior string) error {
+// Pass no argument — or "" — to omit behavior, matching Python's
+// pause(behavior: Optional[str] = None) signature.
+func (ra *RecordAction) Pause(behavior ...string) error {
 	if ra.call == nil || ra.call.client == nil {
 		return fmt.Errorf("action not associated with a call or client")
 	}
@@ -205,8 +207,8 @@ func (ra *RecordAction) Pause(behavior string) error {
 		"call_id":    ra.call.callID,
 		"control_id": ra.controlID,
 	}
-	if behavior != "" {
-		params["behavior"] = behavior
+	if len(behavior) > 0 && behavior[0] != "" {
+		params["behavior"] = behavior[0]
 	}
 	_, err := ra.call.client.execute("calling.record.pause", params)
 	return err


### PR DESCRIPTION
## Summary

- Change `(ra *RecordAction).Pause(behavior string) error` → `Pause(behavior ...string) error`.
- Aligns with Python's `pause(behavior: Optional[str] = None)` so the caller can omit behavior entirely.

## Backwards compatibility

- `record.Pause(\"silence\")` — still works (single-arg variadic call)
- `record.Pause(\"\")` — still works (empty sentinel handled internally)
- `record.Pause()` — newly works (matches Python omission semantics)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/call.py:123-127`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/call.py#L123-L127):
```python
async def pause(self, behavior: Optional[str] = None) -> dict:
    params: dict[str, Any] = {\"control_id\": self.control_id}
    if behavior:
        params[\"behavior\"] = behavior
    return await self.call._execute(\"record.pause\", params)
```

Closes #134
Refs #3