### PR TITLE
fix(relay): auto-load SIGNALWIRE_* env defaults in NewRelayClient (match Python)

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -50,6 +50,13 @@ type Client struct {
 }
 
 // NewRelayClient creates a new RELAY Client with the given options.
+//
+// After explicit options are applied, any remaining unset auth/space
+// fields fall back to SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN,
+// SIGNALWIRE_JWT_TOKEN, SIGNALWIRE_SPACE, and RELAY_MAX_ACTIVE_CALLS
+// environment variables — matching Python RelayClient.__init__'s
+// automatic env-var fallback (relay/client.py:115-119). Explicit
+// options always win.
 func NewRelayClient(opts ...ClientOption) *Client {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &Client{
@@ -66,6 +73,7 @@ func NewRelayClient(opts ...ClientOption) *Client {
 	for _, opt := range opts {
 		opt(c)
 	}
+	c.applyEnvDefaults()
 	return c
 }
 

--- a/pkg/relay/options.go
+++ b/pkg/relay/options.go
@@ -368,47 +368,47 @@ func WithMessageOnCompleted(cb func(*Message)) MessageOption {
 	}
 }
 
-// WithEnvDefaults reads SIGNALWIRE_PROJECT_ID, SIGNALWIRE_API_TOKEN,
-// SIGNALWIRE_JWT_TOKEN, SIGNALWIRE_SPACE, and RELAY_MAX_ACTIVE_CALLS from
-// environment variables and applies them as fallback values (only used when the
-// corresponding field has not already been set via another option). This mirrors
-// Python RelayClient.__init__ which reads these env vars automatically.
-//
-// Apply this option first so that explicit WithProject/WithToken/etc. options
-// take precedence:
-//
-//	c := relay.NewRelayClient(
-//	    relay.WithEnvDefaults(),
-//	    relay.WithProject("override"),  // overrides env
-//	)
-func WithEnvDefaults() ClientOption {
-	return func(c *Client) {
-		if c.projectID == "" {
-			c.projectID = os.Getenv("SIGNALWIRE_PROJECT_ID")
-		}
-		if c.token == "" {
-			c.token = os.Getenv("SIGNALWIRE_API_TOKEN")
-		}
-		if c.jwtToken == "" {
-			c.jwtToken = os.Getenv("SIGNALWIRE_JWT_TOKEN")
-		}
-		if c.space == "" {
-			c.space = os.Getenv("SIGNALWIRE_SPACE")
-		}
-		if c.maxActiveCalls == 0 {
-			if v := os.Getenv("RELAY_MAX_ACTIVE_CALLS"); v != "" {
-				n := 0
-				for _, ch := range v {
-					if ch < '0' || ch > '9' {
-						n = 0
-						break
-					}
-					n = n*10 + int(ch-'0')
+// applyEnvDefaults fills any unset auth/space fields from SIGNALWIRE_*
+// environment variables. Called automatically at the end of
+// NewRelayClient (mirroring Python RelayClient.__init__'s env-var
+// fallback at relay/client.py:115-119). Idempotent — calling again
+// after fields are populated is a no-op.
+func (c *Client) applyEnvDefaults() {
+	if c.projectID == "" {
+		c.projectID = os.Getenv("SIGNALWIRE_PROJECT_ID")
+	}
+	if c.token == "" {
+		c.token = os.Getenv("SIGNALWIRE_API_TOKEN")
+	}
+	if c.jwtToken == "" {
+		c.jwtToken = os.Getenv("SIGNALWIRE_JWT_TOKEN")
+	}
+	if c.space == "" {
+		c.space = os.Getenv("SIGNALWIRE_SPACE")
+	}
+	if c.maxActiveCalls == 0 {
+		if v := os.Getenv("RELAY_MAX_ACTIVE_CALLS"); v != "" {
+			n := 0
+			for _, ch := range v {
+				if ch < '0' || ch > '9' {
+					n = 0
+					break
 				}
-				if n > 0 {
-					c.maxActiveCalls = n
-				}
+				n = n*10 + int(ch-'0')
+			}
+			if n > 0 {
+				c.maxActiveCalls = n
 			}
 		}
+	}
+}
+
+// WithEnvDefaults is now a no-op pass-through retained for backwards
+// compatibility — env defaults are loaded automatically at the end of
+// NewRelayClient (mirroring Python RelayClient.__init__). New code can
+// rely on the auto-load behavior and omit this option entirely.
+func WithEnvDefaults() ClientOption {
+	return func(c *Client) {
+		c.applyEnvDefaults()
 	}
 }


### PR DESCRIPTION
## Summary

- Extract env-loading logic into internal `(*Client).applyEnvDefaults()`.
- Call it automatically at the end of `NewRelayClient` after explicit options run, so user-supplied values still win.
- Keep `WithEnvDefaults()` as an idempotent pass-through for backwards compatibility.
- New callers can omit `WithEnvDefaults()` and env auto-loads anyway, mirroring Python.

## Backwards compatibility

- Explicit `WithProject(\"x\")`/etc. still take precedence (env only fills empty fields).
- Existing callers that pass `WithEnvDefaults()` keep working — `applyEnvDefaults` is idempotent (set-if-empty).
- Empty env vars produce empty fields (same as Python's `os.environ.get(..., \"\")`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:115-119`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L115-L119):
```python
self.project = project or os.environ.get(\"SIGNALWIRE_PROJECT_ID\", \"\")
self.token = token or os.environ.get(\"SIGNALWIRE_API_TOKEN\", \"\")
self.jwt_token = jwt_token or os.environ.get(\"SIGNALWIRE_JWT_TOKEN\", \"\")
self.host = host or os.environ.get(\"SIGNALWIRE_SPACE\", DEFAULT_RELAY_HOST)
```

Closes #154
Refs #3