### PR TITLE
feat(skills): SKILL-CONTRACT gate + fix 8 skill-contract divergences

### DIFF
--- a/cmd/emit-skills/main.go
+++ b/cmd/emit-skills/main.go
@@ -1,0 +1,121 @@
+// Command emit-skills is the Go port's SKILL-DUMP program for the cross-port
+// SKILL-CONTRACT differ (porting-sdk/scripts/diff_skill_contracts.py).
+//
+// The sibling of cmd/emit-corpus, for built-in SKILLS rather than
+// FunctionResult. For each covered skill it looks up the skill's factory in the
+// global registry (populated by the builtin packages' init()), instantiates it
+// with the canonical config from the shared corpus
+// (porting-sdk/scripts/skill_contract_corpus.py — the single source of truth),
+// runs Setup() + RegisterTools(), and prints ONE JSON object mapping
+//
+//	skill-id -> [ { "name": ..., "parameters": {...} }, ... ]
+//
+// to stdout. The differ runs this, parses it, and structurally compares each
+// skill's tool contract against the Python reference (which registers the same
+// tools). The differ normalises both sides (flat vs wrapped params, required
+// list, enum order); this program just emits each tool's Name + Parameters
+// verbatim. DESCRIPTIONS are not part of the compared contract.
+//
+// CONTRACT (mirrors the per-port dump contract in the differ's --help):
+//   - The id set MUST equal corpus_ids() (the differ rejects a mismatch).
+//   - Only stdout carries the JSON object; logs go to stderr.
+//
+// Run from the signalwire-go repo root:
+//
+//	go run ./cmd/emit-skills
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/signalwire/signalwire-go/pkg/skills"
+	_ "github.com/signalwire/signalwire-go/pkg/skills/all" // register all built-in skills via init()
+)
+
+// corpusEntry mirrors one entry of skill_contract_corpus.py's CORPUS.
+type corpusEntry struct {
+	ID     string         `json:"id"`
+	Skill  string         `json:"skill"`
+	Config map[string]any `json:"config"`
+}
+
+// toolContract is the per-tool shape the differ reads. Parameters is emitted
+// verbatim (the wrapped JSON-Schema map the skill registered); the differ peels
+// off type/properties/required and folds enum/required order.
+type toolContract struct {
+	Name       string         `json:"name"`
+	Parameters map[string]any `json:"parameters"`
+}
+
+// loadCorpus runs the shared corpus script and returns its CORPUS entries.
+// porting-sdk is resolved via $PORTING_SDK / $PORTING_SDK_PATH or the sibling
+// ../porting-sdk (the adjacency convention).
+func loadCorpus() ([]corpusEntry, error) {
+	var bases []string
+	for _, env := range []string{os.Getenv("PORTING_SDK"), os.Getenv("PORTING_SDK_PATH")} {
+		if env != "" {
+			bases = append(bases, env)
+		}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		bases = append(bases, filepath.Join(wd, "..", "porting-sdk"))
+	}
+	for _, base := range bases {
+		script := filepath.Join(base, "scripts", "skill_contract_corpus.py")
+		if _, err := os.Stat(script); err != nil {
+			continue
+		}
+		out, err := exec.Command("python3", script).Output()
+		if err != nil {
+			return nil, fmt.Errorf("running %s: %w", script, err)
+		}
+		var parsed struct {
+			Corpus []corpusEntry `json:"corpus"`
+		}
+		if err := json.Unmarshal(out, &parsed); err != nil {
+			return nil, fmt.Errorf("parsing corpus JSON: %w", err)
+		}
+		return parsed.Corpus, nil
+	}
+	return nil, fmt.Errorf("cannot locate porting-sdk/scripts/skill_contract_corpus.py " +
+		"(set PORTING_SDK / PORTING_SDK_PATH or clone porting-sdk adjacent)")
+}
+
+func main() {
+	corpus, err := loadCorpus()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "emit-skills: %v\n", err)
+		os.Exit(1)
+	}
+
+	result := make(map[string][]toolContract, len(corpus))
+	for _, entry := range corpus {
+		factory := skills.GetSkillFactory(entry.Skill)
+		if factory == nil {
+			fmt.Fprintf(os.Stderr, "emit-skills: no registered factory for covered skill %q\n", entry.Skill)
+			os.Exit(1)
+		}
+		skill := factory(entry.Config)
+		if !skill.Setup() {
+			fmt.Fprintf(os.Stderr, "emit-skills: skill %q Setup() returned false with the "+
+				"corpus config — config drift between the corpus and the port.\n", entry.Skill)
+			os.Exit(1)
+		}
+		tools := skill.RegisterTools()
+		contracts := make([]toolContract, 0, len(tools))
+		for _, t := range tools {
+			contracts = append(contracts, toolContract{Name: t.Name, Parameters: t.Parameters})
+		}
+		result[entry.ID] = contracts
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "emit-skills: encoding result: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1523,16 +1523,16 @@ func TestAddSkill_DateTime(t *testing.T) {
 	tools := a.DefineTools()
 	toolFound := false
 	for _, tool := range tools {
-		if tool.Name == "get_datetime" {
+		if tool.Name == "get_current_time" {
 			toolFound = true
 			if tool.Handler == nil {
-				t.Error("expected handler to be set for get_datetime tool")
+				t.Error("expected handler to be set for get_current_time tool")
 			}
 			break
 		}
 	}
 	if !toolFound {
-		t.Error("expected get_datetime tool to be registered")
+		t.Error("expected get_current_time tool to be registered")
 	}
 
 	// Verify hints were added
@@ -1598,9 +1598,9 @@ func TestAddSkill_ToolExecutes(t *testing.T) {
 	a.AddSkill("datetime", nil)
 
 	// Call the tool and verify it returns a valid result
-	result, err := a.OnFunctionCall("get_datetime", map[string]any{}, nil)
+	result, err := a.OnFunctionCall("get_current_time", map[string]any{}, nil)
 	if err != nil {
-		t.Fatalf("unexpected error calling get_datetime: %v", err)
+		t.Fatalf("unexpected error calling get_current_time: %v", err)
 	}
 	m, ok := result.(map[string]any)
 	if !ok {
@@ -1608,7 +1608,7 @@ func TestAddSkill_ToolExecutes(t *testing.T) {
 	}
 	resp, ok := m["response"].(string)
 	if !ok || resp == "" {
-		t.Errorf("expected non-empty response from get_datetime, got %v", m["response"])
+		t.Errorf("expected non-empty response from get_current_time, got %v", m["response"])
 	}
 }
 

--- a/pkg/skills/builtin/builtin_test.go
+++ b/pkg/skills/builtin/builtin_test.go
@@ -71,13 +71,13 @@ func TestDateTimeInstantiationAndSetup(t *testing.T) {
 	if len(tools) == 0 {
 		t.Error("datetime RegisterTools() returned empty")
 	}
-	// Skills now register get_current_time, get_current_date, and get_datetime.
-	// Verify all three are present.
+	// datetime registers exactly get_current_time + get_current_date (matches
+	// Python; no combined get_datetime tool).
 	toolNames := make(map[string]bool)
 	for _, tool := range tools {
 		toolNames[tool.Name] = true
 	}
-	for _, want := range []string{"get_current_time", "get_current_date", "get_datetime"} {
+	for _, want := range []string{"get_current_time", "get_current_date"} {
 		if !toolNames[want] {
 			t.Errorf("expected tool %q to be registered", want)
 		}

--- a/pkg/skills/builtin/datasphere.go
+++ b/pkg/skills/builtin/datasphere.go
@@ -134,7 +134,7 @@ func (s *DataSphereSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "The search query",
 					},
 				},
-				"required": []string{"query"},
+				// No `required` — Python passes none (datasphere/skill.py:171).
 			},
 			Handler: s.handleSearch,
 		},

--- a/pkg/skills/builtin/datetime.go
+++ b/pkg/skills/builtin/datetime.go
@@ -62,20 +62,6 @@ func (s *DateTimeSkill) RegisterTools() []skills.ToolRegistration {
 			},
 			Handler: s.handleGetCurrentDate,
 		},
-		{
-			Name:        "get_datetime",
-			Description: "Get the current date and time, optionally in a specific timezone",
-			Parameters: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"timezone": map[string]any{
-						"type":        "string",
-						"description": "Timezone name (e.g., 'America/New_York', 'Europe/London'). Defaults to UTC.",
-					},
-				},
-			},
-			Handler: s.handleGetDateTime,
-		},
 	}
 }
 
