### PR TITLE
fix(relay): align Call.UserEvent wire shape with Python

### DIFF
--- a/pkg/relay/call.go
+++ b/pkg/relay/call.go
@@ -978,13 +978,26 @@ func (c *Call) ClearDigitBindings(realm string) error {
 	return err
 }
 
-// UserEvent sends a user-defined event on the call.
-func (c *Call) UserEvent(event map[string]any) error {
-	_, err := c.client.execute("calling.user_event", map[string]any{
+// UserEvent sends a user-defined event on the call. eventName is the
+// custom event identifier; pass "" to omit it. Optional `extra` maps are
+// merged into the top-level wire params (mirroring Python's **kwargs in
+// user_event(*, event: Optional[str] = None, **kwargs)).
+//
+// Wire shape (matches Python): {"event": <eventName>, ...extra}.
+func (c *Call) UserEvent(eventName string, extra ...map[string]any) error {
+	params := map[string]any{
 		"node_id": c.nodeID,
 		"call_id": c.callID,
-		"event":   event,
-	})
+	}
+	if eventName != "" {
+		params["event"] = eventName
+	}
+	for _, m := range extra {
+		for k, v := range m {
+			params[k] = v
+		}
+	}
+	_, err := c.client.execute("calling.user_event", params)
 	return err
 }
 

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -458,14 +458,16 @@ call.ClearDigitBindings()
 
 ## User Events
 
-### `UserEvent(event map[string]any) (map[string]any, error)`
+### `UserEvent(eventName string, extra ...map[string]any) error`
 
-Send a custom event.
+Send a custom event. The eventName is the event identifier (sent as the
+`event` key on the wire). Any extra map(s) are merged into the top-level
+wire params, matching Python's `user_event(*, event: Optional[str] = None,
+**kwargs)`.
 
 ```go
-call.UserEvent(map[string]any{
-	"name": "order_placed",
-	"data": map[string]any{"order_id": "12345"},
+call.UserEvent("order_placed", map[string]any{
+    "order_id": "12345",
 })
 ```
 


### PR DESCRIPTION
## Summary

- Change `Call.UserEvent(event map[string]any) error` → `UserEvent(eventName string, extra ...map[string]any) error`.
- Wire payload now matches Python: `{\"event\": \"<name>\", ...extra}` instead of the previous nested `{\"event\": {<map>}}`.
- Optional `extra` maps merge into top-level params, mirroring Python's `**kwargs`.
- Doc example in `relay/docs/call-methods.md` updated to the new signature.

## Why this is a breaking change

The previous wire shape was wrong (nested map under `\"event\"` instead of a string event name with flat kwargs). Anyone using the method against a real SignalWire server was getting a different payload from what Python sends. Internal grep finds zero call sites in `pkg/`, `cmd/`, `examples/`, `internal/` — only docs reference it.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/call.py:1251-1262`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/call.py#L1251-L1262):
```python
async def user_event(self, *, event: Optional[str] = None, **kwargs: Any) -> dict:
    params: dict[str, Any] = {}
    if event is not None:
        params[\"event\"] = event
    params.update(kwargs)
    return await self._execute(\"user_event\", params)
```

Closes #142
Refs #3