### PR TITLE
ci: add dedicated unit test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go vet ./...
+      - run: go test -race ./...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` that runs `go vet ./...` and `go test -race ./...` on every PR and push to `main`
- Mirrors the structure of [`signalwire-typescript`'s `test.yml`](https://github.com/signalwire/signalwire-typescript/blob/main/.github/workflows/test.yml) — no path filters, simple two-step Go setup + test

## Why
The existing `doc-audit.yml` runs `go test ./...` as its last step, but it's gated by path filters (`docs/**`, `examples/**`, `pkg/**`, `cmd/enumerate-surface/**`). PRs touching only `internal/`, `cmd/swaig-test/`, top-level Go files, or test files in unrelated locations don't trigger it, so failing unit tests can land on `main` undetected. This workflow closes that gap.

`-race` matches the `go test -race` example in `CLAUDE.md`'s standard test commands and catches goroutine bugs that pure unit tests miss.

## Verification
Locally on `a1b24d2` (latest `main`): `go vet ./...` passes, `go test -race ./...` is green across all 17 packages.

## Follow-ups (not in this PR)
- The redundant `go vet` and `go test` steps at the bottom of `doc-audit.yml` could be removed once this workflow is enforced as a required check, since they'll duplicate work on PRs that match doc-audit's path filter.
- Consider marking the new `test` job as a required status check on the `main` branch protection rule.

## Test plan
- [ ] `Test` workflow appears on this PR and goes green
- [ ] Verify `Test` runs on a follow-up PR that touches a non-doc-audit path (e.g. `internal/` or top-level)
- [ ] Configure branch protection to require the `Test` check before merge