@@ -111,20 +97,6 @@ func (s *DateTimeSkill) handleGetCurrentDate(args map[string]any, _ map[string]a
 	return swaig.NewFunctionResult(fmt.Sprintf("Today's date is %s", dateStr))
 }
 
-func (s *DateTimeSkill) handleGetDateTime(args map[string]any, _ map[string]any) *swaig.FunctionResult {
-	loc, err := s.resolveLocation(args)
-	if err != nil {
-		tzName, _ := args["timezone"].(string)
-		return swaig.NewFunctionResult(fmt.Sprintf("Error: invalid timezone '%s'", tzName))
-	}
-
-	now := time.Now().In(loc)
-	dateStr := now.Format("Monday, January 02, 2006")
-	timeStr := now.Format("03:04:05 PM MST")
-
-	return swaig.NewFunctionResult(fmt.Sprintf("The current date is %s and the time is %s", dateStr, timeStr))
-}
-
 func (s *DateTimeSkill) GetHints() []string {
 	return []string{"time", "date", "today", "now", "current", "timezone"}
 }
@@ -135,8 +107,9 @@ func (s *DateTimeSkill) GetPromptSections() []map[string]any {
 			"title": "Date and Time Information",
 			"body":  "You can provide current date and time information.",
 			"bullets": []string{
-				"Use get_datetime to tell users the current date and time",
-				"Supports different timezones",
+				"Use get_current_time to tell users what time it is",
+				"Use get_current_date to tell users today's date",
+				"Both tools support different timezones via IANA identifiers",
 			},
 		},
 	}

