### PR TITLE
ci: run the full 6-gate run-ci.sh in CI (close the EMISSION/NO-CHEAT coverage gap)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,13 @@
 name: Test
+
+# Runs the full per-port CI gate set via scripts/run-ci.sh:
+#   TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION
+# Mirrors `bash scripts/run-ci.sh` exactly so there's no drift between local
+# and CI behavior. Previously this workflow ran only `go vet` + `go test`,
+# which left the EMISSION and NO-CHEAT gates unenforced on every Go PR — a
+# behavioral-emission regression (wrong to_dict()/ToMap() shape) could land
+# green. run-ci.sh closes that hole.
+
 env:
   # Opt into Node.js 24 ahead of GitHub's 2026-06-02 default switch.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -12,10 +21,58 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - name: Checkout signalwire-go
+        uses: actions/checkout@v5
         with:
-          go-version-file: go.mod
+          path: signalwire-go
+
+      - name: Checkout porting-sdk (mock servers + audit scripts + EMISSION corpus)
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/porting-sdk
+          path: porting-sdk
+          token: ${{ secrets.PORTING_SDK_TOKEN }}
+
+      # The EMISSION gate compares this port's ToMap()/to_value() output against
+      # the signalwire-python oracle (FunctionResult), which pulls fastapi via
+      # signalwire/__init__. Check it out as a sibling so the gate has its
+      # reference (it is NOT present in this per-port workflow otherwise).
+      - name: Checkout signalwire-python (EMISSION oracle)
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/signalwire-python
+          path: signalwire-python
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: signalwire-go/go.mod
           cache: true
-      - run: go vet ./...
-      - run: go test -race ./...
+          cache-dependency-path: signalwire-go/go.sum
+
+      - name: Set up Python (porting-sdk audit scripts + mock servers)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python test harnesses (mock_relay + mock_signalwire)
+        run: |
+          pip install -e porting-sdk/test_harness/mock_relay
+          pip install -e porting-sdk/test_harness/mock_signalwire
+
+      # The EMISSION gate needs `import signalwire` (the oracle). Install it from
+      # the adjacent checkout only if it isn't already importable.
+      - name: Install signalwire-python (EMISSION oracle) if not importable
+        run: |
+          if python -c "import signalwire.core.function_result" 2>/dev/null; then
+            echo "signalwire-python already importable; skipping install"
+          else
+            pip install ./signalwire-python
+          fi
+
+      - name: Run CI gate script (TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION)
+        working-directory: signalwire-go
+        env:
+          PORTING_SDK: ${{ github.workspace }}/porting-sdk
+        run: bash scripts/run-ci.sh


### PR DESCRIPTION
Wires the existing 6-gate `scripts/run-ci.sh` into CI so every PR is guarded by **all six** gates (TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION), not a partial subset.

**The gap:** this port had a complete `run-ci.sh` + emit-corpus tool, but no workflow invoked it — so the **EMISSION** gate (byte-compares this port's emitted action shape against the signalwire-python `to_dict()` oracle over the shared corpus) and **NO-CHEAT** gate ran nowhere. A behavioral-emission regression (wrong action name, invented/dropped keys, wrong value types) could land green while the surface stayed drift-0.

**The fix:** run `bash scripts/run-ci.sh` (the same script used locally — no local/CI drift), with the mock harnesses + the signalwire-python EMISSION oracle checked out as a sibling. Mirrors the java/ruby/rust/dotnet `test.yml` workflows that already do this.

Part of a 4-PR batch closing this gap on go, typescript, perl, and cpp (the 4 ports that were missing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)