### PR TITLE
align(rest): Fabric address sub-resources, CxmlApplications.ListAddresses, ShortCodes.List params

### DIFF
--- a/pkg/rest/namespaces/fabric.go
+++ b/pkg/rest/namespaces/fabric.go
@@ -158,6 +158,11 @@ func (r *CxmlApplicationsResource) Create(_ map[string]any) (map[string]any, err
 	return nil, errors.New("cXML applications cannot be created via this API")
 }
 
+// ListAddresses lists addresses for a cXML application.
+func (r *CxmlApplicationsResource) ListAddresses(id string, params map[string]string) (map[string]any, error) {
+	return r.HTTP.Get(r.Path(id, "addresses"), params)
+}
+
 // ---------- AutoMaterializedWebhook resources ----------
 
 // AutoMaterializedWebhookResource is a Fabric webhook resource that is
@@ -316,8 +321,8 @@ type FabricNamespace struct {
 	// PhoneNumbers.SetSwmlWebhook / SetCxmlWebhook for creation. Direct
 	// .Create still works for backcompat but emits a deprecation warning.
 	SWMLWebhooks *AutoMaterializedWebhookResource
-	AIAgents     *CrudResource
-	SIPGateways  *CrudResource
+	AIAgents     *CrudWithAddresses
+	SIPGateways  *CrudWithAddresses
 	CXMLWebhooks *AutoMaterializedWebhookResource
 
 	// Special resources
@@ -348,8 +353,8 @@ func NewFabricNamespace(client HTTPClient) *FabricNamespace {
 			helperName:     "phone_numbers.SetSwmlWebhook(sid, url)",
 			deprecationKey: "SWMLWebhooks.Create",
 		},
-		AIAgents:    NewCrudResource(client, base+"/ai_agents"),
-		SIPGateways: NewCrudResource(client, base+"/sip_gateways"),
+		AIAgents:    NewCrudWithAddresses(client, base+"/ai_agents"),
+		SIPGateways: NewCrudWithAddresses(client, base+"/sip_gateways"),
 		CXMLWebhooks: &AutoMaterializedWebhookResource{
 			CrudResource:   NewCrudResource(client, base+"/cxml_webhooks"),
 			helperName:     "phone_numbers.SetCxmlWebhook(sid, url, opts)",

--- a/pkg/rest/namespaces/namespaces_test.go
+++ b/pkg/rest/namespaces/namespaces_test.go
@@ -466,8 +466,8 @@ func TestFabricNamespace_PATCHResources(t *testing.T) {
 	// PATCH-update resources
 	patchResources := []*CrudResource{
 		f.SWMLWebhooks.CrudResource,
-		f.AIAgents,
-		f.SIPGateways,
+		f.AIAgents.CrudResource,
+		f.SIPGateways.CrudResource,
 		f.CXMLWebhooks.CrudResource,
 	}
 	for _, r := range patchResources {

--- a/pkg/rest/namespaces/short_codes.go
+++ b/pkg/rest/namespaces/short_codes.go
@@ -7,6 +7,8 @@
 
 package namespaces
 
+import "fmt"
+
 // ShortCodesNamespace provides short code management (read + update only).
 type ShortCodesNamespace struct {
 	Resource
@@ -20,8 +22,12 @@ func NewShortCodesNamespace(client HTTPClient) *ShortCodesNamespace {
 }
 
 // List lists all short codes.
-func (r *ShortCodesNamespace) List(params map[string]string) (map[string]any, error) {
-	return r.HTTP.Get(r.Base, params)
+func (r *ShortCodesNamespace) List(params map[string]any) (map[string]any, error) {
+	str := make(map[string]string, len(params))
+	for k, v := range params {
+		str[k] = fmt.Sprint(v)
+	}
+	return r.HTTP.Get(r.Base, str)
 }
 
 // Get retrieves a short code by ID.


### PR DESCRIPTION
## What this PR does

Aligns three interfaces in `pkg/rest/namespaces/` with their Python counterparts, implementing the gaps surfaced by the 2026-04-27 cross-SDK alignment audit (LSP-verified, double-validated).

**Interfaces in this PR:**
- `CxmlApplicationsResource` — closes #162 (1 P1 gap)
- `FabricNamespace` — closes #163 (2 P1 gaps)
- `ShortCodesResource` (Go: `ShortCodesNamespace`) — closes #164 (1 P2 gap)

## Why

The Fabric address sub-resource hierarchy was the standout finding. Both audit runs initially treated Python's `FabricResource → CrudResource` chain as a flat type unification and dismissed `client.fabric.ai_agents` / `client.fabric.sip_gateways` as already-aligned. LSP-verified validation showed they actually inherit `list_addresses` via `CrudWithAddresses` — and the Go fields, typed `*CrudResource`, made `ListAddresses` unreachable. `CxmlApplicationsResource` had the same gap by inheritance through `FabricResourcePUT(CrudWithAddresses)`. The Go SDK already defines `*CrudWithAddresses` with `ListAddresses` (in `pkg/rest/namespaces/common.go`), so the fix is small: change the field types for AIAgents/SIPGateways, switch the factory init to `NewCrudWithAddresses`, and add a `ListAddresses` method to `CxmlApplicationsResource` that follows the same pattern as `GenericResources.ListAddresses`.

`ShortCodesResource.List` is a small intra-file consistency fix: the file's `Update` method already takes `map[string]any`, while `List` was the odd one out at `map[string]string`, forcing callers to manually string-convert numeric/boolean query values. The HTTPClient.Get interface is unchanged — conversion is done internally with `fmt.Sprint`.

## Changes

### `CxmlApplicationsResource` (#162)

| Symbol | Category | Python reference | Fix applied | Test impact |
|--------|----------|------------------|-------------|-------------|
| `ListAddresses` | MISSING_METHOD (P1) | [`signalwire/rest/namespaces/fabric.py:121`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/fabric.py#L121) → inherits `list_addresses` from `CrudWithAddresses` via `FabricResourcePUT` ([`fabric.py:24`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/fabric.py#L24)) → [`_base.py:112`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/_base.py#L112) | Added `func (r *CxmlApplicationsResource) ListAddresses(id string, params map[string]string) (map[string]any, error) { return r.HTTP.Get(r.Path(id, "addresses"), params) }` to `pkg/rest/namespaces/fabric.go` (mirrors `GenericResources.ListAddresses`) | None — pure addition |

### `FabricNamespace` (#163)

| Symbol | Category | Python reference | Fix applied | Test impact |
|--------|----------|------------------|-------------|-------------|
| `AIAgents` field | MISSING_METHOD (`ListAddresses`) on field (P1) | [`fabric.py:226`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/fabric.py#L226) — `FabricResource(http, …/ai_agents)` | Field type `*CrudResource → *CrudWithAddresses`; init `NewCrudResource → NewCrudWithAddresses` | `TestFabricNamespace_PATCHResources` updated to use `f.AIAgents.CrudResource` (the embedded pointer); PATCH-method assertion preserved |
| `SIPGateways` field | MISSING_METHOD (`ListAddresses`) on field (P1) | [`fabric.py:227`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/fabric.py#L227) — `FabricResource(http, …/sip_gateways)` | Same as `AIAgents` for the SIP gateways URL | Same test update covers this field |

### `ShortCodesResource` (#164)

| Symbol | Category | Python reference | Fix applied | Test impact |
|--------|----------|------------------|-------------|-------------|
| `List` params type | TYPE_MISMATCH (P2) | [`signalwire/rest/namespaces/short_codes.py:23`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/short_codes.py#L23) — `def list(self, **params)` | `params map[string]string → map[string]any` in `pkg/rest/namespaces/short_codes.go`; values converted internally with `fmt.Sprint` before passing to `HTTPClient.Get` (which still requires `map[string]string`) | None — no callers in repo passed `map[string]string` literals to `List` |

## Python reference

- [`signalwire/rest/namespaces/fabric.py`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/fabric.py) — `FabricResource`, `FabricResourcePUT`, `CxmlApplicationsResource`, `FabricNamespace`
- [`signalwire/rest/_base.py`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/_base.py) — `CrudWithAddresses.list_addresses`
- [`signalwire/rest/namespaces/short_codes.py`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/short_codes.py) — `ShortCodesResource.list`

Pinned reference SHA: `572ec08cfa36cd9287b3c38b64a07f961c261c38` (signalwire-python v3.0.1).

## Verification

- [x] `go build ./...` passes in clean worktree (no errors)
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (full repo, ~16 packages)
- [x] LSP hover (gopls) re-verified before each edit; line numbers checked against current source
- [x] No `TODO`, `FIXME`, "not yet implemented", or partial-implementation escape hatches in the diff
- [x] No unrelated files touched (3 files changed, +19 / -8)

## Auto-closes

Closes #162
Closes #163
Closes #164

Refs epic #3.

When this PR merges, GitHub auto-closes each interface issue above via the `Closes #N` keyword. Epic #3 will need to be closed manually once all of its sub-issues are done.
