### PR TITLE
lint: expand golangci linter set + promote it to a blocking gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 # Runs the full per-port CI gate set via scripts/run-ci.sh:
 #   TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION
+#   → FMT → LINT (go vet + golangci-lint) → DOC-AUDIT → SURFACE-DIFF
 # Mirrors `bash scripts/run-ci.sh` exactly so there's no drift between local
 # and CI behavior. Previously this workflow ran only `go vet` + `go test`,
 # which left the EMISSION and NO-CHEAT gates unenforced on every Go PR — a
@@ -51,6 +52,18 @@ jobs:
           cache: true
           cache-dependency-path: signalwire-go/go.sum
 
+      # Install golangci-lint (install-only) so run-ci.sh's LINT gate
+      # (go vet + golangci-lint) finds it on PATH. The official action handles
+      # caching + pinning; the version here MUST stay in lockstep with the note
+      # in scripts/run-ci.sh. We do NOT lint via the action — run-ci.sh is the
+      # single canonical entry point and invokes golangci with the repo's
+      # .golangci.yml itself.
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          install-only: true
+
       - name: Set up Python (porting-sdk audit scripts + mock servers)
         uses: actions/setup-python@v6
         with:
@@ -71,7 +84,7 @@ jobs:
             pip install ./signalwire-python
           fi
 
-      - name: Run CI gate script (TEST → SIGNATURES → DRIFT → SURFACE-FRESH → NO-CHEAT → EMISSION)
+      - name: "Run CI gate script (10 gates: TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF)"
         working-directory: signalwire-go
         env:
           PORTING_SDK: ${{ github.workspace }}/porting-sdk

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,8 @@ linters:
     - prealloc         # slice preallocation (perf) — applied
     - unconvert        # redundant type conversions — removed
     - errname          # sentinel errors named errXxx — renamed
+    - errorlint        # err != sentinel fails on wrapped errors — switched to errors.Is
+    - predeclared      # param shadowing a predeclared builtin (max) — renamed
     - gocritic         # mixed; assignOp/ifElseChain/unlambda fixed, 3 appendAssign //nolint'd as intentional
     # Zero-hit guards (clean today; the bug class CAN occur here, so they protect
     # against regressions — adopted on value, not on hit-count):
@@ -41,6 +43,7 @@ linters:
     - bidichk          # dangerous bidi unicode (trojan-source)
     - reassign         # reassigning stdlib/pkg-level vars
     - recvcheck        # mixed value/pointer receivers on one type
+    - wastedassign     # assignments whose value is never read (clean today)
   # DELIBERATELY NOT ADOPTED (measured + sampled — they fire on idiomatic Go in
   # this codebase, 0 real issues; adopting would mean //nolint on correct code):
   #   nilerr        — flags the filepath.Walk continue-on-error idiom + graceful
@@ -53,6 +56,15 @@ linters:
   #                   helper has one caller; not a real defect.
   #   bodyclose     — all sites are expect-failure TLS tests (untrusted.Get that
   #                   must error) where there is no response body to close.
+  #   goprintffuncname — would rename logger.Debug/Info/Warn/Error to *f; those
+  #                   are public API named to mirror Python's logger.debug/info,
+  #                   so renaming both breaks the API and diverges from parity.
+  #   usetesting    — os.Setenv -> t.Setenv in tests; the existing manual
+  #                   save/restore is already correct, and t.Setenv("",..) sets
+  #                   empty (not unset), changing LookupEnv semantics — net style,
+  #                   not a bug. Revisit if we standardize test env handling.
+  #   dupword       — single hit is a legitimate rendered-markdown test fixture
+  #                   ("## Top\n\nTop body"), a false positive on correct data.
   settings:
     staticcheck:
       checks:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,39 @@ version: "2"
 linters:
   # The curated-standard set: errcheck, govet, ineffassign, staticcheck, unused.
   default: standard
+  # Additional linters adopted after a measured survey of all ~95 disabled
+  # linters (each run against the codebase; findings sampled for real-vs-noise).
+  # Every linter here either found GENUINE issues that were fixed by hand, or is
+  # clean today and guards an applicable bug class (a zero-hit linter is a free
+  # regression guard — it's only worthless when the bug class can't occur here).
+  enable:
+    - forcetypeassert  # unchecked x.(T) panics — 388 sites fixed (test helper `as[T]`)
+    - errchkjson       # unchecked json.Marshal(any) can silently fail — fixed
+    - intrange         # Go 1.22 integer range — modernized
+    - prealloc         # slice preallocation (perf) — applied
+    - unconvert        # redundant type conversions — removed
+    - errname          # sentinel errors named errXxx — renamed
+    - gocritic         # mixed; assignOp/ifElseChain/unlambda fixed, 3 appendAssign //nolint'd as intentional
+    # Zero-hit guards (clean today; the bug class CAN occur here, so they protect
+    # against regressions — adopted on value, not on hit-count):
+    - durationcheck    # time.Duration multiplication mistakes
+    - makezero         # make([]T, len) then append (double-length bug)
+    - nilnesserr       # returning a nil error after a non-nil err check
+    - bidichk          # dangerous bidi unicode (trojan-source)
+    - reassign         # reassigning stdlib/pkg-level vars
+    - recvcheck        # mixed value/pointer receivers on one type
+  # DELIBERATELY NOT ADOPTED (measured + sampled — they fire on idiomatic Go in
+  # this codebase, 0 real issues; adopting would mean //nolint on correct code):
+  #   nilerr        — flags the filepath.Walk continue-on-error idiom + graceful
+  #                   fallbacks (return nil to keep walking is correct).
+  #   contextcheck  — flags the defensive `if ctx == nil { ctx = Background() }`
+  #                   guard on RunContext/DialContext, which DO honor the caller's ctx.
+  #   nilnil        — flags `return nil, nil` meaning "absent, and not an error"
+  #                   (a tool with no output / a selector matching nothing).
+  #   unparam       — flags test-helper params that are constant because the
+  #                   helper has one caller; not a real defect.
+  #   bodyclose     — all sites are expect-failure TLS tests (untrusted.Get that
+  #                   must error) where there is no response body to close.
   settings:
     staticcheck:
       checks:

