### PR TITLE
feat(relay): add RelayClient.JWTToken() getter

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -110,6 +110,15 @@ func (c *Client) Token() string {
 	return c.token
 }
 
+// JWTToken returns the configured JWT. Mirrors Python's public
+// client.jwt_token attribute, allowing callers to read back the value
+// supplied via WithJWT(...).
+func (c *Client) JWTToken() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.jwtToken
+}
+
 // Connect establishes the WebSocket connection to SignalWire. This is the
 // public equivalent of the internal connect() method, mirroring Python's
 // async connect() which is also used in the async-with context manager.


### PR DESCRIPTION
## Summary

Add `func (c *Client) JWTToken() string` mirroring Python's public `client.jwt_token` attribute.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:117`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L117).

## Conflict note

Same insertion zone as #145 / #147. Trivial rebase depending on merge order.

Closes #148
Refs #3