### PR TITLE
feat(relay): add RelayClient.Contexts() getter

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -128,6 +128,15 @@ func (c *Client) Space() string {
 	return c.space
 }
 
+// Contexts returns a copy of the configured RELAY contexts. Mirrors
+// Python's public client.contexts attribute. The returned slice is a
+// copy — mutating it does not affect the client.
+func (c *Client) Contexts() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string(nil), c.contexts...)
+}
+
 // Connect establishes the WebSocket connection to SignalWire. This is the
 // public equivalent of the internal connect() method, mirroring Python's
 // async connect() which is also used in the async-with context manager.


### PR DESCRIPTION
## Summary

Add `func (c *Client) Contexts() []string` mirroring Python's public `client.contexts` attribute. Returns a defensive copy so callers can't mutate the internal slice.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:119`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L119).

## Conflict note

Last of the 5 RelayClient getter PRs (#145 / #147 / #149 / #151 / this). Same insertion zone — trivial rebase depending on merge order.

Closes #152
Refs #3