### PR TITLE
fix(relay): Call.AIUnhold — make controlID truly optional (empty-string omits)

### DIFF
--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -814,13 +814,17 @@ func (c *Call) AIHold(controlID string, timeout string, prompt string) error {
 	return err
 }
 
-// AIUnhold removes the call from AI hold. prompt is optional (empty string
-// omits it), matching Python's ai_unhold(*, prompt: str|None).
+// AIUnhold removes the call from AI hold. controlID and prompt are both
+// optional — pass "" to omit either, matching Python's
+// ai_unhold(*, prompt: Optional[str] = None) which has no control_id
+// parameter and only writes keys conditionally.
 func (c *Call) AIUnhold(controlID string, prompt string) error {
 	params := map[string]any{
-		"node_id":    c.nodeID,
-		"call_id":    c.callID,
-		"control_id": controlID,
+		"node_id": c.nodeID,
+		"call_id": c.callID,
+	}
+	if controlID != "" {
+		params["control_id"] = controlID
 	}
 	if prompt != "" {
 		params["prompt"] = prompt


### PR DESCRIPTION
## Summary

Same pattern as #137 / #139.

- Stop unconditionally setting `\"control_id\": controlID` in the wire payload.
- Empty `controlID` now omits the key, matching Python's `ai_unhold` which has no `control_id` parameter.
- Signature unchanged: backwards compatible.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/call.py:1234-1247`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/call.py#L1234-L1247).

Closes #140
Refs #3