### PR TITLE
test(relay): kill the 600s CI hang — timeout-guard event waits + self-diagnosing dumps

### DIFF
--- a/pkg/relay/inbound_call_mock_test.go
+++ b/pkg/relay/inbound_call_mock_test.go
@@ -286,7 +286,11 @@ func TestRelay_HangupInHandlerJournalsCallingEnd(t *testing.T) {
 		CallID:     "c-hangup",
 		AutoStates: []string{"created"},
 	})
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
+	}
 	time.Sleep(100 * time.Millisecond)
 
 	ends := h.JournalRecv(t, "calling.end")
@@ -318,7 +322,11 @@ func TestRelay_PassInHandlerJournalsCallingPass(t *testing.T) {
 		CallID:     "c-pass",
 		AutoStates: []string{"created"},
 	})
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
+	}
 	time.Sleep(100 * time.Millisecond)
 
 	passes := h.JournalRecv(t, "calling.pass")
@@ -603,7 +611,12 @@ func TestRelay_ScenarioPlayFullInboundFlow(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("handler did not fire in scenario_play timeline")
 	}
-	result := <-resultCh
+	var result map[string]any
+	select {
+	case result = <-resultCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ScenarioPlay did not return within 10s")
+	}
 	if result["status"] != "completed" {
 		t.Fatalf("scenario didn't complete: %v", result)
 	}
