### PR TITLE
fix(relay): CallReceiveEvent reads "protocol" wire key when "context" is absent

### DIFF
--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -255,6 +255,59 @@ func TestCallReceiveEvent(t *testing.T) {
 	}
 }
 
+// TestCallReceiveEvent_ProtocolFallback covers the wire-key fallback that
+// Python's CallReceiveEvent.from_payload performs:
+//
+//	context=p.get("context", p.get("protocol", ""))
+//
+// SIP-originated inbound receive events carry the routing identifier under
+// "protocol" instead of "context"; Go must read either key.
+func TestCallReceiveEvent_ProtocolFallback(t *testing.T) {
+	t.Run("protocol only (SIP-originated)", func(t *testing.T) {
+		e := NewCallReceiveEvent(map[string]any{
+			"call_id":  "call-3",
+			"protocol": "sip-inbound",
+		})
+		if e.Context != "sip-inbound" {
+			t.Errorf("Context = %q, want %q (fell back to protocol key)", e.Context, "sip-inbound")
+		}
+	})
+
+	t.Run("context wins over protocol when both present", func(t *testing.T) {
+		e := NewCallReceiveEvent(map[string]any{
+			"call_id":  "call-4",
+			"context":  "office",
+			"protocol": "sip-inbound",
+		})
+		if e.Context != "office" {
+			t.Errorf("Context = %q, want %q (context must win when present)", e.Context, "office")
+		}
+	})
+
+	t.Run("neither key present yields empty string", func(t *testing.T) {
+		e := NewCallReceiveEvent(map[string]any{
+			"call_id": "call-5",
+		})
+		if e.Context != "" {
+			t.Errorf("Context = %q, want empty string", e.Context)
+		}
+	})
+
+	t.Run("explicit empty context wins over present protocol", func(t *testing.T) {
+		// Python's p.get("context", p.get("protocol", "")) returns the value
+		// at "context" when the key is present — even if that value is "".
+		// Go must use a key-presence check, not an empty-string check.
+		e := NewCallReceiveEvent(map[string]any{
+			"call_id":  "call-6",
+			"context":  "",
+			"protocol": "sip-inbound",
+		})
+		if e.Context != "" {
+			t.Errorf("Context = %q, want empty string (explicit empty context must not fall back to protocol)", e.Context)
+		}
+	})
+}
+
 func TestPlayEvent(t *testing.T) {
 	e := NewPlayEvent(map[string]any{
 		"control_id": "ctrl-1",

--- a/pkg/relay/event.go
+++ b/pkg/relay/event.go
@@ -244,7 +244,17 @@ func NewCallReceiveEvent(params map[string]any) *CallReceiveEvent {
 	e.CallState = e.GetString("call_state")
 	e.Direction = e.GetString("direction")
 	e.Device = e.GetMap("device")
-	e.Context = e.GetString("context")
+	// SIP-originated receive events carry routing under "protocol" instead of
+	// "context". Mirrors Python relay/event.py CallReceiveEvent.from_payload:
+	//   context=p.get("context", p.get("protocol", ""))
+	// Use a key-presence check (not an empty-string check) so an explicitly
+	// empty "context" wins over a present "protocol", matching Python's
+	// dict.get default semantics.
+	if _, ok := e.Params["context"]; ok {
+		e.Context = e.GetString("context")
+	} else {
+		e.Context = e.GetString("protocol")
+	}
 	e.Tag = e.GetString("tag")
 	e.CallID = e.GetString("call_id")
 	e.NodeID = e.GetString("node_id")


### PR DESCRIPTION
## Summary

`NewCallReceiveEvent` now mirrors Python's `CallReceiveEvent.from_payload` two-key fallback chain:

```python
context=p.get("context", p.get("protocol", ""))
```

SIP-originated inbound receive events carry the routing identifier under `"protocol"` rather than `"context"`. Before this change, Go read only `"context"` and returned `""` for SIP receivers, breaking application code that branches on `Context` to dispatch SIP vs non-SIP routes.

## Implementation

```go
if _, ok := e.Params["context"]; ok {
    e.Context = e.GetString("context")
} else {
    e.Context = e.GetString("protocol")
}
```

A key-presence check (rather than empty-string check) preserves Python's `dict.get` default semantics: an explicitly empty `"context"` value wins over a present `"protocol"`.

## Wire-input parity matrix

| Input | Python `context` | Go `Context` (after fix) |
|-------|------------------|--------------------------|
| `{"context": "office"}` | `"office"` | `"office"` |
| `{"protocol": "sip-inbound"}` | `"sip-inbound"` | `"sip-inbound"` |
| `{"context": "office", "protocol": "sip"}` | `"office"` | `"office"` |
| `{"context": "", "protocol": "sip"}` | `""` | `""` |
| `{}` | `""` | `""` |

## Tests

`TestCallReceiveEvent_ProtocolFallback` covers all four divergent input shapes:

1. `protocol` only (SIP-originated)
2. `context` wins when both keys present
3. Neither key present → `""`
4. Explicit empty `context` wins over present `protocol`

## Provenance

Surfaced by the 2026-04-27 v2 Go relay alignment audit. The audit found this was the only residual gap in the relay namespace after the 16 prior fix PRs (#129–#159) merged. Independent source-verified validation confirmed the gap (`temp/sdk-alignment/validated/go/_VALIDATED_REPORT_RELAY_V2.md`).

Closing this brings the Go relay namespace to full parity with Python.

## Test plan
- [x] `go build ./...` — passes
- [x] `go vet ./pkg/relay/...` — passes
- [x] `go test ./pkg/relay/...` — passes (all sub-cases of `TestCallReceiveEvent_ProtocolFallback` green)
- [x] `go test ./...` — full suite passes