### PR TITLE
fix(relay): Message on_completed callback receives terminal event (align with Python)

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -228,9 +228,9 @@ func (c *Client) SendMessage(to, from, body string, opts ...MessageOption) (*Mes
 	}
 
 	// Extract internal-only options that must not be sent over the wire.
-	var onCompleted func(*Message)
+	var onCompleted func(*Message, *RelayEvent)
 	if v, ok := params["_on_completed"]; ok {
-		onCompleted, _ = v.(func(*Message))
+		onCompleted, _ = v.(func(*Message, *RelayEvent))
 		delete(params, "_on_completed")
 	}
 

--- a/pkg/relay/message.go
+++ b/pkg/relay/message.go
@@ -24,7 +24,7 @@ type Message struct {
 	mu     sync.Mutex
 
 	completed   bool
-	onCompleted func(*Message)
+	onCompleted func(*Message, *RelayEvent)
 
 	eventHandlers []func(*RelayEvent)
 }
@@ -133,7 +133,7 @@ func (m *Message) updateState(event *RelayEvent) {
 	copy(handlers, m.eventHandlers)
 
 	terminal := isTerminalMessageState(newState)
-	var onCompleted func(*Message)
+	var onCompleted func(*Message, *RelayEvent)
 	if terminal && !m.completed {
 		m.completed = true
 		m.result = event
@@ -147,7 +147,7 @@ func (m *Message) updateState(event *RelayEvent) {
 
 	if terminal {
 		if onCompleted != nil {
-			go onCompleted(m)
+			go onCompleted(m, event)
 		}
 		select {
 		case <-m.done:

--- a/pkg/relay/options.go
+++ b/pkg/relay/options.go
@@ -360,9 +360,11 @@ func WithMessageContext(ctx string) MessageOption {
 }
 
 // WithMessageOnCompleted registers a callback invoked when the message reaches
-// a terminal state (delivered, undelivered, or failed). Mirrors Python's
-// send_message(on_completed=...) parameter.
-func WithMessageOnCompleted(cb func(*Message)) MessageOption {
+// a terminal state (delivered, undelivered, or failed). The callback receives
+// both the message and the terminal RelayEvent, mirroring Python's
+// _on_completed callback contract (relay/message.py:115-117) which receives
+// the event directly. Mirrors Python's send_message(on_completed=...) parameter.
+func WithMessageOnCompleted(cb func(*Message, *RelayEvent)) MessageOption {
 	return func(m map[string]any) {
 		m["_on_completed"] = cb
 	}


### PR DESCRIPTION
## Summary

- Change `WithMessageOnCompleted(cb func(*Message))` → `WithMessageOnCompleted(cb func(*Message, *RelayEvent))`.
- The callback now receives both the message and the terminal `RelayEvent`, matching Python's `_on_completed(event)` contract (relay/message.py:115-117).
- Update `Message.onCompleted` field type, `updateState` invocation site (`go onCompleted(m, event)`), and the type assertion in `Client.SendMessage`.

## Why this is a breaking change

Without the event in the callback signature, callers had to do `msg.Result()` inside the callback — extra ceremony and diverges from Python's contract. Verified zero external callers (only the option function declaration and a comment in `client.go`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./pkg/relay/` clean
- [x] `go test ./pkg/relay/` passes

## Verification against Python

[`signalwire-python` @ `572ec08`, `relay/message.py:115-117`](https://github.com/signalwire/signalwire-python/blob/572ec08/signalwire/signalwire/relay/message.py#L115-L117):
```python
if self._on_completed is not None:
    try:
        result = self._on_completed(event)
```

Closes #158
Refs #3