@@ -636,7 +649,11 @@ func TestRelay_InboundCallJournalSendRecordsCallingCallReceive(t *testing.T) {
 		CallID:     "c-wire",
 		AutoStates: []string{"created"},
 	})
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
+	}
 
 	sends := h.JournalSend(t, "calling.call.receive")
 	if len(sends) == 0 {

--- a/pkg/relay/inbound_call_mock_test.go
+++ b/pkg/relay/inbound_call_mock_test.go
@@ -289,6 +289,7 @@ func TestRelay_HangupInHandlerJournalsCallingEnd(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
+		h.DumpDiagnostics(t, "OnCall handler did not fire within 5s")
 		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -325,6 +326,7 @@ func TestRelay_PassInHandlerJournalsCallingPass(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
+		h.DumpDiagnostics(t, "OnCall handler did not fire within 5s")
 		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -615,6 +617,7 @@ func TestRelay_ScenarioPlayFullInboundFlow(t *testing.T) {
 	select {
 	case result = <-resultCh:
 	case <-time.After(10 * time.Second):
+		h.DumpDiagnostics(t, "ScenarioPlay did not return within 10s")
 		t.Fatal("ScenarioPlay did not return within 10s")
 	}
 	if result["status"] != "completed" {
@@ -652,6 +655,7 @@ func TestRelay_InboundCallJournalSendRecordsCallingCallReceive(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
+		h.DumpDiagnostics(t, "OnCall handler did not fire within 5s")
 		t.Fatal("OnCall handler did not fire within 5s (mock inbound-call event not dispatched)")
 	}
 

--- a/pkg/relay/internal/mocktest/mocktest.go
+++ b/pkg/relay/internal/mocktest/mocktest.go
@@ -364,6 +364,80 @@ func valOrDefault(v, d string) string {
 	return v
 }
 
+// getJSON is a non-fatal GET+decode used by DumpDiagnostics so that dumping
+// state on a failure path never itself calls t.Fatalf (which would mask the
+// original failure). Returns the raw body on decode error.
+func (h *Harness) getJSON(path string, out any) (string, error) {
+	resp, err := h.httpClient.Get(h.HTTPURL + path)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if out != nil {
+		if err := json.Unmarshal(body, out); err != nil {
+			return string(body), err
+		}
+	}
+	return string(body), nil
+}
+
+// DumpDiagnostics writes the full mock-server journal and live WS sessions to
+// the test log. Call it right before failing an event-driven wait so that an
+// intermittent CI failure ("handler never fired") is self-diagnosing: the dump
+// shows whether the server sent the event at all, over which session, and
+// whether the SDK's session was still connected. It never fails the test
+// itself (best-effort, swallows transport errors) so it can run on the failure
+// path without masking the original cause.
+//
+// `context` is a short label (usually the wait that timed out) included at the
+// top of the dump.
+func (h *Harness) DumpDiagnostics(t *testing.T, context string) {
+	t.Helper()
+	t.Logf("=== mocktest diagnostics: %s ===", context)
+
+	// Live sessions: the most decisive signal for "event never fired" — if the
+	// SDK's session is absent/closed here, the push had nowhere to go.
+	var sess struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if raw, err := h.getJSON("/__mock__/sessions", &sess); err != nil {
+		t.Logf("  sessions: <unavailable: %v> raw=%q", err, raw)
+	} else if len(sess.Sessions) == 0 {
+		t.Logf("  sessions: NONE (no live WS session — a push would be dropped)")
+	} else {
+		for i, s := range sess.Sessions {
+			t.Logf("  session[%d]: %v", i, s)
+		}
+	}
+
+	// Full journal in arrival order, both directions, with session attribution
+	// so a send-to-wrong-session race is visible.
+	var entries []JournalEntry
+	if raw, err := h.getJSON("/__mock__/journal", &entries); err != nil {
+		t.Logf("  journal: <unavailable: %v> raw=%q", err, raw)
+		return
+	}
+	if len(entries) == 0 {
+		t.Logf("  journal: EMPTY (server saw no frames in either direction)")
+		return
+	}
+	t.Logf("  journal: %d frame(s) in arrival order:", len(entries))
+	for i, e := range entries {
+		desc := e.Method
+		if e.Direction == "send" && e.Method == "signalwire.event" {
+			desc = "signalwire.event:" + e.EventType()
+		}
+		t.Logf("    [%d] t=%.3f %-4s %-28s sess=%s conn=%s id=%s",
+			i, e.Timestamp, e.Direction, desc,
+			valOrDefault(e.SessionID, "-"), valOrDefault(e.ConnectionID, "-"),
+			valOrDefault(e.RequestID, "-"))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Server lifecycle
 // ---------------------------------------------------------------------------

--- a/pkg/relay/outbound_call_mock_test.go
+++ b/pkg/relay/outbound_call_mock_test.go
@@ -210,6 +210,7 @@ func TestRelay_DialAutoGeneratesUUIDTagWhenOmitted(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(8 * time.Second):
+		h.DumpDiagnostics(t, "answer-pushing goroutine did not finish within 8s")
 		t.Fatal("answer-pushing goroutine did not finish within 8s (dial tag never observed in journal?)")
 	}
 	if err != nil {

--- a/pkg/relay/outbound_call_mock_test.go
+++ b/pkg/relay/outbound_call_mock_test.go
@@ -207,7 +207,11 @@ func TestRelay_DialAutoGeneratesUUIDTagWhenOmitted(t *testing.T) {
 		[][]map[string]any{{phoneDevice("", "")}},
 		relay.WithDialClientTimeout(5*time.Second),
 	)
-	<-done
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		t.Fatal("answer-pushing goroutine did not finish within 8s (dial tag never observed in journal?)")
+	}
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}


### PR DESCRIPTION
## Problem

The cross-port matrix intermittently failed `go test ./pkg/relay` at **600.103s** — Go's default per-package timeout, i.e. a **hang**, not a slow test. The package runs in ~9s locally and could not be reproduced here (green at `-count=5` and under `-race` — no data races).

The CI goroutine dump showed a `readLoop` parked on `ReadMessage`, and the relay tests contained several **unguarded** event-driven receives (`<-done`, `<-resultCh`) waiting for a WS-event-driven `OnCall` handler to fire. Under the slower/contended CI runner, if that inbound-call event is delayed or dropped, the bare receive blocks forever and wedges the whole package for 10 minutes.

## Fix (2 commits)

1. **Guard the receives** — wrap each event-driven receive in `select { case <-ch: case <-time.After(...): t.Fatal(...) }`. An infinite hang becomes a fast, labelled failure (5–10s vs sub-ms local dispatch, so a trip = a genuine delivery failure, not a tight-timeout false alarm). 5 sites across `inbound_call_mock_test.go` (×4) and `outbound_call_mock_test.go` (×1).

2. **Make a trip self-diagnosing** — `Harness.DumpDiagnostics(t, context)` dumps the mock's live WS sessions + full frame journal (both directions, session-attributed) to the test log right before each event-wait `t.Fatal`. A future intermittent failure is then root-causable **from the CI log alone**: it shows whether the server actually *sent* the event (and on which session) vs. whether the SDK's session was even alive — pinpointing mock-side vs SDK-side without a local repro. Verified by forcing a timeout (dump correctly showed the live session + the `calling.call.receive` send frame).

## Verification

- `go test ./pkg/relay` green; `-count=5` green (42s); `-race` clean (no data races).
- Forced-timeout probe confirmed the diagnostic output is useful, then reverted.

This eliminates the unacceptable 600s wedge deterministically and instruments the residual (CI-load-sensitive) event-delivery question so any recurrence is a precise, fast signal instead of a 10-minute black box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)