### PR TITLE
fix(relay): Call.AIMessage — make controlID truly optional (empty-string omits)

### DIFF
--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -771,14 +771,18 @@ func (c *Call) AmazonBedrock(opts ...AIOption) *AIAction {
 	return c.AI(merged...)
 }
 
-// AIMessage sends a text message within an active AI session. The reset and
-// globalData parameters are optional (nil omits them), matching Python's
-// ai_message(*, message_text, role, reset, global_data).
+// AIMessage sends a text message within an active AI session. All parameters
+// are optional, matching Python's ai_message(*, message_text=None, role=None,
+// reset=None, global_data=None). Pass "" for controlID/text/role and nil for
+// reset/globalData to omit them from the wire payload (Python omits the key
+// entirely when the argument is None).
 func (c *Call) AIMessage(controlID, text, role string, reset map[string]any, globalData map[string]any) error {
 	params := map[string]any{
-		"node_id":    c.nodeID,
-		"call_id":    c.callID,
-		"control_id": controlID,
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+	}
+	if controlID != "" {
+		params["control_id"] = controlID
 	}
 	if text != "" {
 		params["message_text"] = text


### PR DESCRIPTION
## Summary

- Stop unconditionally setting `\"control_id\": controlID` in the wire payload.
- Empty `controlID` now omits the key, matching Python's `ai_message` which has no `control_id` parameter at all.
- Signature unchanged: backwards compatible. Updated doc comment to make the empty-string-omit semantics explicit.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/call.py:1196-1216`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/call.py#L1196-L1216) — Python only writes each key when the argument is provided.

Closes #136
Refs #3