--- a/pkg/skills/builtin/datetime_test.go
+++ b/pkg/skills/builtin/datetime_test.go
@@ -102,16 +102,19 @@ func TestDateTimeSkill_ToolName(t *testing.T) {
 	s := factory(nil)
 	s.Setup()
 	tools := s.RegisterTools()
-	// Python registers get_current_time and get_current_date as separate tools;
-	// get_datetime is kept for backward compatibility.
+	// Python registers exactly get_current_time and get_current_date
+	// (datetime/skill.py:33,45) — no third combined tool.
 	toolNames := make(map[string]bool)
 	for _, tool := range tools {
 		toolNames[tool.Name] = true
 	}
-	for _, want := range []string{"get_current_time", "get_current_date", "get_datetime"} {
+	for _, want := range []string{"get_current_time", "get_current_date"} {
 		if !toolNames[want] {
 			t.Errorf("expected tool %q to be registered", want)
 		}
+	}
+	if toolNames["get_datetime"] {
+		t.Error("get_datetime is not part of the Python interface; should not be registered")
 	}
 }
 
@@ -121,25 +124,22 @@ func TestDateTimeSkill_ResponseContainsDate(t *testing.T) {
 	s.Setup()
 	tools := s.RegisterTools()
 
-	// Find get_datetime tool (returns both date and time in one response)
-	var datetimeTool *skills.ToolRegistration
+	// get_current_date returns a date-bearing response.
+	var dateTool *skills.ToolRegistration
 	for i := range tools {
-		if tools[i].Name == "get_datetime" {
-			datetimeTool = &tools[i]
+		if tools[i].Name == "get_current_date" {
+			dateTool = &tools[i]
 			break
 		}
 	}
-	if datetimeTool == nil {
-		t.Fatal("expected get_datetime tool to be registered")
+	if dateTool == nil {
+		t.Fatal("expected get_current_date tool to be registered")
 	}
 
-	result := datetimeTool.Handler(map[string]any{"timezone": "UTC"}, nil)
+	result := dateTool.Handler(map[string]any{"timezone": "UTC"}, nil)
 	m := result.ToMap()
 	resp, _ := m["response"].(string)
 	if !strings.Contains(resp, "date") {
 		t.Errorf("expected 'date' in response, got %q", resp)
-	}
-	if !strings.Contains(resp, "time") {
-		t.Errorf("expected 'time' in response, got %q", resp)
 	}
 }

--- a/pkg/skills/builtin/google_maps.go
+++ b/pkg/skills/builtin/google_maps.go
@@ -72,7 +72,7 @@ func (s *GoogleMapsSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "Longitude to bias results toward (optional)",
 					},
 				},
-				"required": []string{"address"},
+				// No `required` — Python passes none (google_maps/skill.py:433).
 			},
 			Handler: s.handleLookupAddress,
 		},
