### PR TITLE
docs(relay): document RelayClient.Stop() = Python's disconnect()

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -156,6 +156,10 @@ func (c *Client) Run() error {
 }
 
 // Stop gracefully shuts down the client connection.
+//
+// Equivalent to Python's RelayClient.disconnect() (relay/client.py:286).
+// Python users porting code can search for "disconnect" and find this
+// method by its rename.
 func (c *Client) Stop() {
 	c.running.Store(false)
 	c.cancel()


### PR DESCRIPTION
## Summary

Add a doc comment on `(*Client).Stop()` calling out that this is the rename of Python's `RelayClient.disconnect()`. Helps Python users porting code find the symbol by its old name.

No code change.

## Test plan

- [x] `go build ./...` clean

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/client.py:286`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/client.py#L286).

Closes #156
Refs #3