--- a/cmd/enumerate-signatures/main.go
+++ b/cmd/enumerate-signatures/main.go
@@ -266,7 +266,7 @@ func funcTypeString(t *ast.FuncType) string {
 			if len(f.Names) > 0 {
 				n = len(f.Names)
 			}
-			for i := 0; i < n; i++ {
+			for range n {
 				args = append(args, ts)
 			}
 		}
@@ -279,7 +279,7 @@ func funcTypeString(t *ast.FuncType) string {
 			if len(f.Names) > 0 {
 				n = len(f.Names)
 			}
-			for i := 0; i < n; i++ {
+			for range n {
 				results = append(results, ts)
 			}
 		}
@@ -498,7 +498,7 @@ func translateFunc(t string, aliases map[string]string, ctx string) (string, *tr
 	// Find matching closing paren for args
 	depth := 1
 	var argEnd int
-	for i := 0; i < len(rest); i++ {
+	for i := range len(rest) {
 		switch rest[i] {
 		case '(':
 			depth++

--- a/cmd/enumerate-surface/main.go
+++ b/cmd/enumerate-surface/main.go
@@ -526,7 +526,10 @@ func stripGen(b []byte) string {
 		return string(b)
 	}
 	delete(m, "generated_from")
-	out, _ := json.MarshalIndent(m, "", "  ")
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return string(b)
+	}
 	return string(out)
 }
 

--- a/examples/gather_per_question_functions_demo/main.go
+++ b/examples/gather_per_question_functions_demo/main.go
@@ -27,6 +27,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/signalwire/signalwire-go/pkg/agent"
 	"github.com/signalwire/signalwire-go/pkg/contexts"
@@ -161,6 +162,9 @@ func main() {
 		SetEnd(true)
 
 	doc := a.RenderSWML(nil, nil)
-	b, _ := json.MarshalIndent(doc, "", "  ")
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		log.Fatalf("failed to render SWML: %v", err)
+	}
 	fmt.Println(string(b))
 }

--- a/examples/session_state/main.go
+++ b/examples/session_state/main.go
@@ -108,6 +108,7 @@ func main() {
 			// The existing cart_items array in global_data gets the new entry
 			var items []any
 			if existingItems, ok := globalData["cart_items"].([]any); ok {
+				//nolint:gocritic // appendAssign: deliberately derives a new cart slice from the global-data value, stored back via UpdateGlobalData; existingItems is not reused.
 				items = append(existingItems, newItem)
 			} else {
 				items = []any{newItem}

--- a/examples/step_function_inheritance_demo/main.go
+++ b/examples/step_function_inheritance_demo/main.go
@@ -35,6 +35,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/signalwire/signalwire-go/pkg/agent"
 	"github.com/signalwire/signalwire-go/pkg/swaig"
@@ -132,6 +133,9 @@ func main() {
 	// Render the SWML document so you can see exactly which steps have
 	// a `functions` key in the output and which don't.
 	doc := a.RenderSWML(nil, nil)
-	b, _ := json.MarshalIndent(doc, "", "  ")
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		log.Fatalf("failed to render SWML: %v", err)
+	}
 	fmt.Println(string(b))
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1165,7 +1165,8 @@ func (a *AgentBase) AddLanguageTyped(name, code, voice string, speechFillers, fu
 
 	// Voice formatting: prefer explicit engine/model params; then try to parse
 	// "engine.voice:model" combined format; otherwise use voice string as-is.
-	if engine != "" || model != "" {
+	switch {
+	case engine != "" || model != "":
 		lang["voice"] = voice
 		if engine != "" {
 			lang["engine"] = engine
@@ -1173,7 +1174,7 @@ func (a *AgentBase) AddLanguageTyped(name, code, voice string, speechFillers, fu
 		if model != "" {
 			lang["model"] = model
 		}
-	} else if strings.Contains(voice, ".") && strings.Contains(voice, ":") {
+	case strings.Contains(voice, ".") && strings.Contains(voice, ":"):
 		// Parse "engine.voice:model" combined format
 		parts := strings.SplitN(voice, ":", 2)
 		if len(parts) == 2 {
@@ -1189,17 +1190,18 @@ func (a *AgentBase) AddLanguageTyped(name, code, voice string, speechFillers, fu
 		} else {
 			lang["voice"] = voice
 		}
-	} else {
+	default:
 		lang["voice"] = voice
 	}
 
 	// Fillers
-	if len(speechFillers) > 0 && len(functionFillers) > 0 {
+	switch {
+	case len(speechFillers) > 0 && len(functionFillers) > 0:
 		lang["speech_fillers"] = speechFillers
 		lang["function_fillers"] = functionFillers
-	} else if len(speechFillers) > 0 {
+	case len(speechFillers) > 0:
 		lang["fillers"] = speechFillers
-	} else if len(functionFillers) > 0 {
+	case len(functionFillers) > 0:
 		lang["fillers"] = functionFillers
 	}
 
@@ -2972,14 +2974,15 @@ func (a *AgentBase) handleSWML(w http.ResponseWriter, r *http.Request) {
 	modifications := a.OnSwmlRequest(body, callbackPath, r)
 
 	var doc map[string]any
-	if callbackPath != "" {
+	switch {
+	case callbackPath != "":
 		// The swml service's OnRequest dispatches to the registered callback
 		// and returns the callback's result; if the callback returns nil,
 		// OnRequest falls back to the default rendered document.
 		doc = a.Service.OnRequest(body, callbackPath)
-	} else if hasDynamic {
+	case hasDynamic:
 		doc = a.handleDynamicConfig(body, r)
-	} else {
+	default:
 		doc = a.RenderSWML(body, r)
 	}
 
@@ -3381,7 +3384,7 @@ func (a *AgentBase) withSignedPost(next http.HandlerFunc) http.HandlerFunc {
 		TrustProxy:   a.signingKeyTrustProxy,
 		ProxyURLBase: a.proxyURLBase,
 	})
-	wrapped := mw(http.HandlerFunc(next))
+	wrapped := mw(next)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			next(w, r)

--- a/pkg/agent/agent_run_ctx_test.go
+++ b/pkg/agent/agent_run_ctx_test.go
@@ -25,7 +25,11 @@ func agentFreePort(t *testing.T) int {
 		t.Fatalf("agentFreePort: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
-	return ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected *net.TCPAddr, got %T", ln.Addr())
+	}
+	return addr.Port
 }
 
 func portToStr(n int) string {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -184,7 +184,10 @@ func TestPromptAddSection_WithBullets(t *testing.T) {
 	a := NewAgentBase()
 	a.PromptAddSection("Rules", "", []string{"Be polite", "Be concise"})
 
-	sections := a.GetPrompt().([]map[string]any)
+	sections, ok := a.GetPrompt().([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", a.GetPrompt())
+	}
 	bullets, ok := sections[0]["bullets"].([]string)
 	if !ok {
 		t.Fatal("expected bullets as []string")
@@ -210,8 +213,14 @@ func TestPromptAddToSection(t *testing.T) {
 	a.PromptAddSection("Info", "Line 1", nil)
 	a.PromptAddToSection("Info", "Line 2")
 
-	sections := a.GetPrompt().([]map[string]any)
-	body := sections[0]["body"].(string)
+	sections, ok := a.GetPrompt().([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", a.GetPrompt())
+	}
+	body, ok := sections[0]["body"].(string)
+	if !ok {
+		t.Fatalf("expected string body, got %T", sections[0]["body"])
+	}
 	if body != "Line 1\nLine 2" {
 		t.Errorf("expected appended body, got %q", body)
 	}
@@ -222,7 +231,10 @@ func TestPromptAddSubsection(t *testing.T) {
 	a.PromptAddSection("Parent", "parent body", nil)
 	a.PromptAddSubsection("Parent", "Child", "child body", nil)
 
-	sections := a.GetPrompt().([]map[string]any)
+	sections, ok := a.GetPrompt().([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", a.GetPrompt())
+	}
 	subs, ok := sections[0]["subsections"].([]map[string]any)
 	if !ok || len(subs) != 1 {
 		t.Fatal("expected 1 subsection")
@@ -243,7 +255,10 @@ func TestSetPromptPom(t *testing.T) {
 	if !a.usePom {
 		t.Error("expected usePom=true after SetPromptPom")
 	}
-	sections := a.GetPrompt().([]map[string]any)
+	sections, ok := a.GetPrompt().([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", a.GetPrompt())
+	}
 	if len(sections) != 1 || sections[0]["title"] != "Section1" {
 		t.Error("unexpected POM content")
 	}
@@ -667,7 +682,10 @@ func TestRenderSWML_BasicStructure(t *testing.T) {
 		}
 		if _, hasAI := vm["ai"]; hasAI {
 			foundAI = true
-			aiConfig := vm["ai"].(map[string]any)
+			aiConfig, ok := vm["ai"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected map[string]any, got %T", vm["ai"])
+			}
 
 			// Check prompt
 			promptCfg, ok := aiConfig["prompt"].(map[string]any)
@@ -690,11 +708,11 @@ func TestRenderSWML_WithPOM(t *testing.T) {
 	a.PromptAddSection("Rules", "", []string{"Be polite"})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			promptCfg, ok := aiCfg["prompt"].(map[string]any)
 			if !ok {
@@ -718,11 +736,11 @@ func TestRenderSWML_AutoAnswerFalse(t *testing.T) {
 	a.SetPromptText("Hello")
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if _, hasAnswer := vm["answer"]; hasAnswer {
 			t.Error("answer verb should not be present when autoAnswer=false")
 		}
@@ -744,11 +762,11 @@ func TestRenderSWML_WithTools(t *testing.T) {
 	})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			swaigCfg, ok := aiCfg["SWAIG"].(map[string]any)
 			if !ok {
@@ -793,11 +811,11 @@ func TestRenderSWML_WithParams(t *testing.T) {
 		SetGlobalData(map[string]any{"company": "SW"})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			// Check params
 			params, ok := aiCfg["params"].(map[string]any)
@@ -836,12 +854,12 @@ func TestRenderSWML_WithRecordCall(t *testing.T) {
 	a.SetPromptText("Bot")
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	foundRecord := false
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if _, has := vm["record_call"]; has {
 			foundRecord = true
 		}
@@ -859,17 +877,17 @@ func TestRenderSWML_PreAndPostVerbs(t *testing.T) {
 	a.AddPostAiVerb("hangup", map[string]any{})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	// First verb should be play (pre-answer)
-	first := main[0].(map[string]any)
+	first := as[map[string]any](t, main[0])
 	if _, hasPlay := first["play"]; !hasPlay {
 		t.Error("expected first verb to be play (pre-answer)")
 	}
 
 	// Last verb should be hangup (post-ai)
-	last := main[len(main)-1].(map[string]any)
+	last := as[map[string]any](t, main[len(main)-1])
 	if _, hasHangup := last["hangup"]; !hasHangup {
 		t.Error("expected last verb to be hangup (post-ai)")
 	}
@@ -881,11 +899,11 @@ func TestRenderSWML_WithPostPrompt(t *testing.T) {
 		SetPostPrompt("Summarize the call.")
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			ppCfg, ok := aiCfg["post_prompt"].(map[string]any)
 			if !ok {
@@ -910,11 +928,11 @@ func TestRenderSWML_WithNativeFunctions(t *testing.T) {
 		SetNativeFunctions([]string{"transfer", "hangup"})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			nf, ok := aiCfg["native_functions"].([]string)
 			if !ok {
@@ -936,11 +954,11 @@ func TestRenderSWML_WithContexts(t *testing.T) {
 	ctx.AddStep("greeting").SetText("Hello!")
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			ctxs, ok := aiCfg["contexts"].(map[string]any)
 			if !ok {
@@ -960,11 +978,11 @@ func TestRenderSWML_WithDebugEvents(t *testing.T) {
 	a.SetPromptText("Bot").EnableDebugEvents(2)
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			if aiCfg["debug_events"] != 2 {
 				t.Errorf("expected debug_events=2, got %v", aiCfg["debug_events"])
@@ -995,13 +1013,13 @@ func TestDynamicConfigCallback(t *testing.T) {
 	body := map[string]any{}
 	doc := a.handleDynamicConfig(body, req)
 
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
-			promptCfg := aiCfg["prompt"].(map[string]any)
+			promptCfg := as[map[string]any](t, aiCfg["prompt"])
 			if promptCfg["text"] != "Hello, Alice!" {
 				t.Errorf("expected dynamic prompt, got %v", promptCfg["text"])
 			}
@@ -1023,7 +1041,7 @@ func TestDynamicConfig_DoesNotMutateOriginal(t *testing.T) {
 	a.handleDynamicConfig(nil, req)
 
 	// Original agent should be unchanged
-	prompt := a.GetPrompt().(string)
+	prompt := as[string](t, a.GetPrompt())
 	if prompt != "Original" {
 		t.Errorf("original agent was mutated: %q", prompt)
 	}
@@ -1352,11 +1370,11 @@ func TestRenderSWML_WithFunctionIncludes(t *testing.T) {
 	a.AddFunctionInclude("https://remote.com/swaig", []string{"tool_a"}, nil)
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			swaigCfg, ok := aiCfg["SWAIG"].(map[string]any)
 			if !ok {
@@ -1384,11 +1402,11 @@ func TestRenderSWML_WithPronunciations(t *testing.T) {
 	a.AddPronunciation("SWML", "swimmel")
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
 			pronounce, ok := aiCfg["pronounce"].([]map[string]any)
 			if !ok {
@@ -1417,14 +1435,14 @@ func TestRenderSWML_DataMapTool(t *testing.T) {
 	})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
-			swaigCfg := aiCfg["SWAIG"].(map[string]any)
-			functions := swaigCfg["functions"].([]map[string]any)
+			swaigCfg := as[map[string]any](t, aiCfg["SWAIG"])
+			functions := as[[]map[string]any](t, swaigCfg["functions"])
 			if len(functions) != 1 {
 				t.Fatalf("expected 1 function, got %d", len(functions))
 			}
@@ -1457,15 +1475,15 @@ func TestRenderSWML_WithRoute(t *testing.T) {
 	})
 
 	doc := a.RenderSWML(nil, nil)
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections := as[map[string]any](t, doc["sections"])
+	main := as[[]any](t, sections["main"])
 
 	for _, v := range main {
-		vm := v.(map[string]any)
+		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
-			swaigCfg := aiCfg["SWAIG"].(map[string]any)
-			functions := swaigCfg["functions"].([]map[string]any)
-			webhookURL := functions[0]["web_hook_url"].(string)
+			swaigCfg := as[map[string]any](t, aiCfg["SWAIG"])
+			functions := as[[]map[string]any](t, swaigCfg["functions"])
+			webhookURL := as[string](t, functions[0]["web_hook_url"])
 			if !strings.Contains(webhookURL, "/myagent/swaig") {
 				t.Errorf("expected webhook URL to contain route /myagent/swaig, got %q", webhookURL)
 			}

--- a/pkg/agent/assert_test.go
+++ b/pkg/agent/assert_test.go
@@ -1,0 +1,14 @@
+package agent
+
+import "testing"
+
+// as checks a type assertion and fails the test on mismatch, so a wrong wire
+// shape surfaces as a clear test failure instead of a panic.
+func as[T any](t *testing.T, v any) T {
+	t.Helper()
+	tv, ok := v.(T)
+	if !ok {
+		t.Fatalf("expected %T, got %T", tv, v)
+	}
+	return tv
+}

--- a/pkg/agent/mcp_test.go
+++ b/pkg/agent/mcp_test.go
@@ -357,12 +357,15 @@ func TestMcpHttpEndpoint(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	body, _ := json.Marshal(map[string]any{
+	body, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "tools/list",
 		"params":  map[string]any{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := http.Post(ts.URL+"/test/mcp", "application/json", bytes.NewReader(body))
 	if err != nil {

--- a/pkg/agent/params_builder_integration_test.go
+++ b/pkg/agent/params_builder_integration_test.go
@@ -58,7 +58,7 @@ func TestBuilderParams_RenderedIntoRealSWAIGJSON(t *testing.T) {
 		Parameters:  params,
 		Required:    required,
 		Handler: func(args map[string]any, raw map[string]any) *swaig.FunctionResult {
-			return swaig.NewFunctionResult("checked " + args["service"].(string))
+			return swaig.NewFunctionResult("checked " + as[string](t, args["service"]))
 		},
 	})
 
@@ -99,8 +99,14 @@ func TestBuilderParams_RenderedIntoRealSWAIGJSON(t *testing.T) {
 	}
 
 	// JSON-equal comparison (normalizes object key order, preserves array order).
-	gb, _ := json.Marshal(gotParams)
-	wb, _ := json.Marshal(wantParams)
+	gb, err := json.Marshal(gotParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wb, err := json.Marshal(wantParams)
+	if err != nil {
+		t.Fatal(err)
+	}
 	var gv, wv any
 	_ = json.Unmarshal(gb, &gv)
 	_ = json.Unmarshal(wb, &wv)
@@ -109,8 +115,8 @@ func TestBuilderParams_RenderedIntoRealSWAIGJSON(t *testing.T) {
 	}
 
 	// Spot-check the enum array actually rode through into the generated JSON.
-	props := gotParams["properties"].(map[string]any)
-	fmtProp := props["fmt"].(map[string]any)
+	props := as[map[string]any](t, gotParams["properties"])
+	fmtProp := as[map[string]any](t, props["fmt"])
 	enum, ok := fmtProp["enum"].([]any)
 	if !ok || len(enum) != 3 || enum[0] != "mp3" || enum[2] != "mp4" {
 		t.Errorf("fmt enum not rendered correctly: %#v", fmtProp["enum"])
@@ -161,8 +167,14 @@ func TestBuilderParams_EquivalentToHandWrittenInRender(t *testing.T) {
 	builtFn := findSwaigFunctions(t, makeAgent(builderParams, builderReq).RenderSWML(nil, nil))[0]
 	handFn := findSwaigFunctions(t, makeAgent(handParams, handReq).RenderSWML(nil, nil))[0]
 
-	bb, _ := json.Marshal(builtFn["parameters"])
-	hb, _ := json.Marshal(handFn["parameters"])
+	bb, err := json.Marshal(builtFn["parameters"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	hb, err := json.Marshal(handFn["parameters"])
+	if err != nil {
+		t.Fatal(err)
+	}
 	var bv, hv any
 	_ = json.Unmarshal(bb, &bv)
 	_ = json.Unmarshal(hb, &hv)

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -226,14 +226,14 @@ func TestGetPrompt_PomMode(t *testing.T) {
 func TestGetPrompt_ReturnsCopy(t *testing.T) {
 	a := NewAgentBase()
 	a.PromptAddSection("S1", "", nil)
-	result := a.GetPrompt().([]map[string]any)
+	result := as[[]map[string]any](t, a.GetPrompt())
 	result = append(result, map[string]any{"title": "Extra"})
 	// The returned slice is the caller's to mutate: appending grew it to 2.
 	if len(result) != 2 {
 		t.Errorf("expected appended copy to have 2 sections, got %d", len(result))
 	}
 	// ...and that mutation must NOT have affected the agent's own state.
-	orig := a.GetPrompt().([]map[string]any)
+	orig := as[[]map[string]any](t, a.GetPrompt())
 	if len(orig) != 1 {
 		t.Errorf("modifying result should not affect agent; got %d sections", len(orig))
 	}

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -621,14 +621,20 @@ func TestAddEnterExitFiller(t *testing.T) {
 	ctx.AddExitFiller("en-US", []string{"Goodbye"})
 
 	m := ctx.ToMap()
-	ef := m["enter_fillers"].(map[string][]string)
+	ef, ok := m["enter_fillers"].(map[string][]string)
+	if !ok {
+		t.Fatalf("expected map[string][]string, got %T", m["enter_fillers"])
+	}
 	if len(ef) != 2 {
 		t.Fatalf("expected 2 enter filler languages, got %d", len(ef))
 	}
 	if ef["es"][0] != "Hola" {
 		t.Fatalf("unexpected es filler: %v", ef["es"])
 	}
-	xf := m["exit_fillers"].(map[string][]string)
+	xf, ok := m["exit_fillers"].(map[string][]string)
+	if !ok {
+		t.Fatalf("expected map[string][]string, got %T", m["exit_fillers"])
+	}
 	if xf["en-US"][0] != "Goodbye" {
 		t.Fatalf("unexpected exit filler: %v", xf["en-US"])
 	}
@@ -774,11 +780,17 @@ func TestFullRoundTrip(t *testing.T) {
 		t.Fatal("expected 'support' context in output")
 	}
 
-	salesMap := m["sales"].(map[string]any)
+	salesMap, ok := m["sales"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", m["sales"])
+	}
 	if salesMap["post_prompt"] != "Summarise the sales call" {
 		t.Fatal("unexpected post_prompt")
 	}
-	steps := salesMap["steps"].([]map[string]any)
+	steps, ok := salesMap["steps"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", salesMap["steps"])
+	}
 	if len(steps) != 2 {
 		t.Fatalf("expected 2 steps in sales, got %d", len(steps))
 	}
@@ -807,10 +819,22 @@ func TestGatherInfoInBuilder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defaultCtx := m["default"].(map[string]any)
-	steps := defaultCtx["steps"].([]map[string]any)
-	giMap := steps[0]["gather_info"].(map[string]any)
-	qs := giMap["questions"].([]map[string]any)
+	defaultCtx, ok := m["default"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", m["default"])
+	}
+	steps, ok := defaultCtx["steps"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", defaultCtx["steps"])
+	}
+	giMap, ok := steps[0]["gather_info"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", steps[0]["gather_info"])
+	}
+	qs, ok := giMap["questions"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", giMap["questions"])
+	}
 	if len(qs) != 2 {
 		t.Fatalf("expected 2 questions, got %d", len(qs))
 	}

--- a/pkg/datamap/assert_test.go
+++ b/pkg/datamap/assert_test.go
@@ -1,0 +1,14 @@
+package datamap
+
+import "testing"
+
+// as checks a type assertion and fails the test on mismatch, so a wrong wire
+// shape surfaces as a clear test failure instead of a panic.
+func as[T any](t *testing.T, v any) T {
+	t.Helper()
+	tv, ok := v.(T)
+	if !ok {
+		t.Fatalf("expected %T, got %T", tv, v)
+	}
+	return tv
+}

--- a/pkg/datamap/datamap_test.go
+++ b/pkg/datamap/datamap_test.go
@@ -156,9 +156,18 @@ func TestParametersWithEnum(t *testing.T) {
 
 	result := dm.ToSwaigFunction()
 
-	argument := result["parameters"].(map[string]any)
-	properties := argument["properties"].(map[string]any)
-	modeProp := properties["mode"].(map[string]any)
+	argument, ok := result["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result["parameters"])
+	}
+	properties, ok := argument["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", argument["properties"])
+	}
+	modeProp, ok := properties["mode"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", properties["mode"])
+	}
 
 	enumVal, ok := modeProp["enum"].([]string)
 	if !ok {
@@ -181,9 +190,18 @@ func TestParametersNoEnum(t *testing.T) {
 
 	result := dm.ToSwaigFunction()
 
-	argument := result["parameters"].(map[string]any)
-	properties := argument["properties"].(map[string]any)
-	queryProp := properties["query"].(map[string]any)
+	argument, ok := result["parameters"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result["parameters"])
+	}
+	properties, ok := argument["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", argument["properties"])
+	}
+	queryProp, ok := properties["query"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", properties["query"])
+	}
 
 	if _, exists := queryProp["enum"]; exists {
 		t.Error("expected no enum key when enum is nil")
@@ -210,8 +228,8 @@ func TestWebhookConfiguration(t *testing.T) {
 		Output(swaig.NewFunctionResult("Done: ${response.status}"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	if len(webhooks) != 1 {
 		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
@@ -226,7 +244,7 @@ func TestWebhookConfiguration(t *testing.T) {
 		t.Errorf("unexpected url: %v", wh["url"])
 	}
 
-	headers := wh["headers"].(map[string]string)
+	headers := as[map[string]string](t, wh["headers"])
 	if headers["Authorization"] != "Bearer tok" {
 		t.Errorf("unexpected Authorization header: %v", headers["Authorization"])
 	}
@@ -238,12 +256,12 @@ func TestWebhookConfiguration(t *testing.T) {
 		t.Errorf("expected input_args_as_params true, got %v", wh["input_args_as_params"])
 	}
 
-	requireArgs := wh["require_args"].([]string)
+	requireArgs := as[[]string](t, wh["require_args"])
 	if len(requireArgs) != 2 {
 		t.Errorf("expected 2 require_args, got %d", len(requireArgs))
 	}
 
-	body := wh["body"].(map[string]any)
+	body := as[map[string]any](t, wh["body"])
 	if body["id"] != "${args.id}" {
 		t.Errorf("unexpected body id: %v", body["id"])
 	}
@@ -259,27 +277,27 @@ func TestOutputAndFallbackOutput(t *testing.T) {
 		FallbackOutput(swaig.NewFunctionResult("All APIs failed"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
 
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 	if len(webhooks) != 2 {
 		t.Fatalf("expected 2 webhooks, got %d", len(webhooks))
 	}
 
 	// Check first webhook output
-	output1 := webhooks[0]["output"].(map[string]any)
+	output1 := as[map[string]any](t, webhooks[0]["output"])
 	if output1["response"] != "Primary: ${response.data}" {
 		t.Errorf("unexpected first webhook output: %v", output1["response"])
 	}
 
 	// Check second webhook output
-	output2 := webhooks[1]["output"].(map[string]any)
+	output2 := as[map[string]any](t, webhooks[1]["output"])
 	if output2["response"] != "Fallback: ${response.data}" {
 		t.Errorf("unexpected second webhook output: %v", output2["response"])
 	}
 
 	// Check fallback output at data_map level
-	fallback := dataMap["output"].(map[string]any)
+	fallback := as[map[string]any](t, dataMap["output"])
 	if fallback["response"] != "All APIs failed" {
 		t.Errorf("unexpected fallback output: %v", fallback["response"])
 	}
@@ -299,7 +317,7 @@ func TestExpressions(t *testing.T) {
 		)
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
 
 	expressions, ok := dataMap["expressions"].([]map[string]any)
 	if !ok {
@@ -317,7 +335,7 @@ func TestExpressions(t *testing.T) {
 	if expr1["pattern"] != "start.*" {
 		t.Errorf("unexpected expression pattern: %v", expr1["pattern"])
 	}
-	output1 := expr1["output"].(map[string]any)
+	output1 := as[map[string]any](t, expr1["output"])
 	if output1["response"] != "Starting..." {
 		t.Errorf("unexpected expression output: %v", output1["response"])
 	}
@@ -330,7 +348,7 @@ func TestExpressions(t *testing.T) {
 	if _, exists := expr2["nomatch-output"]; !exists {
 		t.Error("expected nomatch-output for second expression")
 	}
-	nomatch := expr2["nomatch-output"].(map[string]any)
+	nomatch := as[map[string]any](t, expr2["nomatch-output"])
 	if nomatch["response"] != "Unknown stop command" {
 		t.Errorf("unexpected nomatch output: %v", nomatch["response"])
 	}
@@ -365,8 +383,8 @@ func TestCreateSimpleApiTool(t *testing.T) {
 		t.Errorf("expected default description, got %v", result["description"])
 	}
 
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 	if len(webhooks) != 1 {
 		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
 	}
@@ -377,19 +395,19 @@ func TestCreateSimpleApiTool(t *testing.T) {
 	}
 
 	// Check error keys are on the webhook
-	errorKeys := wh["error_keys"].([]string)
+	errorKeys := as[[]string](t, wh["error_keys"])
 	if len(errorKeys) != 2 {
 		t.Errorf("expected 2 error keys, got %d", len(errorKeys))
 	}
 
 	// Check output
-	output := wh["output"].(map[string]any)
+	output := as[map[string]any](t, wh["output"])
 	if output["response"] != "${response.name}: $${response.price}" {
 		t.Errorf("unexpected output response: %v", output["response"])
 	}
 
 	// Check headers
-	headers := wh["headers"].(map[string]string)
+	headers := as[map[string]string](t, wh["headers"])
 	if headers["X-Api-Key"] != "key123" {
 		t.Errorf("unexpected header: %v", headers["X-Api-Key"])
 	}
@@ -414,15 +432,15 @@ func TestCreateSimpleApiToolWithBody(t *testing.T) {
 	)
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 	wh := webhooks[0]
 
 	if wh["method"] != "POST" {
 		t.Errorf("expected POST, got %v", wh["method"])
 	}
 
-	body := wh["body"].(map[string]any)
+	body := as[map[string]any](t, wh["body"])
 	if body["q"] != "${args.query}" {
 		t.Errorf("unexpected body q: %v", body["q"])
 	}
@@ -455,8 +473,8 @@ func TestCreateExpressionTool(t *testing.T) {
 		t.Errorf("expected function %q, got %v", "playback_control", result["function"])
 	}
 
-	dataMap := result["data_map"].(map[string]any)
-	expressions := dataMap["expressions"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	expressions := as[[]map[string]any](t, dataMap["expressions"])
 	if len(expressions) != 1 {
 		t.Fatalf("expected 1 expression, got %d", len(expressions))
 	}
@@ -487,8 +505,8 @@ func TestWebhookExpressions(t *testing.T) {
 		Output(swaig.NewFunctionResult("Status: ${response.status}"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	wh := webhooks[0]
 	whExprs, ok := wh["expressions"].([]map[string]any)
@@ -507,7 +525,7 @@ func TestGlobalErrorKeys(t *testing.T) {
 		GlobalErrorKeys([]string{"error", "err_msg"})
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
 
 	errorKeys, ok := dataMap["error_keys"].([]string)
 	if !ok {
@@ -536,8 +554,8 @@ func TestForeachConfig(t *testing.T) {
 		Output(swaig.NewFunctionResult("Results:\n${formatted}"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	wh := webhooks[0]
 	foreach, ok := wh["foreach"].(map[string]any)
@@ -562,8 +580,8 @@ func TestParamsOnWebhook(t *testing.T) {
 		Output(swaig.NewFunctionResult("Found: ${response.result}"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	wh := webhooks[0]
 	params, ok := wh["params"].(map[string]any)
@@ -583,13 +601,13 @@ func TestEmptyDataMap(t *testing.T) {
 		t.Errorf("expected function %q, got %v", "empty_tool", result["function"])
 	}
 
-	dataMap := result["data_map"].(map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
 	if len(dataMap) != 0 {
 		t.Errorf("expected empty data_map, got %d entries", len(dataMap))
 	}
 
-	argument := result["parameters"].(map[string]any)
-	properties := argument["properties"].(map[string]any)
+	argument := as[map[string]any](t, result["parameters"])
+	properties := as[map[string]any](t, argument["properties"])
 	if len(properties) != 0 {
 		t.Errorf("expected empty properties, got %d entries", len(properties))
 	}
@@ -601,8 +619,8 @@ func TestMethodUppercased(t *testing.T) {
 		Output(swaig.NewFunctionResult("ok"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	if webhooks[0]["method"] != "POST" {
 		t.Errorf("expected method to be uppercased to POST, got %v", webhooks[0]["method"])
@@ -620,25 +638,25 @@ func TestMultipleWebhooksPreserveSeparateConfig(t *testing.T) {
 		Output(swaig.NewFunctionResult("Secondary result"))
 
 	result := dm.ToSwaigFunction()
-	dataMap := result["data_map"].(map[string]any)
-	webhooks := dataMap["webhooks"].([]map[string]any)
+	dataMap := as[map[string]any](t, result["data_map"])
+	webhooks := as[[]map[string]any](t, dataMap["webhooks"])
 
 	if len(webhooks) != 2 {
 		t.Fatalf("expected 2 webhooks, got %d", len(webhooks))
 	}
 
 	// First webhook should have its own body and error keys
-	body1 := webhooks[0]["body"].(map[string]any)
+	body1 := as[map[string]any](t, webhooks[0]["body"])
 	if body1["source"] != "primary" {
 		t.Errorf("expected first webhook body source %q, got %v", "primary", body1["source"])
 	}
-	ek1 := webhooks[0]["error_keys"].([]string)
+	ek1 := as[[]string](t, webhooks[0]["error_keys"])
 	if len(ek1) != 1 || ek1[0] != "err" {
 		t.Errorf("expected first webhook error_keys [err], got %v", ek1)
 	}
 
 	// Second webhook should have its own body, no error keys
-	body2 := webhooks[1]["body"].(map[string]any)
+	body2 := as[map[string]any](t, webhooks[1]["body"])
 	if body2["source"] != "secondary" {
 		t.Errorf("expected second webhook body source %q, got %v", "secondary", body2["source"])
 	}

--- a/pkg/datamap/public_symbols_test.go
+++ b/pkg/datamap/public_symbols_test.go
@@ -68,8 +68,14 @@ func TestExpressionRegexpEquivalentToExpression(t *testing.T) {
 	dmB := New("a")
 	dmB.ExpressionRegexp("${args.x}", regexp.MustCompile("^foo$"), out, nil)
 
-	aBytes, _ := json.Marshal(dmA.ToSwaigFunction())
-	bBytes, _ := json.Marshal(dmB.ToSwaigFunction())
+	aBytes, err := json.Marshal(dmA.ToSwaigFunction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bBytes, err := json.Marshal(dmB.ToSwaigFunction())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if string(aBytes) != string(bBytes) {
 		t.Fatalf("ExpressionRegexp and Expression should produce equivalent output\nExpression:\n%s\nExpressionRegexp:\n%s",
 			aBytes, bBytes)

--- a/pkg/livewire/livewire.go
+++ b/pkg/livewire/livewire.go
@@ -616,7 +616,11 @@ func (s *AgentSession) Start(ctx *JobContext, ag *Agent, opts ...StartOption) er
 
 	// Register session-level tools first, then agent tools.
 	// Mirrors Python _build_sw_agent(): all_tools = list(self._tools) + list(agent._tools) (line 591).
-	allTools := append(s.sessionTools, ag.tools...)
+	// Build a fresh slice (Python's concat makes a new list) rather than append
+	// onto s.sessionTools, whose backing array must not be aliased/mutated.
+	allTools := make([]toolDef, 0, len(s.sessionTools)+len(ag.tools))
+	allTools = append(allTools, s.sessionTools...)
+	allTools = append(allTools, ag.tools...)
 	for _, td := range allTools {
 		def := agent.ToolDefinition{
 			Name:        td.name,

--- a/pkg/livewire/livewire_test.go
+++ b/pkg/livewire/livewire_test.go
@@ -516,7 +516,7 @@ func TestNoopTracker_OnlyLogsOnce(t *testing.T) {
 	tracker := newNoopTracker(logging.New("test"))
 
 	// Call once multiple times with same key
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tracker.once("feature", "some message")
 	}
 
@@ -538,7 +538,7 @@ func TestNoopTracker_ConcurrentSafety(t *testing.T) {
 	tracker := newNoopTracker(logging.New("test"))
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/pkg/pom/pom.go
+++ b/pkg/pom/pom.go
@@ -443,7 +443,9 @@ func writeJSONSection(buf *bytes.Buffer, s *Section, indent int) error {
 			}
 			buf.Write(b)
 		case "bullets":
-			writeJSONStringList(buf, s.Bullets, indent+1)
+			if err := writeJSONStringList(buf, s.Bullets, indent+1); err != nil {
+				return err
+			}
 		case "subsections":
 			buf.WriteString("[\n")
 			for j, sub := range s.Subsections {
@@ -472,12 +474,15 @@ func writeJSONSection(buf *bytes.Buffer, s *Section, indent int) error {
 	return nil
 }
 
-func writeJSONStringList(buf *bytes.Buffer, items []string, indent int) {
+func writeJSONStringList(buf *bytes.Buffer, items []string, indent int) error {
 	pad := strings.Repeat("  ", indent)
 	pad2 := strings.Repeat("  ", indent+1)
 	buf.WriteString("[\n")
 	for i, it := range items {
-		b, _ := json.Marshal(it)
+		b, err := json.Marshal(it)
+		if err != nil {
+			return err
+		}
 		buf.WriteString(pad2)
 		buf.Write(b)
 		if i < len(items)-1 {
@@ -487,6 +492,7 @@ func writeJSONStringList(buf *bytes.Buffer, items []string, indent int) {
 		}
 	}
 	buf.WriteString(pad + "]")
+	return nil
 }
 
 // ToYAML serializes the POM to a YAML string in the same shape as
@@ -775,7 +781,7 @@ func (p *PromptObjectModel) RenderMarkdown() string {
 			break
 		}
 	}
-	var md []string
+	md := make([]string, 0, len(p.Sections))
 	counter := 0
 	for _, s := range p.Sections {
 		var sectionNumber []int
@@ -795,7 +801,7 @@ func (p *PromptObjectModel) RenderMarkdown() string {
 //
 // Python equivalent: PromptObjectModel.render_xml
 func (p *PromptObjectModel) RenderXML() string {
-	var xml []string
+	xml := make([]string, 0, 2+len(p.Sections)+1)
 	xml = append(xml, `<?xml version="1.0" encoding="UTF-8"?>`)
 	xml = append(xml, "<prompt>")
 	anyNumbered := false

--- a/pkg/prefabs/bedrock.go
+++ b/pkg/prefabs/bedrock.go
@@ -99,11 +99,12 @@ func NewBedrockAgent(opts BedrockOptions) *BedrockAgent {
 	}
 
 	// Build base AgentOption list: name + route first, then caller overrides.
-	baseOpts := []agent.AgentOption{
+	baseOpts := make([]agent.AgentOption, 0, 3+len(opts.AgentOptions))
+	baseOpts = append(baseOpts,
 		agent.WithName(name),
 		agent.WithRoute(route),
 		agent.WithAIVerbName("amazon_bedrock"),
-	}
+	)
 	baseOpts = append(baseOpts, opts.AgentOptions...)
 
 	base := agent.NewAgentBase(baseOpts...)

--- a/pkg/prefabs/concierge.go
+++ b/pkg/prefabs/concierge.go
@@ -82,12 +82,13 @@ func NewConciergeAgent(opts ConciergeOptions) *ConciergeAgent {
 		"Provide exceptional service by helping users with information, recommendations, and booking assistance.",
 		nil,
 	)
-	instructions := []string{
+	instructions := make([]string, 0, 4+len(opts.SpecialInstructions))
+	instructions = append(instructions,
 		"Be warm and welcoming but professional at all times.",
 		"Provide accurate information about amenities, services, and operating hours.",
 		"Offer to help with reservations and bookings when appropriate.",
 		"Answer questions concisely with specific, relevant details.",
-	}
+	)
 	instructions = append(instructions, opts.SpecialInstructions...)
 	base.PromptAddSection("Instructions", "", instructions)
 
@@ -158,7 +159,8 @@ func NewConciergeAgent(opts ConciergeOptions) *ConciergeAgent {
 	})
 
 	// ---- Hints ----
-	hints := []string{opts.VenueName}
+	hints := make([]string, 0, 1+len(opts.Services)+len(opts.Amenities))
+	hints = append(hints, opts.VenueName)
 	hints = append(hints, opts.Services...)
 	for k := range opts.Amenities {
 		hints = append(hints, k)
@@ -195,7 +197,8 @@ func (ca *ConciergeAgent) registerTools() {
 			},
 		},
 		Handler: func(args map[string]any, rawData map[string]any) *swaig.FunctionResult {
-			service := strings.ToLower(strings.TrimSpace(args["service"].(string)))
+			serviceRaw, _ := args["service"].(string)
+			service := strings.ToLower(strings.TrimSpace(serviceRaw))
 			date, _ := args["date"].(string)
 			time, _ := args["time"].(string)
 
@@ -232,7 +235,8 @@ func (ca *ConciergeAgent) registerTools() {
 			},
 		},
 		Handler: func(args map[string]any, rawData map[string]any) *swaig.FunctionResult {
-			dest := strings.ToLower(strings.TrimSpace(args["location"].(string)))
+			destRaw, _ := args["location"].(string)
+			dest := strings.ToLower(strings.TrimSpace(destRaw))
 
 			if amenity, ok := ca.amenities[dest]; ok && amenity.Location != "" {
 				return swaig.NewFunctionResult(

--- a/pkg/prefabs/info_gatherer.go
+++ b/pkg/prefabs/info_gatherer.go
@@ -235,6 +235,7 @@ func (ig *InfoGathererAgent) registerTools() {
 
 			// Record the answer
 			newAnswer := map[string]any{"key_name": keyName, "answer": answer}
+			//nolint:gocritic // appendAssign: deliberately derives a fresh answers slice that is stored alongside newIdx via UpdateGlobalData; the original answers is intentionally not mutated.
 			newAnswers := append(answers, newAnswer)
 			newIdx := idx + 1
 

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -546,7 +546,7 @@ func (c *Client) connect() error {
 	if host == "" {
 		host = c.space
 		if !strings.Contains(host, ".") {
-			host = host + ".signalwire.com"
+			host += ".signalwire.com"
 		}
 	}
 	scheme := os.Getenv("SIGNALWIRE_RELAY_SCHEME")
@@ -780,7 +780,10 @@ func (c *Client) readLoop() {
 			c.mu.RUnlock()
 			if ok {
 				if msg.Error != nil {
-					errJSON, _ := json.Marshal(msg.Error)
+					errJSON, err := json.Marshal(msg.Error)
+					if err != nil {
+						c.logger.Printf("relay error marshal error: %v", err)
+					}
 					ch <- errJSON
 				} else {
 					ch <- msg.Result

--- a/pkg/relay/client_test.go
+++ b/pkg/relay/client_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -463,7 +464,7 @@ func TestAction_WaitTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("Wait should return error on timeout")
 	}
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected DeadlineExceeded, got %v", err)
 	}
 }
@@ -617,7 +618,7 @@ func TestCall_WaitForTimeout(t *testing.T) {
 	_, err := call.WaitFor(ctx, EventCallingCallState, func(e *RelayEvent) bool {
 		return e.GetString("call_state") == CallStateEnded
 	})
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected DeadlineExceeded, got %v", err)
 	}
 }

--- a/pkg/relay/device_test.go
+++ b/pkg/relay/device_test.go
@@ -68,7 +68,10 @@ func TestDevice_NilParamsBecomesEmptyObject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	wantJSON, _ := json.Marshal(want)
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
 	if string(gotJSON) != string(wantJSON) {
 		t.Errorf("JSON = %s, want %s", gotJSON, wantJSON)
 	}
@@ -156,8 +159,14 @@ func TestDevice_RoundTripsThroughRealDialFrame(t *testing.T) {
 	// The device on the wire must equal the hand-written device, JSON-for-JSON
 	// (compare via JSON because the wire round-trip normalises numeric/string
 	// representations identically for both sides).
-	gotJSON, _ := json.Marshal(gotDev)
-	wantJSON, _ := json.Marshal(handWritten)
+	gotJSON, err := json.Marshal(gotDev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	wantJSON, err := json.Marshal(handWritten)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
 	if string(gotJSON) != string(wantJSON) {
 		t.Errorf("wire device = %s, want %s", gotJSON, wantJSON)
 	}
@@ -203,8 +212,14 @@ func TestDevice_RoundTripsThroughRealConnectFrame(t *testing.T) {
 	if !ok {
 		t.Fatalf("device[0] not an object: %#v", leg[0])
 	}
-	gotJSON, _ := json.Marshal(gotDev)
-	wantJSON, _ := json.Marshal(handWritten)
+	gotJSON, err := json.Marshal(gotDev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	wantJSON, err := json.Marshal(handWritten)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
 	if string(gotJSON) != string(wantJSON) {
 		t.Errorf("wire device = %s, want %s", gotJSON, wantJSON)
 	}

--- a/pkg/relay/options.go
+++ b/pkg/relay/options.go
@@ -376,8 +376,8 @@ func WithPayTimeout(timeout string) PayOption {
 }
 
 // WithPayMaxAttempts sets the maximum number of payment attempts.
-func WithPayMaxAttempts(max string) PayOption {
-	return func(m map[string]any) { m["max_attempts"] = max }
+func WithPayMaxAttempts(maxAttempts string) PayOption {
+	return func(m map[string]any) { m["max_attempts"] = maxAttempts }
 }
 
 // WithPaySecurityCode sets whether to collect security code.

--- a/pkg/relay/outbound_call_mock_test.go
+++ b/pkg/relay/outbound_call_mock_test.go
@@ -559,7 +559,11 @@ func TestRelay_DialRecordsCallStateProgressionOnWinner(t *testing.T) {
 	for _, e := range stateEvents {
 		inner, _ := e.EventParams()
 		if inner["call_id"] == "WIN-PROG" {
-			winnerStates = append(winnerStates, inner["call_state"].(string))
+			cs, ok := inner["call_state"].(string)
+			if !ok {
+				t.Fatalf("expected string call_state, got %T", inner["call_state"])
+			}
+			winnerStates = append(winnerStates, cs)
 		}
 	}
 	for _, s := range []string{"created", "ringing", "answered"} {

--- a/pkg/rest/namespaces/pagination_mock_test.go
+++ b/pkg/rest/namespaces/pagination_mock_test.go
@@ -21,6 +21,7 @@
 package namespaces_test
 
 import (
+	"errors"
 	"testing"
 
 	rest "github.com/signalwire/signalwire-go/pkg/rest"
@@ -216,7 +217,7 @@ func TestPaginatedIterator_ForEachStopsOnError(t *testing.T) {
 		}
 		return nil
 	})
-	if err != stopErr {
+	if !errors.Is(err, stopErr) {
 		t.Errorf("ForEach error = %v, want stopErr", err)
 	}
 	if visited != 2 {

--- a/pkg/security/webhook_test.go
+++ b/pkg/security/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"net/url"
 	"sort"
 	"strings"
@@ -273,7 +274,7 @@ func TestErrors_MissingSigningKeyReturnsErrorOnE(t *testing.T) {
 	if ok {
 		t.Fatalf("expected ok=false on empty key")
 	}
-	if err == nil || err != ErrMissingSigningKey {
+	if err == nil || !errors.Is(err, ErrMissingSigningKey) {
 		t.Fatalf("expected ErrMissingSigningKey, got %v", err)
 	}
 }

--- a/pkg/server/server_ctx_test.go
+++ b/pkg/server/server_ctx_test.go
@@ -32,7 +32,11 @@ func freePort(t *testing.T) int {
 		t.Fatalf("freePort: %v", err)
 	}
 	defer func() { _ = ln.Close() }()
-	return ln.Addr().(*net.TCPAddr).Port
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected *net.TCPAddr, got %T", ln.Addr())
+	}
+	return addr.Port
 }
 
 // waitHealthy blocks until GET /health on the given base URL returns 200, or

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -405,7 +405,10 @@ func TestHTTP_RootIndex_ListsAgents(t *testing.T) {
 		t.Fatalf("expected 2 agents, got %d", len(agentsRaw))
 	}
 
-	first := agentsRaw[0].(map[string]any)
+	first, ok := agentsRaw[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", agentsRaw[0])
+	}
 	if first["route"] != "/bot1" {
 		t.Errorf("expected first agent route=/bot1, got %v", first["route"])
 	}
@@ -431,7 +434,10 @@ func TestHTTP_RootIndex_Empty(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	agentsRaw := body["agents"].([]any)
+	agentsRaw, ok := body["agents"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", body["agents"])
+	}
 	if len(agentsRaw) != 0 {
 		t.Errorf("expected 0 agents, got %d", len(agentsRaw))
 	}

--- a/pkg/skills/builtin/assert_test.go
+++ b/pkg/skills/builtin/assert_test.go
@@ -1,0 +1,14 @@
+package builtin
+
+import "testing"
+
+// as checks a type assertion and fails the test on mismatch, so a wrong wire
+// shape surfaces as a clear test failure instead of a panic.
+func as[T any](t *testing.T, v any) T {
+	t.Helper()
+	tv, ok := v.(T)
+	if !ok {
+		t.Fatalf("expected %T, got %T", tv, v)
+	}
+	return tv
+}

--- a/pkg/skills/builtin/claude_skills.go
+++ b/pkg/skills/builtin/claude_skills.go
@@ -476,17 +476,18 @@ func (s *ClaudeSkillsSkill) applyInvocationControl(parsed *skillEntry) {
 		return
 	}
 
-	if parsed.disableModelInvocation {
+	switch {
+	case parsed.disableModelInvocation:
 		// disable-model-invocation: true → no tool, no prompt.
 		parsed.skipTool = true
 		parsed.skipPrompt = true
 		slog.Debug("claude_skills: skill has disable-model-invocation=true — skipping tool and prompt", "name", parsed.name)
-	} else if !parsed.userInvocable {
+	case !parsed.userInvocable:
 		// user-invocable: false → no tool, yes prompt (knowledge-only).
 		parsed.skipTool = true
 		parsed.skipPrompt = false
 		slog.Debug("claude_skills: skill has user-invocable=false — skipping tool, keeping prompt", "name", parsed.name)
-	} else {
+	default:
 		parsed.skipTool = false
 		parsed.skipPrompt = false
 	}

--- a/pkg/skills/builtin/custom_skills.go
+++ b/pkg/skills/builtin/custom_skills.go
@@ -58,7 +58,7 @@ func (s *CustomSkillsSkill) Setup() bool {
 }
 
 func (s *CustomSkillsSkill) RegisterTools() []skills.ToolRegistration {
-	var registrations []skills.ToolRegistration
+	registrations := make([]skills.ToolRegistration, 0, len(s.tools))
 
 	for _, toolDef := range s.tools {
 		name, _ := toolDef["name"].(string)

--- a/pkg/skills/builtin/datasphere.go
+++ b/pkg/skills/builtin/datasphere.go
@@ -168,7 +168,10 @@ func (s *DataSphereSkill) handleSearch(args map[string]any, _ map[string]any) *s
 		payload["max_synonyms"] = s.maxSynonyms
 	}
 
-	bodyBytes, _ := json.Marshal(payload)
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return swaig.NewFunctionResult("Error creating search request.")
+	}
 
 	req, err := http.NewRequest("POST", s.apiURL, strings.NewReader(string(bodyBytes)))
 	if err != nil {

--- a/pkg/skills/builtin/mcp_gateway.go
+++ b/pkg/skills/builtin/mcp_gateway.go
@@ -289,8 +289,12 @@ func (s *MCPGatewaySkill) callMCPTool(serviceName, toolName string, args map[str
 		retries = 1
 	}
 
-	for attempt := 0; attempt < retries; attempt++ {
-		bodyBytes, _ := json.Marshal(reqData)
+	bodyBytes, err := json.Marshal(reqData)
+	if err != nil {
+		return swaig.NewFunctionResult(fmt.Sprintf("Error calling %s.%s", serviceName, toolName))
+	}
+
+	for range retries {
 		req, err := http.NewRequest("POST",
 			fmt.Sprintf("%s/services/%s/call", s.gatewayURL, serviceName),
 			bytes.NewReader(bodyBytes),

--- a/pkg/skills/builtin/native_vector_search.go
+++ b/pkg/skills/builtin/native_vector_search.go
@@ -248,7 +248,11 @@ func (s *NativeVectorSearchSkill) handleSearch(args map[string]any, _ map[string
 		"tags":                 s.tags,
 	}
 
-	bodyBytes, _ := json.Marshal(searchReq)
+	bodyBytes, err := json.Marshal(searchReq)
+	if err != nil {
+		s.logger.Error("native_vector_search: failed to marshal search request", "error", err)
+		return swaig.NewFunctionResult("Search service is temporarily unavailable. Please try again later.")
+	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	req, err := http.NewRequest("POST", s.remoteBaseURL+"/search", strings.NewReader(string(bodyBytes)))
 	if err != nil {

--- a/pkg/skills/builtin/swml_transfer.go
+++ b/pkg/skills/builtin/swml_transfer.go
@@ -87,7 +87,8 @@ func (s *SWMLTransferSkill) RegisterTools() []skills.ToolRegistration {
 			"enum":        enumVals,
 		},
 	}
-	requiredParams := []string{s.paramName}
+	requiredParams := make([]string, 0, 1+len(s.requiredFields))
+	requiredParams = append(requiredParams, s.paramName)
 
 	for fieldName, fieldDesc := range s.requiredFields {
 		properties[fieldName] = map[string]any{
@@ -266,13 +267,12 @@ func (s *SWMLTransferSkill) GetPromptSections() []map[string]any {
 		transferBullets = append(transferBullets, fmt.Sprintf(`"%s" - transfers to %s`, cleaned, destination))
 	}
 
-	sections := []map[string]any{
-		{
-			"title":   "Transferring",
-			"body":    fmt.Sprintf("You can transfer calls using the %s function with the following destinations:", s.toolName),
-			"bullets": transferBullets,
-		},
-	}
+	sections := make([]map[string]any, 0, 2)
+	sections = append(sections, map[string]any{
+		"title":   "Transferring",
+		"body":    fmt.Sprintf("You can transfer calls using the %s function with the following destinations:", s.toolName),
+		"bullets": transferBullets,
+	})
 
 	// Section 2: "Transfer Instructions"
 	instructionBullets := []string{

--- a/pkg/skills/builtin/web_search.go
+++ b/pkg/skills/builtin/web_search.go
@@ -591,7 +591,7 @@ func calculateContentQuality(text, rawURL, query string) map[string]any {
 				}
 			}
 			exactBonus := 0.0
-			for i := 0; i < len(queryWords)-1; i++ {
+			for i := range len(queryWords) - 1 {
 				phrase := queryWords[i] + " " + queryWords[i+1]
 				if strings.Contains(lowerContent, phrase) {
 					exactBonus += 0.2

--- a/pkg/skills/builtin/web_search_test.go
+++ b/pkg/skills/builtin/web_search_test.go
@@ -32,7 +32,10 @@ func TestWebSearch_Setup_ReadsPrefixPostfixParams(t *testing.T) {
 	if !s.Setup() {
 		t.Fatal("Setup failed")
 	}
-	ws := s.(*WebSearchSkill)
+	ws, ok := s.(*WebSearchSkill)
+	if !ok {
+		t.Fatalf("expected *WebSearchSkill, got %T", s)
+	}
 	if ws.responsePrefix != "PREFIX" {
 		t.Errorf("responsePrefix = %q, want PREFIX", ws.responsePrefix)
 	}
@@ -50,7 +53,10 @@ func TestWebSearch_Setup_DefaultsPrefixPostfixToEmpty(t *testing.T) {
 	if !s.Setup() {
 		t.Fatal("Setup failed")
 	}
-	ws := s.(*WebSearchSkill)
+	ws, ok := s.(*WebSearchSkill)
+	if !ok {
+		t.Fatalf("expected *WebSearchSkill, got %T", s)
+	}
 	if ws.responsePrefix != "" {
 		t.Errorf("default responsePrefix = %q, want empty", ws.responsePrefix)
 	}
@@ -104,7 +110,10 @@ func runWebSearchHandler(t *testing.T, params map[string]any, query string) stri
 	if !s.Setup() {
 		t.Fatal("Setup failed")
 	}
-	ws := s.(*WebSearchSkill)
+	ws, ok := s.(*WebSearchSkill)
+	if !ok {
+		t.Fatalf("expected *WebSearchSkill, got %T", s)
+	}
 	res := ws.handleWebSearch(map[string]any{"query": query}, nil)
 	m := res.ToMap()
 	resp, _ := m["response"].(string)
@@ -196,7 +205,10 @@ func TestWebSearch_Handler_NoResultsNotWrappedByPrefixPostfix(t *testing.T) {
 	if !s.Setup() {
 		t.Fatal("Setup failed")
 	}
-	ws := s.(*WebSearchSkill)
+	ws, ok := s.(*WebSearchSkill)
+	if !ok {
+		t.Fatalf("expected *WebSearchSkill, got %T", s)
+	}
 	res := ws.handleWebSearch(map[string]any{"query": "obscurequery"}, nil)
 	resp, _ := res.ToMap()["response"].(string)
 	if strings.Contains(resp, "PFX") || strings.Contains(resp, "SFX") {
@@ -223,8 +235,8 @@ func latencyStubServer(t *testing.T, query string, numItems int, contentDelay ti
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/customsearch/v1") {
 			w.Header().Set("Content-Type", "application/json")
-			var items []string
-			for i := 0; i < numItems; i++ {
+			items := make([]string, 0, numItems)
+			for i := range numItems {
 				items = append(items, fmt.Sprintf(
 					`{"title":"Result %[1]d about %[2]s","link":"%[3]s/page%[1]d","snippet":"snippet %[1]d on %[2]s"}`,
 					i, query, "http://"+r.Host))
@@ -273,7 +285,7 @@ func buildWebSearch(t *testing.T, params map[string]any) *WebSearchSkill {
 	if !s.Setup() {
 		t.Fatal("Setup failed")
 	}
-	return s.(*WebSearchSkill)
+	return as[*WebSearchSkill](t, s)
 }
 
 func TestWebSearch_Setup_LatencyParamsDefault(t *testing.T) {
@@ -481,7 +493,7 @@ func TestWebSearch_Handler_ParallelFastPathScrapesContent(t *testing.T) {
 // Every latency/response param read in Setup() must be advertised in the schema
 // with the matching type + default.
 func TestWebSearch_Schema_AdvertisesLatencyAndResponseParams(t *testing.T) {
-	ws := NewWebSearch(map[string]any{"api_key": "k", "search_engine_id": "e"}).(*WebSearchSkill)
+	ws := as[*WebSearchSkill](t, NewWebSearch(map[string]any{"api_key": "k", "search_engine_id": "e"}))
 	schema := ws.GetParameterSchema()
 
 	for _, key := range []string{

--- a/pkg/swaig/assert_test.go
+++ b/pkg/swaig/assert_test.go
@@ -1,0 +1,14 @@
+package swaig
+
+import "testing"
+
+// as checks a type assertion and fails the test on mismatch, so a wrong wire
+// shape surfaces as a clear test failure instead of a panic.
+func as[T any](t *testing.T, v any) T {
+	t.Helper()
+	tv, ok := v.(T)
+	if !ok {
+		t.Fatalf("expected %T, got %T", tv, v)
+	}
+	return tv
+}

--- a/pkg/swaig/function_result_test.go
+++ b/pkg/swaig/function_result_test.go
@@ -192,7 +192,10 @@ func TestMethodChaining(t *testing.T) {
 	if m["post_process"] != true {
 		t.Error("post_process should be true")
 	}
-	actions := m["action"].([]map[string]any)
+	actions, ok := m["action"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", m["action"])
+	}
 	if len(actions) != 2 {
 		t.Fatalf("actions length = %d, want 2", len(actions))
 	}
@@ -206,7 +209,10 @@ func TestAddActions(t *testing.T) {
 		})
 
 	m := fr.ToMap()
-	actions := m["action"].([]map[string]any)
+	actions, ok := m["action"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", m["action"])
+	}
 	if len(actions) != 2 {
 		t.Fatalf("actions length = %d, want 2", len(actions))
 	}
@@ -222,7 +228,10 @@ func TestConnect(t *testing.T) {
 		Connect("+15551234567", true, "+15559876543")
 
 	m := fr.ToMap()
-	actions := m["action"].([]map[string]any)
+	actions, ok := m["action"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", m["action"])
+	}
 	if len(actions) != 1 {
 		t.Fatalf("actions length = %d, want 1", len(actions))
 	}
@@ -236,10 +245,22 @@ func TestConnect(t *testing.T) {
 	if !ok {
 		t.Fatal("SWML should be a map")
 	}
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	connectVerb := main[0].(map[string]any)
-	connectParams := connectVerb["connect"].(map[string]any)
+	sections, ok := swml["sections"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", swml["sections"])
+	}
+	main, ok := sections["main"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", sections["main"])
+	}
+	connectVerb, ok := main[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", main[0])
+	}
+	connectParams, ok := connectVerb["connect"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", connectVerb["connect"])
+	}
 
 	if connectParams["to"] != "+15551234567" {
 		t.Errorf("to = %v, want +15551234567", connectParams["to"])
@@ -253,17 +274,17 @@ func TestConnectNoFrom(t *testing.T) {
 	fr := NewFunctionResult("Transferring").
 		Connect("+15551234567", false, "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	action := actions[0]
 	if action["transfer"] != "false" {
 		t.Errorf("transfer = %v, want %q", action["transfer"], "false")
 	}
 
-	swml := action["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	connectVerb := main[0].(map[string]any)
-	connectParams := connectVerb["connect"].(map[string]any)
+	swml := as[map[string]any](t, action["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	connectVerb := as[map[string]any](t, main[0])
+	connectParams := as[map[string]any](t, connectVerb["connect"])
 
 	if _, ok := connectParams["from"]; ok {
 		t.Error("from should not be present when empty")
@@ -274,27 +295,27 @@ func TestSwmlTransfer(t *testing.T) {
 	fr := NewFunctionResult("Transferring").
 		SwmlTransfer("https://example.com/swml", "Goodbye!", true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	action := actions[0]
 	if action["transfer"] != "true" {
 		t.Errorf("transfer = %v, want %q", action["transfer"], "true")
 	}
 
-	swml := action["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	swml := as[map[string]any](t, action["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
 	if len(main) != 2 {
 		t.Fatalf("main verbs length = %d, want 2", len(main))
 	}
 
-	setVerb := main[0].(map[string]any)
-	setData := setVerb["set"].(map[string]any)
+	setVerb := as[map[string]any](t, main[0])
+	setData := as[map[string]any](t, setVerb["set"])
 	if setData["ai_response"] != "Goodbye!" {
 		t.Errorf("ai_response = %v, want %q", setData["ai_response"], "Goodbye!")
 	}
 
-	transferVerb := main[1].(map[string]any)
-	transferData := transferVerb["transfer"].(map[string]any)
+	transferVerb := as[map[string]any](t, main[1])
+	transferData := as[map[string]any](t, transferVerb["transfer"])
 	if transferData["dest"] != "https://example.com/swml" {
 		t.Errorf("dest = %v, want %q", transferData["dest"], "https://example.com/swml")
 	}
@@ -303,7 +324,7 @@ func TestSwmlTransfer(t *testing.T) {
 func TestHangup(t *testing.T) {
 	fr := NewFunctionResult("Goodbye").Hangup()
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if len(actions) != 1 {
 		t.Fatalf("actions length = %d, want 1", len(actions))
 	}
@@ -315,7 +336,7 @@ func TestHangup(t *testing.T) {
 func TestHold(t *testing.T) {
 	fr := NewFunctionResult("Please hold").Hold(120)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["hold"] != 120 {
 		t.Errorf("hold = %v, want 120", actions[0]["hold"])
 	}
@@ -323,7 +344,7 @@ func TestHold(t *testing.T) {
 
 func TestHoldClampMin(t *testing.T) {
 	fr := NewFunctionResult("hold").Hold(-10)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["hold"] != 0 {
 		t.Errorf("hold = %v, want 0 (clamped)", actions[0]["hold"])
 	}
@@ -331,7 +352,7 @@ func TestHoldClampMin(t *testing.T) {
 
 func TestHoldClampMax(t *testing.T) {
 	fr := NewFunctionResult("hold").Hold(9999)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["hold"] != 900 {
 		t.Errorf("hold = %v, want 900 (clamped)", actions[0]["hold"])
 	}
@@ -339,7 +360,7 @@ func TestHoldClampMax(t *testing.T) {
 
 func TestWaitForUserAnswerFirst(t *testing.T) {
 	fr := NewFunctionResult("wait").WaitForUser(nil, nil, true)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["wait_for_user"] != "answer_first" {
 		t.Errorf("wait_for_user = %v, want %q", actions[0]["wait_for_user"], "answer_first")
 	}
@@ -348,7 +369,7 @@ func TestWaitForUserAnswerFirst(t *testing.T) {
 func TestWaitForUserTimeout(t *testing.T) {
 	timeout := 30
 	fr := NewFunctionResult("wait").WaitForUser(nil, &timeout, false)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["wait_for_user"] != 30 {
 		t.Errorf("wait_for_user = %v, want 30", actions[0]["wait_for_user"])
 	}
@@ -357,7 +378,7 @@ func TestWaitForUserTimeout(t *testing.T) {
 func TestWaitForUserEnabled(t *testing.T) {
 	enabled := false
 	fr := NewFunctionResult("wait").WaitForUser(&enabled, nil, false)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["wait_for_user"] != false {
 		t.Errorf("wait_for_user = %v, want false", actions[0]["wait_for_user"])
 	}
@@ -365,7 +386,7 @@ func TestWaitForUserEnabled(t *testing.T) {
 
 func TestWaitForUserDefault(t *testing.T) {
 	fr := NewFunctionResult("wait").WaitForUser(nil, nil, false)
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["wait_for_user"] != true {
 		t.Errorf("wait_for_user = %v, want true", actions[0]["wait_for_user"])
 	}
@@ -373,7 +394,7 @@ func TestWaitForUserDefault(t *testing.T) {
 
 func TestStop(t *testing.T) {
 	fr := NewFunctionResult("stopping").Stop()
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["stop"] != true {
 		t.Errorf("stop = %v, want true", actions[0]["stop"])
 	}
@@ -385,8 +406,8 @@ func TestUpdateGlobalData(t *testing.T) {
 	fr := NewFunctionResult("updated").
 		UpdateGlobalData(map[string]any{"key": "value", "count": 42})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	data := actions[0]["set_global_data"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	data := as[map[string]any](t, actions[0]["set_global_data"])
 	if data["key"] != "value" {
 		t.Errorf("key = %v, want %q", data["key"], "value")
 	}
@@ -399,8 +420,8 @@ func TestRemoveGlobalData(t *testing.T) {
 	fr := NewFunctionResult("removed").
 		RemoveGlobalData([]string{"key1", "key2"})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	keys := actions[0]["unset_global_data"].([]string)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	keys := as[[]string](t, actions[0]["unset_global_data"])
 	if len(keys) != 2 || keys[0] != "key1" || keys[1] != "key2" {
 		t.Errorf("keys = %v, want [key1, key2]", keys)
 	}
@@ -410,9 +431,9 @@ func TestRemoveGlobalDataKey(t *testing.T) {
 	fr := NewFunctionResult("removed").
 		RemoveGlobalDataKey("single-key")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	// Single key variant emits bare string, not array — matches Python Union[str, List[str]] behavior
-	key := actions[0]["unset_global_data"].(string)
+	key := as[string](t, actions[0]["unset_global_data"])
 	if key != "single-key" {
 		t.Errorf("unset_global_data = %v, want %q", key, "single-key")
 	}
@@ -422,8 +443,8 @@ func TestSetMetadata(t *testing.T) {
 	fr := NewFunctionResult("metadata").
 		SetMetadata(map[string]any{"session": "abc123"})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	data := actions[0]["set_meta_data"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	data := as[map[string]any](t, actions[0]["set_meta_data"])
 	if data["session"] != "abc123" {
 		t.Errorf("session = %v, want %q", data["session"], "abc123")
 	}
@@ -433,8 +454,8 @@ func TestRemoveMetadata(t *testing.T) {
 	fr := NewFunctionResult("remove").
 		RemoveMetadata([]string{"old_key"})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	keys := actions[0]["unset_meta_data"].([]string)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	keys := as[[]string](t, actions[0]["unset_meta_data"])
 	if len(keys) != 1 || keys[0] != "old_key" {
 		t.Errorf("keys = %v, want [old_key]", keys)
 	}
@@ -444,9 +465,9 @@ func TestRemoveMetadataKey(t *testing.T) {
 	fr := NewFunctionResult("remove").
 		RemoveMetadataKey("single-meta-key")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	// Single key variant emits bare string, not array — matches Python Union[str, List[str]] behavior
-	key := actions[0]["unset_meta_data"].(string)
+	key := as[string](t, actions[0]["unset_meta_data"])
 	if key != "single-meta-key" {
 		t.Errorf("unset_meta_data = %v, want %q", key, "single-meta-key")
 	}
@@ -456,13 +477,13 @@ func TestSwmlUserEvent(t *testing.T) {
 	fr := NewFunctionResult("event sent").
 		SwmlUserEvent(map[string]any{"type": "cards_dealt", "score": 21})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	userEvent := verb["user_event"].(map[string]any)
-	event := userEvent["event"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	userEvent := as[map[string]any](t, verb["user_event"])
+	event := as[map[string]any](t, userEvent["event"])
 
 	if event["type"] != "cards_dealt" {
 		t.Errorf("type = %v, want %q", event["type"], "cards_dealt")
@@ -476,7 +497,7 @@ func TestSwmlChangeStep(t *testing.T) {
 	fr := NewFunctionResult("changing step").
 		SwmlChangeStep("betting")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	// Python emits {"change_step": "betting"} — plain string, not a struct
 	if actions[0]["change_step"] != "betting" {
 		t.Errorf("change_step = %v, want %q", actions[0]["change_step"], "betting")
@@ -487,7 +508,7 @@ func TestSwmlChangeContext(t *testing.T) {
 	fr := NewFunctionResult("changing context").
 		SwmlChangeContext("support")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	// Python emits {"change_context": "support"} — plain string, not a struct
 	if actions[0]["change_context"] != "support" {
 		t.Errorf("change_context = %v, want %q", actions[0]["change_context"], "support")
@@ -498,7 +519,7 @@ func TestSwitchContextSimple(t *testing.T) {
 	fr := NewFunctionResult("switch").
 		SwitchContext("You are a helper.", "", false, false, false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	cs := actions[0]["context_switch"]
 	if cs != "You are a helper." {
 		t.Errorf("context_switch = %v, want simple string", cs)
@@ -509,8 +530,8 @@ func TestSwitchContextAdvanced(t *testing.T) {
 	fr := NewFunctionResult("switch").
 		SwitchContext("new prompt", "user msg", true, false, false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	cs := actions[0]["context_switch"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	cs := as[map[string]any](t, actions[0]["context_switch"])
 	if cs["system_prompt"] != "new prompt" {
 		t.Errorf("system_prompt = %v", cs["system_prompt"])
 	}
@@ -529,8 +550,8 @@ func TestSwitchContextIsolated(t *testing.T) {
 	fr := NewFunctionResult("switch").
 		SwitchContext("prompt", "", false, false, true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	cs := actions[0]["context_switch"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	cs := as[map[string]any](t, actions[0]["context_switch"])
 	if cs["isolated"] != true {
 		t.Error("isolated should be true")
 	}
@@ -540,7 +561,7 @@ func TestReplaceInHistoryString(t *testing.T) {
 	fr := NewFunctionResult("replace").
 		ReplaceInHistory("summary text")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["replace_in_history"] != "summary text" {
 		t.Errorf("replace_in_history = %v, want %q", actions[0]["replace_in_history"], "summary text")
 	}
@@ -550,7 +571,7 @@ func TestReplaceInHistoryBool(t *testing.T) {
 	fr := NewFunctionResult("replace").
 		ReplaceInHistory(true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["replace_in_history"] != true {
 		t.Errorf("replace_in_history = %v, want true", actions[0]["replace_in_history"])
 	}
@@ -561,7 +582,7 @@ func TestReplaceInHistoryBool(t *testing.T) {
 func TestSay(t *testing.T) {
 	fr := NewFunctionResult("speaking").Say("Hello there!")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["say"] != "Hello there!" {
 		t.Errorf("say = %v, want %q", actions[0]["say"], "Hello there!")
 	}
@@ -571,7 +592,7 @@ func TestPlayBackgroundFile(t *testing.T) {
 	fr := NewFunctionResult("playing").
 		PlayBackgroundFile("music.mp3", false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["playback_bg"] != "music.mp3" {
 		t.Errorf("playback_bg = %v, want %q", actions[0]["playback_bg"], "music.mp3")
 	}
@@ -581,8 +602,8 @@ func TestPlayBackgroundFileWait(t *testing.T) {
 	fr := NewFunctionResult("playing").
 		PlayBackgroundFile("music.mp3", true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	bg := actions[0]["playback_bg"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	bg := as[map[string]any](t, actions[0]["playback_bg"])
 	if bg["file"] != "music.mp3" {
 		t.Errorf("file = %v, want %q", bg["file"], "music.mp3")
 	}
@@ -594,7 +615,7 @@ func TestPlayBackgroundFileWait(t *testing.T) {
 func TestStopBackgroundFile(t *testing.T) {
 	fr := NewFunctionResult("stopping").StopBackgroundFile()
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["stop_playback_bg"] != true {
 		t.Errorf("stop_playback_bg = %v, want true", actions[0]["stop_playback_bg"])
 	}
@@ -604,12 +625,12 @@ func TestRecordCall(t *testing.T) {
 	fr := NewFunctionResult("recording").
 		RecordCall("rec-123", true, "wav", "both", nil)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["record_call"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["record_call"])
 
 	if params["control_id"] != "rec-123" {
 		t.Errorf("control_id = %v, want %q", params["control_id"], "rec-123")
@@ -652,10 +673,10 @@ func TestRecordCall_FormatEnumOrString(t *testing.T) {
 	}
 
 	extractFormat := func(fr *FunctionResult) any {
-		actions := fr.ToMap()["action"].([]map[string]any)
-		swml := actions[0]["SWML"].(map[string]any)
-		main := swml["sections"].(map[string]any)["main"].([]any)
-		return main[0].(map[string]any)["record_call"].(map[string]any)["format"]
+		actions := as[[]map[string]any](t, fr.ToMap()["action"])
+		swml := as[map[string]any](t, actions[0]["SWML"])
+		main := as[[]any](t, as[map[string]any](t, swml["sections"])["main"])
+		return as[map[string]any](t, as[map[string]any](t, main[0])["record_call"])["format"]
 	}
 
 	// Typed constant path.
@@ -675,12 +696,12 @@ func TestRecordCallNoControlID(t *testing.T) {
 	fr := NewFunctionResult("recording").
 		RecordCall("", false, "mp3", "speak", nil)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["record_call"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["record_call"])
 
 	if _, ok := params["control_id"]; ok {
 		t.Error("control_id should not be present when empty")
@@ -706,12 +727,12 @@ func TestRecordCallWithOptions(t *testing.T) {
 			StatusURL:         "https://example.com/recording-status",
 		})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["record_call"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["record_call"])
 
 	if params["terminators"] != "#" {
 		t.Errorf("terminators = %v, want %q", params["terminators"], "#")
@@ -739,11 +760,11 @@ func TestRecordCallWithOptions(t *testing.T) {
 // recordCallParams drives the real RecordCall verb and returns the serialized
 // record_call params map for inspection (no mock — the SWML document is built
 // and read back through ToMap).
-func recordCallParams(fr *FunctionResult) map[string]any {
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	main := swml["sections"].(map[string]any)["main"].([]any)
-	return main[0].(map[string]any)["record_call"].(map[string]any)
+func recordCallParams(t *testing.T, fr *FunctionResult) map[string]any {
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	main := as[[]any](t, as[map[string]any](t, swml["sections"])["main"])
+	return as[map[string]any](t, as[map[string]any](t, main[0])["record_call"])
 }
 
 // TestRecordCall_DirectionConstantsAreWireStrings proves (a) each RecordDirection
@@ -795,7 +816,7 @@ func TestRecordCall_DirectionEnumOrStringByteIdentical(t *testing.T) {
 				d.str, typedJSON, strJSON)
 		}
 		// And the emitted token must be exactly the wire string.
-		if got := recordCallParams(NewFunctionResult("rec").
+		if got := recordCallParams(t, NewFunctionResult("rec").
 			RecordCall("id", true, FormatWAV, d.typed, nil))["direction"]; got != d.str {
 			t.Errorf("emitted direction = %v, want %q", got, d.str)
 		}
@@ -807,7 +828,7 @@ func TestRecordCall_DirectionEnumOrStringByteIdentical(t *testing.T) {
 // real method, appears unchanged in the serialized direction param.
 func TestRecordCall_DirectionAllRoundTrip(t *testing.T) {
 	for _, d := range []RecordDirection{RecordDirectionSpeak, RecordDirectionListen, RecordDirectionBoth} {
-		got := recordCallParams(NewFunctionResult("rec").
+		got := recordCallParams(t, NewFunctionResult("rec").
 			RecordCall("id", false, FormatMP3, d, nil))["direction"]
 		if got != string(d) {
 			t.Errorf("RecordDirection %q did not round-trip onto the wire (got %v)", string(d), got)
@@ -827,12 +848,12 @@ func TestStopRecordCall(t *testing.T) {
 	fr := NewFunctionResult("stop recording").
 		StopRecordCall("rec-123")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["stop_record_call"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["stop_record_call"])
 
 	if params["control_id"] != "rec-123" {
 		t.Errorf("control_id = %v, want %q", params["control_id"], "rec-123")
@@ -845,8 +866,8 @@ func TestAddDynamicHints(t *testing.T) {
 	hints := []any{"Cabby", map[string]any{"pattern": "cab bee", "replace": "Cabby"}}
 	fr := NewFunctionResult("hints").AddDynamicHints(hints)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	h := actions[0]["add_dynamic_hints"].([]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	h := as[[]any](t, actions[0]["add_dynamic_hints"])
 	if len(h) != 2 {
 		t.Fatalf("hints length = %d, want 2", len(h))
 	}
@@ -858,7 +879,7 @@ func TestAddDynamicHints(t *testing.T) {
 func TestClearDynamicHints(t *testing.T) {
 	fr := NewFunctionResult("clear").ClearDynamicHints()
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	ch, ok := actions[0]["clear_dynamic_hints"].(map[string]any)
 	if !ok {
 		t.Fatal("clear_dynamic_hints should be a map")
@@ -871,7 +892,7 @@ func TestClearDynamicHints(t *testing.T) {
 func TestSetEndOfSpeechTimeout(t *testing.T) {
 	fr := NewFunctionResult("timeout").SetEndOfSpeechTimeout(500)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["end_of_speech_timeout"] != 500 {
 		t.Errorf("end_of_speech_timeout = %v, want 500", actions[0]["end_of_speech_timeout"])
 	}
@@ -880,7 +901,7 @@ func TestSetEndOfSpeechTimeout(t *testing.T) {
 func TestSetSpeechEventTimeout(t *testing.T) {
 	fr := NewFunctionResult("timeout").SetSpeechEventTimeout(1000)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["speech_event_timeout"] != 1000 {
 		t.Errorf("speech_event_timeout = %v, want 1000", actions[0]["speech_event_timeout"])
 	}
@@ -893,8 +914,8 @@ func TestToggleFunctions(t *testing.T) {
 	}
 	fr := NewFunctionResult("toggle").ToggleFunctions(toggles)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	tf := actions[0]["toggle_functions"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	tf := as[[]map[string]any](t, actions[0]["toggle_functions"])
 	if len(tf) != 2 {
 		t.Fatalf("toggles length = %d, want 2", len(tf))
 	}
@@ -909,7 +930,7 @@ func TestToggleFunctions(t *testing.T) {
 func TestEnableFunctionsOnTimeout(t *testing.T) {
 	fr := NewFunctionResult("timeout").EnableFunctionsOnTimeout(true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["functions_on_speaker_timeout"] != true {
 		t.Errorf("functions_on_speaker_timeout = %v, want true", actions[0]["functions_on_speaker_timeout"])
 	}
@@ -918,7 +939,7 @@ func TestEnableFunctionsOnTimeout(t *testing.T) {
 func TestEnableExtensiveData(t *testing.T) {
 	fr := NewFunctionResult("data").EnableExtensiveData(true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	if actions[0]["extensive_data"] != true {
 		t.Errorf("extensive_data = %v, want true", actions[0]["extensive_data"])
 	}
@@ -928,8 +949,8 @@ func TestUpdateSettings(t *testing.T) {
 	fr := NewFunctionResult("settings").
 		UpdateSettings(map[string]any{"temperature": 0.5, "top_p": 0.9})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	s := actions[0]["settings"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	s := as[map[string]any](t, actions[0]["settings"])
 	if s["temperature"] != 0.5 {
 		t.Errorf("temperature = %v, want 0.5", s["temperature"])
 	}
@@ -946,8 +967,8 @@ func TestExecuteSwmlMap(t *testing.T) {
 	}
 	fr := NewFunctionResult("exec").ExecuteSwml(content, false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
 	if swml["version"] != "1.0.0" {
 		t.Errorf("version = %v, want %q", swml["version"], "1.0.0")
 	}
@@ -960,8 +981,8 @@ func TestExecuteSwmlMapWithTransfer(t *testing.T) {
 	content := map[string]any{"version": "1.0.0"}
 	fr := NewFunctionResult("exec").ExecuteSwml(content, true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
 	if swml["transfer"] != "true" {
 		t.Errorf("transfer = %v, want %q", swml["transfer"], "true")
 	}
@@ -973,8 +994,8 @@ func TestExecuteSwmlStringParsesJSON(t *testing.T) {
 	// at the top of the SWML action, and there is NO raw_swml wrapper.
 	fr := NewFunctionResult("exec").ExecuteSwml(`{"version":"1.0.0","sections":{"main":[]}}`, false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
 	if _, ok := swml["raw_swml"]; ok {
 		t.Errorf("a valid JSON-object string should be parsed and spread, not wrapped in raw_swml; got %v", swml["raw_swml"])
 	}
@@ -990,8 +1011,8 @@ func TestExecuteSwmlStringParsedWithTransfer(t *testing.T) {
 	// A parsed JSON-object string still gets the transfer key added on top.
 	fr := NewFunctionResult("exec").ExecuteSwml(`{"version":"1.0.0"}`, true)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
 	if swml["version"] != "1.0.0" {
 		t.Errorf("version = %v, want %q", swml["version"], "1.0.0")
 	}
@@ -1009,8 +1030,8 @@ func TestExecuteSwmlStringInvalidJSONFallsBackToRawSwml(t *testing.T) {
 	raw := "this is not json"
 	fr := NewFunctionResult("exec").ExecuteSwml(raw, false)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
 	if swml["raw_swml"] != raw {
 		t.Errorf("raw_swml = %v, want %q", swml["raw_swml"], raw)
 	}
@@ -1033,12 +1054,12 @@ func TestJoinConference(t *testing.T) {
 			WaitURL: "https://example.com/hold.mp3",
 		})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["join_conference"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["join_conference"])
 
 	if params["name"] != "my-conf" {
 		t.Errorf("name = %v, want %q", params["name"], "my-conf")
@@ -1063,11 +1084,11 @@ func TestJoinConferenceDefaults(t *testing.T) {
 	fr := NewFunctionResult("joining").
 		JoinConference("simple-conf", nil)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
 
 	name, ok := verb["join_conference"].(string)
 	if !ok {
@@ -1085,8 +1106,8 @@ func TestJoinConferenceSimpleVsFull(t *testing.T) {
 	// function_result.py:1124 vs :1134).
 	full := NewFunctionResult("joining").
 		JoinConference("conf", &JoinConferenceOptions{Muted: true})
-	actions := full.ToMap()["action"].([]map[string]any)
-	verb := actions[0]["SWML"].(map[string]any)["sections"].(map[string]any)["main"].([]any)[0].(map[string]any)
+	actions := as[[]map[string]any](t, full.ToMap()["action"])
+	verb := as[map[string]any](t, as[[]any](t, as[map[string]any](t, as[map[string]any](t, actions[0]["SWML"])["sections"])["main"])[0])
 	params, ok := verb["join_conference"].(map[string]any)
 	if !ok {
 		t.Fatalf("a non-default option must produce the object form, got %T", verb["join_conference"])
@@ -1115,12 +1136,12 @@ func TestJoinConferenceFullOptions(t *testing.T) {
 			MaxParticipants:               50,
 		})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["join_conference"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["join_conference"])
 
 	if params["record"] != "record-from-start" {
 		t.Errorf("record = %v", params["record"])
@@ -1142,12 +1163,12 @@ func TestJoinConferenceFullOptions(t *testing.T) {
 func TestJoinRoom(t *testing.T) {
 	fr := NewFunctionResult("joining room").JoinRoom("my-room")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["join_room"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["join_room"])
 
 	if params["name"] != "my-room" {
 		t.Errorf("name = %v, want %q", params["name"], "my-room")
@@ -1157,12 +1178,12 @@ func TestJoinRoom(t *testing.T) {
 func TestSipRefer(t *testing.T) {
 	fr := NewFunctionResult("referring").SIPRefer("sip:agent@example.com")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["sip_refer"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["sip_refer"])
 
 	if params["to_uri"] != "sip:agent@example.com" {
 		t.Errorf("to_uri = %v", params["to_uri"])
@@ -1173,12 +1194,12 @@ func TestTap(t *testing.T) {
 	fr := NewFunctionResult("tapping").
 		Tap("rtp://192.168.1.1:5000", "tap-1", "speak", "PCMA", 0, "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["tap"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["tap"])
 
 	if params["uri"] != "rtp://192.168.1.1:5000" {
 		t.Errorf("uri = %v", params["uri"])
@@ -1198,12 +1219,12 @@ func TestTapDefaults(t *testing.T) {
 	fr := NewFunctionResult("tapping").
 		Tap("ws://example.com", "", "both", "PCMU", 0, "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["tap"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["tap"])
 
 	if _, ok := params["control_id"]; ok {
 		t.Error("control_id should not be present when empty")
@@ -1220,12 +1241,12 @@ func TestTapWithRtpPtimeAndStatusURL(t *testing.T) {
 	fr := NewFunctionResult("tapping").
 		Tap("rtp://192.168.1.1:5000", "", "both", "PCMU", 30, "https://example.com/tap-status")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["tap"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["tap"])
 
 	if params["rtp_ptime"] != 30 {
 		t.Errorf("rtp_ptime = %v, want 30", params["rtp_ptime"])
@@ -1237,11 +1258,11 @@ func TestTapWithRtpPtimeAndStatusURL(t *testing.T) {
 
 // tapParamsOf drives the real Tap verb and returns the serialized tap params map
 // for inspection (no mock — the SWML document is built and read back via ToMap).
-func tapParamsOf(fr *FunctionResult) map[string]any {
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	main := swml["sections"].(map[string]any)["main"].([]any)
-	return main[0].(map[string]any)["tap"].(map[string]any)
+func tapParamsOf(t *testing.T, fr *FunctionResult) map[string]any {
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	main := as[[]any](t, as[map[string]any](t, swml["sections"])["main"])
+	return as[map[string]any](t, as[map[string]any](t, main[0])["tap"])
 }
 
 // TestTap_DirectionConstantsAreWireStrings proves (a) each TapDirection constant
@@ -1320,23 +1341,23 @@ func TestTap_DirectionAndCodecEnumOrStringByteIdentical(t *testing.T) {
 func TestTap_DirectionAndCodecAllRoundTrip(t *testing.T) {
 	// Non-default directions are emitted verbatim.
 	for _, d := range []TapDirection{TapDirectionSpeak, TapDirectionHear} {
-		got := tapParamsOf(NewFunctionResult("tap").Tap("ws://x", "", d, CodecPCMU, 0, ""))["direction"]
+		got := tapParamsOf(t, NewFunctionResult("tap").Tap("ws://x", "", d, CodecPCMU, 0, ""))["direction"]
 		if got != string(d) {
 			t.Errorf("TapDirection %q did not round-trip (got %v)", string(d), got)
 		}
 	}
 	// The default direction (both) is suppressed.
-	if _, ok := tapParamsOf(NewFunctionResult("tap").
+	if _, ok := tapParamsOf(t, NewFunctionResult("tap").
 		Tap("ws://x", "", TapDirectionBoth, CodecPCMU, 0, ""))["direction"]; ok {
 		t.Error("TapDirectionBoth (default) must be omitted from tap params")
 	}
 	// The non-default codec is emitted verbatim.
-	if got := tapParamsOf(NewFunctionResult("tap").
+	if got := tapParamsOf(t, NewFunctionResult("tap").
 		Tap("ws://x", "", TapDirectionBoth, CodecPCMA, 0, ""))["codec"]; got != "PCMA" {
 		t.Errorf("CodecPCMA did not round-trip (got %v)", got)
 	}
 	// The default codec (PCMU) is suppressed.
-	if _, ok := tapParamsOf(NewFunctionResult("tap").
+	if _, ok := tapParamsOf(t, NewFunctionResult("tap").
 		Tap("ws://x", "", TapDirectionBoth, CodecPCMU, 0, ""))["codec"]; ok {
 		t.Error("CodecPCMU (default) must be omitted from tap params")
 	}
@@ -1350,12 +1371,12 @@ func TestTap_DirectionAndCodecAllRoundTrip(t *testing.T) {
 func TestStopTap(t *testing.T) {
 	fr := NewFunctionResult("stop tap").StopTap("tap-1")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["stop_tap"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["stop_tap"])
 
 	if params["control_id"] != "tap-1" {
 		t.Errorf("control_id = %v", params["control_id"])
@@ -1365,12 +1386,12 @@ func TestStopTap(t *testing.T) {
 func TestStopTapNoControlID(t *testing.T) {
 	fr := NewFunctionResult("stop tap").StopTap("")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["stop_tap"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["stop_tap"])
 
 	if len(params) != 0 {
 		t.Errorf("stop_tap should be empty map, got %v", params)
@@ -1381,12 +1402,12 @@ func TestSendSms(t *testing.T) {
 	fr := NewFunctionResult("sms sent").
 		SendSms("+15551234567", "+15559876543", "Hello!", nil, nil, "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["send_sms"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["send_sms"])
 
 	if params["to_number"] != "+15551234567" {
 		t.Errorf("to_number = %v", params["to_number"])
@@ -1412,12 +1433,12 @@ func TestSendSmsWithRegion(t *testing.T) {
 	fr := NewFunctionResult("sms sent").
 		SendSms("+15551234567", "+15559876543", "Hello!", nil, nil, "us-east")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["send_sms"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["send_sms"])
 
 	if params["region"] != "us-east" {
 		t.Errorf("region = %v, want %q", params["region"], "us-east")
@@ -1430,21 +1451,21 @@ func TestSendSmsWithMediaAndTags(t *testing.T) {
 			[]string{"https://example.com/image.jpg"},
 			[]string{"support", "urgent"}, "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	params := verb["send_sms"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	params := as[map[string]any](t, verb["send_sms"])
 
 	if _, ok := params["body"]; ok {
 		t.Error("body should not be present when empty")
 	}
-	media := params["media"].([]string)
+	media := as[[]string](t, params["media"])
 	if len(media) != 1 || media[0] != "https://example.com/image.jpg" {
 		t.Errorf("media = %v", media)
 	}
-	tags := params["tags"].([]string)
+	tags := as[[]string](t, params["tags"])
 	if len(tags) != 2 {
 		t.Errorf("tags = %v", tags)
 	}
@@ -1455,17 +1476,17 @@ func TestPay(t *testing.T) {
 	fr := NewFunctionResult("processing payment").
 		Pay("https://example.com/pay", nil)
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
 
 	// Default behavior includes the "set" verb with ai_response
 	if len(main) != 2 {
 		t.Fatalf("main verbs = %d, want 2 (set + pay)", len(main))
 	}
-	verb := main[1].(map[string]any)
-	params := verb["pay"].(map[string]any)
+	verb := as[map[string]any](t, main[1])
+	params := as[map[string]any](t, verb["pay"])
 	if params["payment_connector_url"] != "https://example.com/pay" {
 		t.Errorf("payment_connector_url = %v", params["payment_connector_url"])
 	}
@@ -1482,24 +1503,24 @@ func TestPayAlwaysEmitsSetVerb(t *testing.T) {
 	fr := NewFunctionResult("processing payment").
 		Pay("https://example.com/pay", &PayOptions{AIResponse: "-"})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
 
 	// Both verbs are always present: set first, then pay.
 	if len(main) != 2 {
 		t.Fatalf("main verbs = %d, want 2 (set + pay)", len(main))
 	}
 
-	setVerb := main[0].(map[string]any)
-	setData := setVerb["set"].(map[string]any)
+	setVerb := as[map[string]any](t, main[0])
+	setData := as[map[string]any](t, setVerb["set"])
 	if setData["ai_response"] != "-" {
 		t.Errorf("ai_response = %v, want %q (emitted verbatim, not suppressed)", setData["ai_response"], "-")
 	}
 
-	verb := main[1].(map[string]any)
-	params := verb["pay"].(map[string]any)
+	verb := as[map[string]any](t, main[1])
+	params := as[map[string]any](t, verb["pay"])
 	if params["payment_connector_url"] != "https://example.com/pay" {
 		t.Errorf("payment_connector_url = %v", params["payment_connector_url"])
 	}
@@ -1509,17 +1530,17 @@ func TestPayWithCustomAiResponse(t *testing.T) {
 	fr := NewFunctionResult("processing payment").
 		Pay("https://example.com/pay", &PayOptions{AIResponse: "Payment complete"})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
 
 	if len(main) != 2 {
 		t.Fatalf("main verbs = %d, want 2 (set + pay)", len(main))
 	}
 
-	setVerb := main[0].(map[string]any)
-	setData := setVerb["set"].(map[string]any)
+	setVerb := as[map[string]any](t, main[0])
+	setData := as[map[string]any](t, setVerb["set"])
 	if setData["ai_response"] != "Payment complete" {
 		t.Errorf("ai_response = %v", setData["ai_response"])
 	}
@@ -1545,21 +1566,21 @@ func TestPayWithFullOptions(t *testing.T) {
 			AIResponse:      "Payment processed",
 		})
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
 
 	// set verb is always first, pay verb second (Python emits both unconditionally).
 	if len(main) != 2 {
 		t.Fatalf("main verbs = %d, want 2 (set + pay)", len(main))
 	}
-	setData := main[0].(map[string]any)["set"].(map[string]any)
+	setData := as[map[string]any](t, as[map[string]any](t, main[0])["set"])
 	if setData["ai_response"] != "Payment processed" {
 		t.Errorf("ai_response = %v, want %q", setData["ai_response"], "Payment processed")
 	}
-	verb := main[1].(map[string]any)
-	params := verb["pay"].(map[string]any)
+	verb := as[map[string]any](t, main[1])
+	params := as[map[string]any](t, verb["pay"])
 
 	if params["input"] != "voice" {
 		t.Errorf("input = %v, want %q", params["input"], "voice")
@@ -1587,12 +1608,12 @@ func TestExecuteRpc(t *testing.T) {
 	fr := NewFunctionResult("rpc").
 		ExecuteRPC("custom.method", map[string]any{"key": "value"}, "", "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	if rpc["method"] != "custom.method" {
 		t.Errorf("method = %v, want %q", rpc["method"], "custom.method")
@@ -1602,7 +1623,7 @@ func TestExecuteRpc(t *testing.T) {
 	if _, ok := rpc["jsonrpc"]; ok {
 		t.Errorf("jsonrpc should NOT be present in the execute_rpc verb, got %v", rpc["jsonrpc"])
 	}
-	params := rpc["params"].(map[string]any)
+	params := as[map[string]any](t, rpc["params"])
 	if params["key"] != "value" {
 		t.Errorf("params.key = %v, want %q", params["key"], "value")
 	}
@@ -1612,12 +1633,12 @@ func TestExecuteRpcNoParams(t *testing.T) {
 	fr := NewFunctionResult("rpc").
 		ExecuteRPC("simple.method", nil, "", "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	if _, ok := rpc["params"]; ok {
 		t.Error("params should not be present when nil")
@@ -1628,12 +1649,12 @@ func TestExecuteRpcWithCallIDAndNodeID(t *testing.T) {
 	fr := NewFunctionResult("rpc").
 		ExecuteRPC("my.method", map[string]any{"key": "val"}, "call-123", "node-456")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	if rpc["call_id"] != "call-123" {
 		t.Errorf("call_id = %v, want %q", rpc["call_id"], "call-123")
@@ -1647,12 +1668,12 @@ func TestRpcDial(t *testing.T) {
 	fr := NewFunctionResult("dialing").
 		RPCDial("+15551234567", "+15559876543", "https://example.com/swml", "phone")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	// Python uses bare "dial", not "calling.dial"
 	if rpc["method"] != "dial" {
@@ -1663,16 +1684,16 @@ func TestRpcDial(t *testing.T) {
 		t.Errorf("jsonrpc should NOT be present, got %v", rpc["jsonrpc"])
 	}
 
-	params := rpc["params"].(map[string]any)
+	params := as[map[string]any](t, rpc["params"])
 	if params["dest_swml"] != "https://example.com/swml" {
 		t.Errorf("dest_swml = %v", params["dest_swml"])
 	}
 
-	devices := params["devices"].(map[string]any)
+	devices := as[map[string]any](t, params["devices"])
 	if devices["type"] != "phone" {
 		t.Errorf("type = %v, want %q", devices["type"], "phone")
 	}
-	deviceParams := devices["params"].(map[string]any)
+	deviceParams := as[map[string]any](t, devices["params"])
 	if deviceParams["to_number"] != "+15551234567" {
 		t.Errorf("to_number = %v", deviceParams["to_number"])
 	}
@@ -1682,15 +1703,15 @@ func TestRpcDialDefaultDeviceType(t *testing.T) {
 	fr := NewFunctionResult("dialing").
 		RPCDial("+15551234567", "+15559876543", "https://example.com/swml", "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
-	params := rpc["params"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
+	params := as[map[string]any](t, rpc["params"])
 
-	devices := params["devices"].(map[string]any)
+	devices := as[map[string]any](t, params["devices"])
 	// Empty deviceType should default to "phone"
 	if devices["type"] != "phone" {
 		t.Errorf("type = %v, want %q (default)", devices["type"], "phone")
@@ -1701,12 +1722,12 @@ func TestRpcAiMessage(t *testing.T) {
 	fr := NewFunctionResult("messaging").
 		RPCAiMessage("call-abc-123", "Please take a message", "")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	// Python uses bare "ai_message", not "calling.ai_message"
 	if rpc["method"] != "ai_message" {
@@ -1720,7 +1741,7 @@ func TestRpcAiMessage(t *testing.T) {
 		t.Errorf("jsonrpc should NOT be present, got %v", rpc["jsonrpc"])
 	}
 
-	params := rpc["params"].(map[string]any)
+	params := as[map[string]any](t, rpc["params"])
 	if params["role"] != "system" {
 		t.Errorf("role = %v, want %q", params["role"], "system")
 	}
@@ -1733,13 +1754,13 @@ func TestRpcAiMessageCustomRole(t *testing.T) {
 	fr := NewFunctionResult("messaging").
 		RPCAiMessage("call-abc-123", "Hello", "user")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
-	params := rpc["params"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
+	params := as[map[string]any](t, rpc["params"])
 
 	if params["role"] != "user" {
 		t.Errorf("role = %v, want %q", params["role"], "user")
@@ -1750,12 +1771,12 @@ func TestRpcAiUnhold(t *testing.T) {
 	fr := NewFunctionResult("unholding").
 		RPCAiUnhold("call-abc-123")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
-	swml := actions[0]["SWML"].(map[string]any)
-	sections := swml["sections"].(map[string]any)
-	main := sections["main"].([]any)
-	verb := main[0].(map[string]any)
-	rpc := verb["execute_rpc"].(map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
+	swml := as[map[string]any](t, actions[0]["SWML"])
+	sections := as[map[string]any](t, swml["sections"])
+	main := as[[]any](t, sections["main"])
+	verb := as[map[string]any](t, main[0])
+	rpc := as[map[string]any](t, verb["execute_rpc"])
 
 	// Python uses bare "ai_unhold", not "calling.ai_unhold"
 	if rpc["method"] != "ai_unhold" {
@@ -1774,7 +1795,7 @@ func TestSimulateUserInput(t *testing.T) {
 	fr := NewFunctionResult("simulating").
 		SimulateUserInput("I need help")
 
-	actions := fr.ToMap()["action"].([]map[string]any)
+	actions := as[[]map[string]any](t, fr.ToMap()["action"])
 	// Python emits {"user_input": "..."} — not "simulate_user_input"
 	if actions[0]["user_input"] != "I need help" {
 		t.Errorf("user_input = %v, want %q", actions[0]["user_input"], "I need help")
@@ -1798,7 +1819,10 @@ func TestMultipleActionsChained(t *testing.T) {
 		SetPostProcess(true)
 
 	m := fr.ToMap()
-	actions := m["action"].([]map[string]any)
+	actions, ok := m["action"].([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", m["action"])
+	}
 	if len(actions) != 3 {
 		t.Fatalf("actions length = %d, want 3", len(actions))
 	}

--- a/pkg/swml/schema.go
+++ b/pkg/swml/schema.go
@@ -35,15 +35,15 @@ type Schema struct {
 var (
 	globalSchema     *Schema
 	globalSchemaOnce sync.Once
-	globalSchemaErr  error
+	errGlobalSchema  error
 )
 
 // GetSchema returns the global singleton Schema loaded from the embedded schema.json.
 func GetSchema() (*Schema, error) {
 	globalSchemaOnce.Do(func() {
-		globalSchema, globalSchemaErr = loadEmbeddedSchema()
+		globalSchema, errGlobalSchema = loadEmbeddedSchema()
 	})
-	return globalSchema, globalSchemaErr
+	return globalSchema, errGlobalSchema
 }
 
 func loadEmbeddedSchema() (*Schema, error) {

--- a/pkg/swml/schema_utils.go
+++ b/pkg/swml/schema_utils.go
@@ -362,10 +362,11 @@ func (s *SchemaUtils) GenerateMethodBody(verbName string) string {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	lines := []string{
+	lines := make([]string, 0, 2+2*len(keys)+1+1+1+1+1+1+1)
+	lines = append(lines,
 		"        # Prepare the configuration",
 		"        config = {}",
-	}
+	)
 	for _, name := range keys {
 		lines = append(lines, fmt.Sprintf("        if %s is not None:", name))
 		lines = append(lines, fmt.Sprintf("            config['%s'] = %s", name, name))

--- a/pkg/swml/service_test.go
+++ b/pkg/swml/service_test.go
@@ -162,8 +162,14 @@ func TestServiceRender(t *testing.T) {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 
-	sections := doc["sections"].(map[string]any)
-	main := sections["main"].([]any)
+	sections, ok := doc["sections"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", doc["sections"])
+	}
+	main, ok := sections["main"].([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", sections["main"])
+	}
 	if len(main) != 3 {
 		t.Errorf("expected 3 verbs, got %d", len(main))
 	}

--- a/pkg/swml/tls_server_test.go
+++ b/pkg/swml/tls_server_test.go
@@ -26,6 +26,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -63,7 +64,7 @@ func TestTLS_Server_HTTPS(t *testing.T) {
 		_ = svc.Stop()
 		select {
 		case err := <-serveErr:
-			if err != nil && err != http.ErrServerClosed {
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				t.Logf("Serve returned: %v", err)
 			}
 		case <-time.After(3 * time.Second):

--- a/pkg/swml/tls_server_test.go
+++ b/pkg/swml/tls_server_test.go
@@ -148,7 +148,11 @@ func freeTCPPort(t *testing.T) int {
 		t.Fatalf("freeTCPPort: %v", err)
 	}
 	defer func() { _ = l.Close() }()
-	return l.Addr().(*net.TCPAddr).Port
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected *net.TCPAddr, got %T", l.Addr())
+	}
+	return addr.Port
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/util/url_validator.go
+++ b/pkg/util/url_validator.go
@@ -49,9 +49,7 @@ var blockedNetworks = func() []*net.IPNet {
 var urlValidatorLogger = logging.New("signalwire.url_validator")
 
 // resolveHost is overridable so tests can inject a fake DNS resolver.
-var resolveHost = func(hostname string) ([]net.IP, error) {
-	return net.LookupIP(hostname)
-}
+var resolveHost = net.LookupIP
 
 // ValidateURL reports whether the supplied URL is safe to fetch.
 //

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -12,7 +12,7 @@
 #   5. no-cheat gate                      — porting-sdk audit_no_cheat_tests.py
 #   6. emission gate                      — porting-sdk diff_port_emission.py
 #   7. fmt gate                           — gofmt (local: auto-fix; CI: -l check)
-#   8. lint gate                          — go vet ./...
+#   8. lint gate                          — go vet + golangci-lint (.golangci.yml)
 #   9. doc-audit gate                     — porting-sdk audit_docs.py
 #  10. surface-diff gate                  — porting-sdk diff_port_surface.py
 #
@@ -173,16 +173,33 @@ fmt_gate() {
 }
 run_gate "FMT" "gofmt (local: auto-fix; CI: -l check)" fmt_gate
 
-# Gate 8: LINT — the language lint gate (go: go vet). `go vet ./...` is the
-# builtin static-analysis floor and exits 0 on this codebase today, so it gates
-# blocking from day one with zero backlog. The TEST gate's `go test ./...` only
-# vets test-bearing packages, so vet is NOT already guaranteed — making it
-# explicit is a free, high-signal gate. (golangci-lint, which bundles
-# staticcheck/errcheck/unused, is the deferred advisory tier: it needs a
-# .golangci.yml excluding examples/ and will surface a backlog — burn down
-# advisory, then promote, exactly as Rust did with clippy.)
-run_gate "LINT" "go vet ./... (lint gate)" \
-    go vet ./...
+# Gate 8: LINT — the language lint gate (go). Two layers:
+#   1. `go vet ./...` — the builtin static-analysis floor (always available).
+#   2. golangci-lint — the deep linter set governed by .golangci.yml (errcheck,
+#      staticcheck, forcetypeassert, errchkjson, … — burned to zero, see the
+#      config header). Mirrors how Rust promoted clippy to a blocking gate after
+#      its burn-down.
+#
+# golangci-lint is installed by the CI workflow via the official
+# golangci/golangci-lint-action (cached, pinned — see .github/workflows/test.yml)
+# rather than curl|sh'd here, so the script never executes a remote installer.
+# In CI ($CI set) golangci MUST be present and the gate is BLOCKING. Locally, if
+# a developer hasn't installed it, the gate warns and runs go-vet-only instead of
+# failing — `go install` it (or `brew install golangci-lint`) to get the full
+# check locally. Pinned version lives in the workflow; keep them in lockstep.
+lint_gate() {
+    go vet ./... || return 1
+    if command -v golangci-lint >/dev/null 2>&1; then
+        golangci-lint run --config "$PORT_ROOT/.golangci.yml" \
+            --max-same-issues 0 --max-issues-per-linter 0 ./... || return 1
+    elif [ -n "${CI:-}" ]; then
+        echo "golangci-lint not found in CI — the workflow must install it (golangci-lint-action)"
+        return 1
+    else
+        echo "    (golangci-lint not installed — running go vet only; install it for the full lint gate)"
+    fi
+}
+run_gate "LINT" "go vet + golangci-lint (lint gate)" lint_gate
 
 # Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced
 # code blocks must resolve to a real symbol in the port surface (catches


### PR DESCRIPTION
**Stacked on #214** (base `lint/golangci-burndown`; merge #214 first → this re-targets `main`). Two commits.

Expands the golangci-lint gate after a **measured survey of all ~95 disabled linters** (each run against the codebase; findings **sampled for real-vs-noise** — counts alone mislead), then **promotes golangci-lint from advisory to a blocking run-ci gate**. Same fix-by-hand discipline as #214.

## Findings worth calling out
- The survey counts were **capped** by golangci's default `max-same-issues: 3` — `forcetypeassert` showed "24" but was really **388**. Re-swept uncapped to reach true zero.
- **Sampling overturned several count-based "bug-catchers"** as false positives on idiomatic Go → dropped (we don't `//nolint` correct code to satisfy a linter).

## Adopted + fixed by hand
`forcetypeassert` (388 sites via generic test helper `as[T]`), `errchkjson`, `errorlint` (wrapped-error `!=`→`errors.Is`), `intrange`, `prealloc`, `unconvert`, `errname`, `predeclared`, `gocritic` (assignOp/ifElseChain/unlambda; 3 `appendAssign` — livewire.go rewritten to a fresh slice to stop aliasing a struct field's backing array, 2 map-derivations `//nolint`'d).

## Adopted as zero-hit guards (clean today; bug class can occur → free regression protection)
`durationcheck`, `makezero`, `nilnesserr`, `bidichk`, `reassign`, `recvcheck`, `wastedassign`

## Deliberately NOT adopted (sampled: fire on idiomatic Go / parity conflict — all documented in `.golangci.yml`)
`nilerr` (filepath.Walk continue), `contextcheck` (ctx-nil guard), `nilnil` (`nil,nil`=absent), `unparam` (one-caller test helpers), `bodyclose` (expect-failure TLS tests), `goprintffuncname` (would break public logger API + Python parity), `usetesting` (manual save/restore already correct; t.Setenv changes unset semantics), `dupword` (FP on a markdown test fixture).

## Gate promotion (burn-first / gate-second, like Rust's clippy)
- `run-ci.sh` **LINT gate** now runs `go vet` **+ golangci-lint** (`--config .golangci.yml`, uncapped). Blocking in CI; locally warns + runs go-vet-only if golangci isn't installed.
- golangci is installed in CI via the official `golangci/golangci-lint-action` (**install-only**, pinned v2.12.2) — the script invokes it but never `curl|sh`s an installer.
- `test.yml`: added the install step; refreshed gate-list comments to the full 10 gates.

## Verification
- golangci-lint with the full config: **0** (uncapped, all packages)
- Full **10-gate `run-ci.sh` green** (LINT now = go vet + golangci-lint); DRIFT/SURFACE/EMISSION unaffected; all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)