### PR TITLE
feat(relay): add RelayClient.Space() getter

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -119,6 +119,15 @@ func (c *Client) JWTToken() string {
 	return c.jwtToken
 }
 
+// Space returns the configured SignalWire space hostname. Mirrors Python's
+// public client.host attribute (Python uses the term "host"; Go uses
+// "space" because that's the more accurate noun — see WithSpace).
+func (c *Client) Space() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.space
+}
+
 // Connect establishes the WebSocket connection to SignalWire. This is the
 // public equivalent of the internal connect() method, mirroring Python's
 // async connect() which is also used in the async-with context manager.


### PR DESCRIPTION
## Summary

Add `func (c *Client) Space() string` mirroring Python's public `client.host` attribute. Python uses \"host\" as the term, Go uses \"space\" — both store the SignalWire space hostname. RLock-guarded.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:118`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L118).

## Conflict note

Same insertion zone as #145 / #147 / #149. Trivial rebase depending on merge order.

Closes #150
Refs #3