@@ -100,7 +100,7 @@ func (s *GoogleMapsSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "Destination longitude",
 					},
 				},
-				"required": []string{"origin_lat", "origin_lng", "dest_lat", "dest_lng"},
+				// No `required` — Python passes none (google_maps/skill.py:457).
 			},
 			Handler: s.handleComputeRoute,
 		},

--- a/pkg/skills/builtin/info_gatherer.go
+++ b/pkg/skills/builtin/info_gatherer.go
@@ -107,7 +107,8 @@ func (s *InfoGathererSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "Only set to true when the user has explicitly confirmed the answer is correct",
 					},
 				},
-				"required": []string{"answer"},
+				// No `required` — Python's submit_answer passes none
+				// (info_gatherer/skill.py:170).
 			},
 			Handler: s.handleSubmitAnswer,
 		},

--- a/pkg/skills/builtin/math.go
+++ b/pkg/skills/builtin/math.go
@@ -44,7 +44,7 @@ func (s *MathSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "Mathematical expression to evaluate (e.g., '2 + 3 * 4', '(10 + 5) / 3')",
 					},
 				},
-				"required": []string{"expression"},
+				// No `required` — Python's math skill passes none (math/skill.py:33).
 			},
 			Handler: s.handleCalculate,
 		},

--- a/pkg/skills/builtin/swml_transfer.go
+++ b/pkg/skills/builtin/swml_transfer.go
@@ -73,18 +73,14 @@ func (s *SWMLTransferSkill) Setup() bool {
 }
 
 func (s *SWMLTransferSkill) RegisterTools() []skills.ToolRegistration {
-	// Build enum from transfer keys
-	enumVals := make([]string, 0, len(s.transfers))
-	for k := range s.transfers {
-		enumVals = append(enumVals, k)
-	}
-
-	// Build properties: primary param + required_fields
+	// Build properties: primary param + required_fields. The primary param is a
+	// plain required string with NO enum — Python's swml_transfer does not put
+	// the transfer keys in the param schema (swml_transfer/skill.py:186); the
+	// keys drive DataMap pattern-matching expressions, not the param's enum.
 	properties := map[string]any{
 		s.paramName: map[string]any{
 			"type":        "string",
 			"description": s.paramDesc,
-			"enum":        enumVals,
 		},
 	}
 	requiredParams := make([]string, 0, 1+len(s.requiredFields))

--- a/pkg/skills/builtin/web_search.go
+++ b/pkg/skills/builtin/web_search.go
@@ -128,7 +128,7 @@ func (s *WebSearchSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "The search query - what you want to find information about",
 					},
 				},
-				"required": []string{"query"},
+				// No `required` — Python passes none (web_search/skill.py:707).
 			},
 			Handler: s.handleWebSearch,
 		},

