### PR TITLE
align(rest): add Python-name type aliases for 6 *Namespace types

### DIFF
--- a/pkg/rest/namespaces/addresses.go
+++ b/pkg/rest/namespaces/addresses.go
@@ -38,3 +38,7 @@ func (r *AddressesNamespace) Get(id string) (map[string]any, error) {
 func (r *AddressesNamespace) Delete(id string) (map[string]any, error) {
 	return r.HTTP.Delete(r.Path(id))
 }
+
+// AddressesResource is an alias for AddressesNamespace, matching the Python
+// class name for cross-SDK parity. Prefer AddressesNamespace in new Go code.
+type AddressesResource = AddressesNamespace

--- a/pkg/rest/namespaces/lookup.go
+++ b/pkg/rest/namespaces/lookup.go
@@ -25,3 +25,7 @@ func NewLookupNamespace(client HTTPClient) *LookupNamespace {
 func (r *LookupNamespace) PhoneNumber(e164 string, params map[string]string) (map[string]any, error) {
 	return r.HTTP.Get(r.Path("phone_number", e164), params)
 }
+
+// LookupResource is an alias for LookupNamespace, matching the Python class
+// name for cross-SDK parity. Prefer LookupNamespace in new Go code.
+type LookupResource = LookupNamespace

--- a/pkg/rest/namespaces/pubsub.go
+++ b/pkg/rest/namespaces/pubsub.go
@@ -23,3 +23,7 @@ func NewPubSubNamespace(client HTTPClient) *PubSubNamespace {
 func (r *PubSubNamespace) CreateToken(data map[string]any) (map[string]any, error) {
 	return r.HTTP.Post(r.Base, data, nil)
 }
+
+// PubSubResource is an alias for PubSubNamespace, matching the Python class
+// name for cross-SDK parity. Prefer PubSubNamespace in new Go code.
+type PubSubResource = PubSubNamespace

--- a/pkg/rest/namespaces/recordings.go
+++ b/pkg/rest/namespaces/recordings.go
@@ -48,3 +48,7 @@ func (r *RecordingsNamespace) Get(id string) (map[string]any, error) {
 func (r *RecordingsNamespace) Delete(id string) (map[string]any, error) {
 	return r.HTTP.Delete(r.Path(id))
 }
+
+// RecordingsResource is an alias for RecordingsNamespace, matching the Python
+// class name for cross-SDK parity. Prefer RecordingsNamespace in new Go code.
+type RecordingsResource = RecordingsNamespace

--- a/pkg/rest/namespaces/short_codes.go
+++ b/pkg/rest/namespaces/short_codes.go
@@ -33,3 +33,7 @@ func (r *ShortCodesNamespace) Get(id string) (map[string]any, error) {
 func (r *ShortCodesNamespace) Update(id string, data map[string]any) (map[string]any, error) {
 	return r.HTTP.Put(r.Path(id), data)
 }
+
+// ShortCodesResource is an alias for ShortCodesNamespace, matching the Python
+// class name for cross-SDK parity. Prefer ShortCodesNamespace in new Go code.
+type ShortCodesResource = ShortCodesNamespace

--- a/pkg/rest/namespaces/sip_profile.go
+++ b/pkg/rest/namespaces/sip_profile.go
@@ -28,3 +28,7 @@ func (r *SipProfileNamespace) Get() (map[string]any, error) {
 func (r *SipProfileNamespace) Update(data map[string]any) (map[string]any, error) {
 	return r.HTTP.Put(r.Base, data)
 }
+
+// SipProfileResource is an alias for SipProfileNamespace, matching the Python
+// class name for cross-SDK parity. Prefer SipProfileNamespace in new Go code.
+type SipProfileResource = SipProfileNamespace


### PR DESCRIPTION
## What this PR does

Adds Python-name type aliases for 6 REST namespace types in `pkg/rest/namespaces/`. This is the validated REST audit's [Option A](https://github.com/signalwire/docs/blob/main/temp/sdk-alignment/_report-go-rest.md): cross-SDK doc parity without renaming the canonical Go type.

**Interfaces in this PR:**
- `AddressesResource` — closes #166
- `LookupResource` — closes #167
- `PubSubResource` — closes #169
- `RecordingsResource` — closes #170
- `ShortCodesResource` — closes #171
- `SipProfileResource` — closes #172

(`PhoneNumbersResource` is in a sibling PR — it carries an additional `Search` param-type widening.)

## Why

The Go SDK uses a uniform `*Namespace` suffix; the Python SDK uses `*Resource`. The cross-SDK alignment audit flagged this 7 times, then validation reclassified it as IDIOMATIC because the suffix is consistent inside Go. The recommended fix (Option A in the report) was to add one-line type aliases — preserves Python class-name compatibility for cross-SDK docs and ports without touching the Go type. Two files in the same package already ship these aliases:

- [`queues.go:39`](https://github.com/signalwire/signalwire-go/blob/956d7a398530a6d00e390074a38ff9fb9be9c6ac/pkg/rest/namespaces/queues.go#L39) — `type QueuesResource = QueuesNamespace`
- [`number_groups.go:44`](https://github.com/signalwire/signalwire-go/blob/956d7a398530a6d00e390074a38ff9fb9be9c6ac/pkg/rest/namespaces/number_groups.go#L44) — `type NumberGroupsResource = NumberGroupsNamespace`

This PR brings the remaining 6 in line with that precedent.

## Changes

| File | Alias added | Closes |
|------|-------------|--------|
| `pkg/rest/namespaces/addresses.go` | `type AddressesResource = AddressesNamespace` | #166 |
| `pkg/rest/namespaces/lookup.go` | `type LookupResource = LookupNamespace` | #167 |
| `pkg/rest/namespaces/pubsub.go` | `type PubSubResource = PubSubNamespace` | #169 |
| `pkg/rest/namespaces/recordings.go` | `type RecordingsResource = RecordingsNamespace` | #170 |
| `pkg/rest/namespaces/short_codes.go` | `type ShortCodesResource = ShortCodesNamespace` | #171 |
| `pkg/rest/namespaces/sip_profile.go` | `type SipProfileResource = SipProfileNamespace` | #172 |

Total: **6 files, +24 lines, no other changes.**

Each alias has the same comment block (matching the precedent in `queues.go`):

```go
// FooResource is an alias for FooNamespace, matching the Python class
// name for cross-SDK parity. Prefer FooNamespace in new Go code.
type FooResource = FooNamespace
```

Type aliases are zero-cost: `*Namespace` and `*Resource` are the exact same Go type at compile time.

## Python reference

Each alias is named after the Python class at the equivalent path:

- [`signalwire/rest/namespaces/addresses.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/addresses.py#L17)
- [`signalwire/rest/namespaces/lookup.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/lookup.py#L17)
- [`signalwire/rest/namespaces/pubsub.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/pubsub.py#L17)
- [`signalwire/rest/namespaces/recordings.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/recordings.py#L17)
- [`signalwire/rest/namespaces/short_codes.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/short_codes.py#L17)
- [`signalwire/rest/namespaces/sip_profile.py:17`](https://github.com/signalwire/signalwire-python/blob/572ec08cfa36cd9287b3c38b64a07f961c261c38/signalwire/rest/namespaces/sip_profile.py#L17)

Pinned reference SHA: `572ec08cfa36cd9287b3c38b64a07f961c261c38` (signalwire-python v3.0.1).

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (16 packages)
- [x] No method bodies, struct definitions, or factory functions touched — aliases only
- [x] Pattern matches existing precedent (`queues.go`, `number_groups.go`)

## Auto-closes

Closes #166
Closes #167
Closes #169
Closes #170
Closes #171
Closes #172
