### PR TITLE
test(relay): give /scenario_play a 30s HTTP timeout (fix the residual flake)

### DIFF
--- a/pkg/relay/internal/mocktest/mocktest.go
+++ b/pkg/relay/internal/mocktest/mocktest.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -224,7 +225,17 @@ func (h *Harness) post(t *testing.T, path string, body any) []byte {
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := h.httpClient.Do(req)
+	// Most control-plane calls are fast (the shared 2s-timeout client is fine).
+	// `/__mock__/scenario_play` is the exception: it plays a scripted timeline
+	// SYNCHRONOUSLY (sleep_ms steps + event round-trips) and only responds when
+	// the whole timeline completes, so under CI load it routinely exceeds 2s.
+	// Use a generous per-call timeout for it so the POST doesn't spuriously
+	// "context deadline exceeded" while the server is legitimately mid-timeline.
+	client := h.httpClient
+	if strings.Contains(path, "/scenario_play") {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("mocktest: %s: %v", path, err)
 	}


### PR DESCRIPTION
Follow-up to #202. After #202 merged (timeout-guards + self-diagnosing dumps), the cross-port matrix surfaced the **real** relay flake — and the diagnostics pinpointed it.

## What the dump showed

`TestRelay_ScenarioPlayFullInboundFlow` failed at **10s** (the test-side guard), *not* the 600s hang #202 fixed:

```
mocktest: /__mock__/scenario_play: Post ".../__mock__/scenario_play":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
=== mocktest diagnostics: ScenarioPlay did not return within 10s ===
  session[0]: ... (live)
  journal: [4] send signalwire.event:calling.call.receive ... [6] recv calling.answer ...
```

The journal proves the scenario **did** run (receive event sent, SDK answered) and the session was live — so it wasn't event delivery. It was the control-plane **POST itself giving up**.

## Root cause

The mocktest HTTP client has a global **2s** timeout, but `/__mock__/scenario_play` plays its scripted timeline **synchronously** (`sleep_ms` steps + event round-trips) and only sends response headers when the whole timeline completes. Under CI load that exceeds 2s → spurious `context deadline exceeded`.

## Fix

`scenario_play` (the one inherently-slow synchronous endpoint) gets its own **30s**-timeout client; the fast 2s client still covers the quick control-plane calls (journal/sessions/push/health). Ordering preserved: the test's 10s `select` guard still fires before the 30s client, so a genuine server hang fails fast with the diagnostic dump rather than a raw HTTP error.

Verified: relay package green at `-count=2`/`-count=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)