--- a/pkg/skills/builtin/wikipedia_search.go
+++ b/pkg/skills/builtin/wikipedia_search.go
@@ -75,7 +75,7 @@ func (s *WikipediaSearchSkill) RegisterTools() []skills.ToolRegistration {
 						"description": "The search term or topic to look up on Wikipedia",
 					},
 				},
-				"required": []string{"query"},
+				// No `required` — Python passes none (wikipedia_search/skill.py:87).
 			},
 			Handler: s.handleSearch,
 		},

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -1,6 +1,6 @@
 {
   "version": "2",
-  "generated_from": "signalwire-go @ a885be93b590e49f2a5b84c22dd3d47b31c55a25 (go/ast walker)",
+  "generated_from": "signalwire-go @ 85cebe4b00f63eabbf87f67dc1311d5bf0111cfd (go/ast walker)",
   "modules": {
     "signalwire": {
       "functions": {

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -141,6 +141,19 @@ run_gate "EMISSION" "diff_port_emission vs python to_dict() oracle" \
         --port go \
         --port-repo "$PORT_ROOT"
 
+# Gate 6b: skill-contract — the sibling of EMISSION for built-in SKILLS. EMISSION
+# byte-compares FunctionResult serialisation; this compares each skill's SWAIG
+# tool contract (name/parameters/required/enum from RegisterTools()) against the
+# Python reference. Catches a class drift/surface/emission can't see: a wrong
+# `required`, a renamed/retyped param, an extra/missing tool. The dump program
+# is cmd/emit-skills (go run ./cmd/emit-skills); dynamic skills are excluded +
+# logged by the shared corpus. Same prereqs as EMISSION (signalwire-python
+# adjacent; no network).
+run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
+        --dump-cmd "go run ./cmd/emit-skills" \
+        --port-repo "$PORT_ROOT"
+
 # Gate 7: FMT — the language format gate. Canonical gate name is language-neutral
 # (FMT); each port runs its own formatter under it. Here that is gofmt (Go's
 # builtin, canonical formatter — no tool to install, no config to bikeshed,


### PR DESCRIPTION
## What

Wires the cross-port **SKILL-CONTRACT** gate into Go and fixes the 8 divergences it found.

The gate (porting-sdk `diff_skill_contracts.py`, merged in porting-sdk #30) is the sibling of EMISSION for **skills**: it compares each built-in skill's SWAIG tool contract (`name` / `parameters` / `required` / `enum` from `RegisterTools()`) against the Python reference — a class of divergence that drift / surface / emission gates can't see.

## The 8 divergences (all verified vs the Python reference, all fixed)

- **datetime** — had an extra `get_datetime` tool Python lacks (Python: only `get_current_time` + `get_current_date`). Removed the tool + handler.
- **math, wikipedia_search, web_search, datasphere, info_gatherer (submit_answer), google_maps (lookup_address + compute_route)** — emitted `required` lists Python omits. Python passes no `required=`, so `SWAIGFunction` emits no `required` key. Dropped them.
- **swml_transfer** — added an `enum` to `transfer_type` Python doesn't have (Python's param is a plain required string; the transfer keys drive DataMap expressions, not the param enum). Dropped the enum.

## Infra

- `cmd/emit-skills` — the Go skill-dump (sibling of `cmd/emit-corpus`): reads the shared corpus, runs each covered skill's `Setup()`+`RegisterTools()`, emits `{name, parameters}` per tool.
- `scripts/run-ci.sh` — new SKILL-CONTRACT gate after EMISSION.

Updated the datetime/agent/builtin tests that asserted the old shapes.

**SKILL-CONTRACT now reports 13 covered contracts match** (4 dynamic skipped: mcp_gateway, claude_skills, datasphere_serverless, native_vector_search). Full 11-gate `run-ci.sh` green locally, including golangci LINT and DRIFT (after signature regen).

No merge-order constraint — `diff_skill_contracts.py` is already on porting-sdk `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)