### PR TITLE
feat(relay): add RelayClient.Token() getter

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -101,6 +101,15 @@ func (c *Client) ProjectID() string {
 	return c.projectID
 }
 
+// Token returns the configured API token. Mirrors Python's public
+// client.token attribute, allowing callers to read back the value
+// supplied via WithToken(...) or the SIGNALWIRE_API_TOKEN env var.
+func (c *Client) Token() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.token
+}
+
 // Connect establishes the WebSocket connection to SignalWire. This is the
 // public equivalent of the internal connect() method, mirroring Python's
 // async connect() which is also used in the async-with context manager.


### PR DESCRIPTION
## Summary

Add `func (c *Client) Token() string` mirroring Python's public `client.token` attribute.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:116`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L116).

## Conflict note

Same insertion zone as #145 (ProjectID), #148 (JWTToken), and remaining getter PRs. Trivial rebase needed depending on merge order.

Closes #146
Refs #3