### PR TITLE
feat(relay): add RelayClient.ProjectID() getter

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -92,6 +92,15 @@ func (c *Client) RelayProtocol() string {
 	return c.protocol
 }
 
+// ProjectID returns the configured project ID. Mirrors Python's public
+// client.project attribute, allowing callers to read back the value
+// supplied via WithProject(...) or the SIGNALWIRE_PROJECT_ID env var.
+func (c *Client) ProjectID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.projectID
+}
+
 // Connect establishes the WebSocket connection to SignalWire. This is the
 // public equivalent of the internal connect() method, mirroring Python's
 // async connect() which is also used in the async-with context manager.


### PR DESCRIPTION
## Summary

Add `func (c *Client) ProjectID() string` mirroring Python's public `client.project` attribute. RLock-guarded for thread safety.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:115`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L115).

## Conflict note

This is the first of 5 RelayClient getter PRs (#144, plus follow-ups for Token, JWTToken, Space, Contexts). All 5 add a method in the same vicinity (after `RelayProtocol`). Whichever lands second will need a trivial rebase.

Closes #144
Refs #3