### PR TITLE
test(mock): session-isolate the shared mock servers for parallel-safe tests

### DIFF
--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	messages           map[string]*Message             // message_id -> Message
 	pendingDials       map[string]chan *Call           // tag -> dial result
 	protocol           string
+	sessionID          string // server-issued `sessionid` from the connect handshake; test-only (see export_test.go)
 	authState          string
 	authorizationState string // signalwire.authorization.state event payload
 	contexts           []string
@@ -115,6 +116,30 @@ func (c *Client) RelayProtocol() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.protocol
+}
+
+// SessionID returns the server-assigned session id captured from the
+// signalwire.connect handshake (the connect result's `sessionid`). It is empty
+// until after a successful Connect+Authenticate.
+//
+// This is test-support surface, not part of the Python-mapped public API:
+// Python's RelayClient keeps the session id internal (TS keeps it as a private
+// `_sessionId`), so SessionID is deliberately NOT in the cross-port surface
+// translation table (internal/surface/tables.go) and is invisible to the
+// SURFACE-DIFF gate — exactly like the other connection-lifecycle helpers
+// (Authenticate, StartReadLoop, SubscribeContexts) that the mock test harness
+// needs but Python does not expose. Go's `export_test.go` mechanism is
+// same-package-only and cannot reach across to the separate
+// pkg/relay/internal/mocktest package, so unlike TS (which casts to the private
+// field) the accessor must be an exported method here; it remains off the
+// tracked surface, so no PORT_ADDITIONS entry is required.
+//
+// The mock harness reads it to scope its journal/scenario control-plane calls
+// to this client's session, making the shared mock safe under parallel tests.
+func (c *Client) SessionID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sessionID
 }
 
 // ProjectID returns the configured project ID. Mirrors Python's public
@@ -699,6 +724,7 @@ func (c *Client) authenticate() error {
 
 			var authResult struct {
 				Protocol      string `json:"protocol"`
+				SessionID     string `json:"sessionid"`
 				JWTToken      string `json:"jwt_token"`
 				Authorization struct {
 					Project string `json:"project"`
@@ -709,6 +735,13 @@ func (c *Client) authenticate() error {
 			}
 			c.mu.Lock()
 			c.protocol = authResult.Protocol
+			// Capture the server-assigned session id from the connect handshake.
+			// Kept off the public surface (Python's RelayClient does not expose it
+			// either — see PORT parity); tests read it via the test-only accessor
+			// in export_test.go to scope the mock harness to this client's session.
+			if authResult.SessionID != "" {
+				c.sessionID = authResult.SessionID
+			}
 			c.jwtToken = authResult.JWTToken
 			c.authState = "authenticated"
 			c.mu.Unlock()

--- a/pkg/relay/connect_mock_test.go
+++ b/pkg/relay/connect_mock_test.go
@@ -157,9 +157,6 @@ func TestRelay_ReconnectWithProtocolStringIncludesProtocolInFrame(t *testing.T) 
 	// client's accessor — easier path: build a second client and
 	// reuse the protocol field we know the server emitted.
 
-	// Reset journal so the only frames we see are the new client's.
-	h.JournalReset(t)
-
 	// Build a second client and inject its remembered protocol via
 	// WithJWT? No — we need a separate hook. The Python test does:
 	//   client2._relay_protocol = issued["protocol"]
@@ -169,8 +166,11 @@ func TestRelay_ReconnectWithProtocolStringIncludesProtocolInFrame(t *testing.T) 
 	// requires an explicit "protocol" field in connect params for the
 	// resume path — without a Go public surface for that, we settle
 	// for the looser invariant: each client gets its own protocol.
-
-	c2 := mocktest.NewClientOnly(t, h,
+	//
+	// The second client gets its OWN session; `c2h` is the harness scoped to
+	// it, so we read only its connect frame (no journal reset needed — a fresh
+	// session starts empty).
+	c2, c2h := mocktest.NewClientOnly(t, h,
 		relay.WithProject("p"),
 		relay.WithToken("t"),
 		relay.WithContexts("c1"),
@@ -179,7 +179,7 @@ func TestRelay_ReconnectWithProtocolStringIncludesProtocolInFrame(t *testing.T) 
 		t.Fatal("second client got empty protocol")
 	}
 	// Verify a connect frame was sent.
-	connects := h.JournalRecv(t, "signalwire.connect")
+	connects := c2h.JournalRecv(t, "signalwire.connect")
 	if len(connects) == 0 {
 		t.Fatal("no connect frame from second client")
 	}
@@ -198,7 +198,7 @@ func TestRelay_ReconnectWithProtocolPreservesProtocolValue(t *testing.T) {
 	if first == "" {
 		t.Fatal("first client got empty protocol")
 	}
-	c2 := mocktest.NewClientOnly(t, h,
+	c2, _ := mocktest.NewClientOnly(t, h,
 		relay.WithProject("p"),
 		relay.WithToken("t"),
 	)
@@ -287,14 +287,14 @@ func TestRelay_ConnectWithJWTCarriesJWTOnWire(t *testing.T) {
 	if h == nil {
 		return
 	}
-	h.JournalReset(t)
-	c := mocktest.NewClientOnly(t, h,
+	c, ch := mocktest.NewClientOnly(t, h,
 		relay.WithJWT("fake-jwt-eyJ.AaaA.BbB"),
 	)
 	if c.RelayProtocol() == "" {
 		t.Fatal("JWT client got no protocol back")
 	}
-	entry := h.JournalLast(t, "signalwire.connect")
+	// Read on the harness scoped to the JWT client's own session.
+	entry := ch.JournalLast(t, "signalwire.connect")
 	params, ok := entry.FrameParams()
 	if !ok {
 		t.Fatalf("connect frame has no params: %#v", entry.Frame)

--- a/pkg/relay/event_dispatch_mock_test.go
+++ b/pkg/relay/event_dispatch_mock_test.go
@@ -318,12 +318,15 @@ func TestRelay_DialEventRoutesViaTagWhenNoTopLevelCallID(t *testing.T) {
 	if h == nil {
 		return
 	}
-	client := mocktest.NewClientOnly(t, h,
+	client, ch := mocktest.NewClientOnly(t, h,
 		relay.WithProject("p"),
 		relay.WithToken("t"),
 		relay.WithContexts("default"),
 	)
-	h.ArmDial(t, mocktest.DialOpts{
+	// Arm + read on the harness scoped to THIS client's session (ch), not the
+	// New() client's harness (h), so the dial dance is queued and observed on
+	// the same session the Dial executes against.
+	ch.ArmDial(t, mocktest.DialOpts{
 		Tag:          "ec-tag-route",
 		WinnerCallID: "WINTAG",
 		States:       []string{"created", "answered"},
@@ -341,7 +344,7 @@ func TestRelay_DialEventRoutesViaTagWhenNoTopLevelCallID(t *testing.T) {
 	if call.CallID() != "WINTAG" {
 		t.Errorf("CallID = %q, want WINTAG", call.CallID())
 	}
-	sends := h.JournalSend(t, "calling.call.dial")
+	sends := ch.JournalSend(t, "calling.call.dial")
 	if len(sends) == 0 {
 		t.Fatal("no calling.call.dial event in journal")
 	}

--- a/pkg/relay/inbound_call_mock_test.go
+++ b/pkg/relay/inbound_call_mock_test.go
@@ -693,13 +693,15 @@ func TestRelay_InboundWithoutHandlerDoesNotCrash(t *testing.T) {
 	if h == nil {
 		return
 	}
-	// Build a fresh client with no on_call registered.
-	client := mocktest.NewClientOnly(t, h,
+	// Build a fresh client with no on_call registered. Use the harness scoped
+	// to THIS client's session (ch) so the inbound-call sequence is delivered
+	// to the client we then ping, not the New() client.
+	client, ch := mocktest.NewClientOnly(t, h,
 		relay.WithProject("p"),
 		relay.WithToken("t"),
 		relay.WithContexts("default"),
 	)
-	h.InboundCall(t, mocktest.InboundCallOpts{
+	ch.InboundCall(t, mocktest.InboundCallOpts{
 		CallID:     "c-nohandler",
 		AutoStates: []string{"created"},
 	})

--- a/pkg/relay/internal/mocktest/mocktest.go
+++ b/pkg/relay/internal/mocktest/mocktest.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,17 @@ type Harness struct {
 	WSPort   int
 	HTTPPort int
 
+	// SessionID scopes journal reads, scenario arming, pushes, and reset to a
+	// single RELAY session (the server-assigned `sessionid` from the connect
+	// handshake). When set, control-plane calls carry `?session_id=<id>` (and
+	// scenario_play stamps each push/expect_recv op), so a test only ever sees
+	// and disturbs its own frames — making the shared singleton mock safe under
+	// parallel (t.Parallel) execution. New() sets this automatically to the
+	// connected client's session. Empty => global (legacy, single-threaded).
+	//
+	// Mirrors signalwire-typescript's MockRelayHarness.sessionId.
+	SessionID string
+
 	httpClient *http.Client
 }
 
@@ -121,10 +133,44 @@ func (h *Harness) RelayHost() string {
 	return fmt.Sprintf("127.0.0.1:%d", h.WSPort)
 }
 
-// Journal returns every journaled frame, in arrival order.
+// scoped returns a shallow copy of this harness with SessionID set to the given
+// session id. The copy shares the same underlying HTTP client + server address;
+// only the session scope differs. Used by New()/NewClientOnly() to hand each
+// test (or each client built mid-test) a view scoped to its own session, while
+// leaving the package-singleton harness untouched. Mirrors the TS harness's
+// per-call `new MockRelayHarness(...)` + `mock.sessionId = ...`.
+func (h *Harness) scoped(sessionID string) *Harness {
+	cp := *h
+	cp.SessionID = sessionID
+	return &cp
+}
+
+// ScopeToClient returns a copy of this harness scoped to the given client's
+// captured connect-handshake session id. Tests that build their own client
+// mid-test (e.g. a second client via NewClientOnly already returns a scoped
+// harness, but a hand-rolled relay.NewRelayClient does not) call this to
+// re-scope the harness to that client's session. Mirrors the TS harness's
+// `mock.sessionId = sessionIdOf(client)`.
+func (h *Harness) ScopeToClient(client *relay.Client) *Harness {
+	return h.scoped(client.SessionID())
+}
+
+// sessionQuery returns the "?session_id=<id>" suffix when this harness is
+// session-scoped, or "" otherwise. The id is URL-escaped so a session id with
+// reserved characters stays a single query value.
+func (h *Harness) sessionQuery() string {
+	if h.SessionID == "" {
+		return ""
+	}
+	return "?session_id=" + url.QueryEscape(h.SessionID)
+}
+
+// Journal returns every journaled frame, in arrival order. Scoped to this
+// harness's SessionID when set (so a parallel test never sees another test's
+// frames); unscoped harnesses see the whole journal.
 func (h *Harness) Journal(t *testing.T) []JournalEntry {
 	t.Helper()
-	resp, err := h.httpClient.Get(h.HTTPURL + "/__mock__/journal")
+	resp, err := h.httpClient.Get(h.HTTPURL + "/__mock__/journal" + h.sessionQuery())
 	if err != nil {
 		t.Fatalf("mocktest: GET /__mock__/journal: %v", err)
 	}
@@ -190,18 +236,21 @@ func (h *Harness) JournalLast(t *testing.T, method string) JournalEntry {
 	return entries[len(entries)-1]
 }
 
-// JournalReset clears the mock journal.
+// JournalReset clears the mock journal. Scoped to this harness's SessionID
+// when set (clears only this session's entries), else clears everything.
 func (h *Harness) JournalReset(t *testing.T) {
 	t.Helper()
-	h.post(t, "/__mock__/journal/reset", nil)
+	h.post(t, "/__mock__/journal/reset"+h.sessionQuery(), nil)
 }
 
-// Reset clears journal + scenarios on the mock server. Tests do not call
-// this directly — New registers it as a t.Cleanup hook.
+// Reset clears journal + scenarios on the mock server. Scoped to this harness's
+// SessionID when set (so a parallel test only ever clears its own session and
+// never races a concurrent test's global state), else clears everything. Tests
+// do not call this directly — New registers it as a t.Cleanup hook.
 func (h *Harness) Reset(t *testing.T) {
 	t.Helper()
-	h.post(t, "/__mock__/journal/reset", nil)
-	h.post(t, "/__mock__/scenarios/reset", nil)
+	h.post(t, "/__mock__/journal/reset"+h.sessionQuery(), nil)
+	h.post(t, "/__mock__/scenarios/reset"+h.sessionQuery(), nil)
 }
 
 // post is an internal HTTP-POST helper.
@@ -247,13 +296,20 @@ func (h *Harness) post(t *testing.T, path string, body any) []byte {
 	return respBody
 }
 
-// Push delivers a single frame to all connected sessions (or one
-// session if sessionID != "").
+// Push delivers a single frame to this harness's session (when scoped) so a
+// parallel test's client never receives it. An explicit sessionID arg overrides
+// the harness scope; an unscoped harness with sessionID=="" broadcasts to every
+// connected session (legacy single-threaded behavior). Mirrors the TS harness's
+// push(frame, sessionId?).
 func (h *Harness) Push(t *testing.T, frame map[string]any, sessionID string) {
 	t.Helper()
+	target := sessionID
+	if target == "" {
+		target = h.SessionID
+	}
 	path := "/__mock__/push"
-	if sessionID != "" {
-		path = path + "?session_id=" + sessionID
+	if target != "" {
+		path = path + "?session_id=" + url.QueryEscape(target)
 	}
 	h.post(t, path, map[string]any{"frame": frame})
 }
@@ -292,8 +348,16 @@ func (h *Harness) InboundCall(t *testing.T, opts InboundCallOpts) {
 	} else {
 		body["delay_ms"] = 50
 	}
-	if opts.SessionID != "" {
-		body["session_id"] = opts.SessionID
+	// Target this harness's session by default so the inbound-call sequence is
+	// delivered only to this test's client (an unscoped harness broadcasts, as
+	// before). An explicit opts.SessionID overrides. Mirrors the TS harness's
+	// inboundCall default-to-this-session behavior.
+	sid := opts.SessionID
+	if sid == "" {
+		sid = h.SessionID
+	}
+	if sid != "" {
+		body["session_id"] = sid
 	}
 	h.post(t, "/__mock__/inbound_call", body)
 }
@@ -301,9 +365,23 @@ func (h *Harness) InboundCall(t *testing.T, opts InboundCallOpts) {
 // ScenarioPlay runs a scripted timeline (mix of sleep_ms / push /
 // expect_recv ops). The op shape matches the JSON the mock expects;
 // callers can pass map literals.
+//
+// When this harness is session-scoped, each push/expect_recv op is stamped with
+// this session id (unless it already carries a session_id), so the timeline
+// targets only this test's client and expect_recv matches only this session's
+// frames — making it parallel-safe. (The eviction-bug fix that makes the
+// session-filtered scan correct already lives in the mock server; the harness
+// only has to stamp.) Mirrors the TS harness's scenarioPlay scopeOp().
 func (h *Harness) ScenarioPlay(t *testing.T, ops []map[string]any) map[string]any {
 	t.Helper()
-	body := h.post(t, "/__mock__/scenario_play", ops)
+	scoped := ops
+	if h.SessionID != "" {
+		scoped = make([]map[string]any, len(ops))
+		for i, op := range ops {
+			scoped[i] = h.scopeOp(op)
+		}
+	}
+	body := h.post(t, "/__mock__/scenario_play", scoped)
 	var out map[string]any
 	if err := json.Unmarshal(body, &out); err != nil {
 		t.Fatalf("mocktest: decode scenario_play response: %v", err)
@@ -311,11 +389,39 @@ func (h *Harness) ScenarioPlay(t *testing.T, ops []map[string]any) map[string]an
 	return out
 }
 
+// scopeOp injects this harness's SessionID into a timeline op's push/expect_recv
+// spec when the op doesn't already specify a session_id. Leaves sleep ops
+// untouched. Returns a shallow copy so the caller's map literals are unmodified.
+func (h *Harness) scopeOp(op map[string]any) map[string]any {
+	out := make(map[string]any, len(op))
+	for k, v := range op {
+		out[k] = v
+	}
+	for _, key := range []string{"push", "expect_recv"} {
+		spec, ok := out[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, has := spec["session_id"]; has {
+			continue
+		}
+		newSpec := make(map[string]any, len(spec)+1)
+		for k, v := range spec {
+			newSpec[k] = v
+		}
+		newSpec["session_id"] = h.SessionID
+		out[key] = newSpec
+	}
+	return out
+}
+
 // ArmMethod queues scripted post-RPC events for `method`. Each entry is
 // a map of {emit: {state, ...}, delay_ms?: int, event_type?: string}.
+// Scoped to this harness's SessionID when set, so a parallel test's
+// calling.<method> execute won't consume another test's armed events.
 func (h *Harness) ArmMethod(t *testing.T, method string, events []map[string]any) {
 	t.Helper()
-	h.post(t, "/__mock__/scenarios/"+method, events)
+	h.post(t, "/__mock__/scenarios/"+method+h.sessionQuery(), events)
 }
 
 // DialOpts mirrors the dial-scenario JSON body.
@@ -336,10 +442,11 @@ type DialLoserOpts struct {
 }
 
 // ArmDial queues a full dial dance for the next calling.dial whose params
-// carry the given Tag.
+// carry the given Tag. Scoped to this harness's SessionID when set, so a
+// parallel dial test won't consume another test's queued dial dance.
 func (h *Harness) ArmDial(t *testing.T, opts DialOpts) {
 	t.Helper()
-	h.post(t, "/__mock__/scenarios/dial", opts)
+	h.post(t, "/__mock__/scenarios/dial"+h.sessionQuery(), opts)
 }
 
 // Sessions returns the active WebSocket session list reported by the
@@ -676,17 +783,15 @@ func probeHealth(client *http.Client, base string) bool {
 // t.Cleanup.
 func New(t *testing.T) (*relay.Client, *Harness) {
 	t.Helper()
-	h := ensureServer(t)
-	if h == nil {
+	shared := ensureServer(t)
+	if shared == nil {
 		return nil, nil
 	}
-	h.Reset(t)
-	t.Cleanup(func() { h.Reset(t) })
 
 	// Point the SDK at our mock. The relay client honors
 	// SIGNALWIRE_RELAY_HOST + SIGNALWIRE_RELAY_SCHEME for exactly this
 	// override scenario.
-	t.Setenv("SIGNALWIRE_RELAY_HOST", h.RelayHost())
+	t.Setenv("SIGNALWIRE_RELAY_HOST", shared.RelayHost())
 	t.Setenv("SIGNALWIRE_RELAY_SCHEME", "ws")
 
 	client := relay.NewRelayClient(
@@ -714,17 +819,31 @@ func New(t *testing.T) (*relay.Client, *Harness) {
 	t.Cleanup(func() {
 		client.Stop()
 	})
+
+	// Return a per-test harness view scoped to THIS client's session id (the
+	// server-assigned `sessionid` from the connect handshake), so the test's
+	// journal reads/resets/pushes see only its own frames — making the shared
+	// singleton mock safe under parallel (t.Parallel) execution. No global
+	// reset is needed: a brand-new session starts with an empty (scoped)
+	// journal. The cleanup reset is scoped to this session too, so it never
+	// races a concurrent test's state. Mirrors the TS newRelayClient().
+	h := shared.scoped(client.SessionID())
+	t.Cleanup(func() { h.Reset(t) })
 	return client, h
 }
 
-// NewClientOnly returns a fresh *relay.Client connected to the running
-// mock, with no contexts subscribed. Useful for tests that need to
-// drive multiple clients in one test (e.g. reconnect-with-protocol).
+// NewClientOnly returns a fresh *relay.Client connected to the running mock,
+// with no contexts subscribed, plus a Harness view scoped to THAT client's
+// session id. Useful for tests that drive multiple clients in one test (e.g.
+// reconnect-with-protocol): each client gets its own session, and the returned
+// harness reads/pushes only that client's frames, so the two clients don't
+// step on each other and the test is parallel-safe.
 //
-// The harness is shared with any previously created clients in the same
-// test — t.Cleanup is registered to disconnect this client when the
-// test ends.
-func NewClientOnly(t *testing.T, h *Harness, opts ...relay.ClientOption) *relay.Client {
+// The passed-in `h` is only used for its server address; the returned harness
+// is a fresh scoped copy (the original `h` keeps its own scope). t.Cleanup is
+// registered to disconnect this client and reset its session when the test
+// ends. Mirrors the TS pattern of re-scoping a harness via sessionIdOf(client).
+func NewClientOnly(t *testing.T, h *Harness, opts ...relay.ClientOption) (*relay.Client, *Harness) {
 	t.Helper()
 	t.Setenv("SIGNALWIRE_RELAY_HOST", h.RelayHost())
 	t.Setenv("SIGNALWIRE_RELAY_SCHEME", "ws")
@@ -740,6 +859,10 @@ func NewClientOnly(t *testing.T, h *Harness, opts ...relay.ClientOption) *relay.
 	if err := client.SubscribeContexts(); err != nil {
 		t.Fatalf("mocktest: relay SubscribeContexts: %v", err)
 	}
-	t.Cleanup(func() { client.Stop() })
-	return client
+	scoped := h.scoped(client.SessionID())
+	t.Cleanup(func() {
+		client.Stop()
+		scoped.Reset(t)
+	})
+	return client, scoped
 }

--- a/pkg/rest/internal/mocktest/mocktest.go
+++ b/pkg/rest/internal/mocktest/mocktest.go
@@ -22,10 +22,14 @@ package mocktest
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,6 +80,24 @@ type Harness struct {
 	URL  string
 	Port int
 
+	// Project is the unique random project this harness's client authenticates
+	// with (`test_proj_<hex>`). Tests that assert on the AccountSid embedded in
+	// a LAML path (`/api/laml/2010-04-01/Accounts/<project>/...`) must read it
+	// from here instead of hard-coding `test_proj`. Empty on an unscoped/raw
+	// harness. Mirrors the TS MockHarness.project.
+	Project string
+
+	// authHeader, when set, scopes journal reads (client-side) and scenario
+	// arming (server-side) to the requests THIS test's client made — identified
+	// by its `Authorization` header (Basic project:token, with a per-test random
+	// project; see New). REST is pure request/response with no session
+	// handshake, so each request is self-identifying via its auth header.
+	// Filtering the shared global journal by that header makes the suite safe
+	// under parallel execution with no SDK change and no mock-server change.
+	// Empty => unscoped (legacy view, returns every entry — only correct under
+	// serial execution). Mirrors the TS MockHarness.authHeader.
+	authHeader string
+
 	httpClient *http.Client
 }
 
@@ -91,7 +113,11 @@ func (h *Harness) Last(t *testing.T) JournalEntry {
 	return entries[len(entries)-1]
 }
 
-// Journal returns every entry recorded since the last reset, in arrival order.
+// Journal returns this client's recorded requests in arrival order. Scoped to
+// this harness's authHeader when set (so a parallel test never sees another
+// test's requests — the filter key is the lowercase `authorization` header,
+// which carries the per-test random project); unscoped harnesses see the whole
+// journal. Mirrors the TS MockHarness.journal().
 func (h *Harness) Journal(t *testing.T) []JournalEntry {
 	t.Helper()
 	resp, err := h.httpClient.Get(h.URL + "/__mock__/journal")
@@ -107,13 +133,30 @@ func (h *Harness) Journal(t *testing.T) []JournalEntry {
 	if err := json.Unmarshal(body, &entries); err != nil {
 		t.Fatalf("mocktest: decode journal: %v (body=%q)", err, body)
 	}
-	return entries
+	if h.authHeader == "" {
+		return entries
+	}
+	filtered := entries[:0:0]
+	for _, e := range entries {
+		if e.Headers["authorization"] == h.authHeader {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
 }
 
-// Reset clears journal + scenarios on the mock server. Tests do not call
-// this directly — New registers it as a t.Cleanup hook.
+// Reset clears journal + scenarios on the mock server. A scoped harness leaves
+// the shared journal alone (it only ever reads its own entries, identified by
+// auth header, so there is nothing to clear and a global wipe would race a
+// concurrent test); the scenario store is server-scoped by auth header too, so
+// a stale scenario can't leak across tests. Unscoped harnesses do the legacy
+// global reset. Tests do not call this directly — New registers it as a
+// t.Cleanup hook. Mirrors the TS MockHarness.reset().
 func (h *Harness) Reset(t *testing.T) {
 	t.Helper()
+	if h.authHeader != "" {
+		return
+	}
 	post := func(path string) {
 		req, err := http.NewRequest("POST", h.URL+path, nil)
 		if err != nil {
@@ -141,11 +184,17 @@ func (h *Harness) PushScenario(t *testing.T, endpointID string, status int, body
 	if err != nil {
 		t.Fatalf("mocktest: marshal scenario: %v", err)
 	}
-	resp, err := h.httpClient.Post(
-		h.URL+"/__mock__/scenarios/"+endpointID,
-		"application/json",
-		bytes.NewReader(payload),
-	)
+	// Scope the override to THIS client's auth header so a concurrent test
+	// can't consume it (and a stale one can't bleed across tests). REST's
+	// session key on the mock is the Authorization header: the mock pops a
+	// scenario using the request's own Authorization header (see
+	// mock_signalwire server `scenarios.pop(..., session_id=auth_header)`), so
+	// we arm it under the same key. Unscoped harness => shared bucket.
+	urlStr := h.URL + "/__mock__/scenarios/" + endpointID
+	if h.authHeader != "" {
+		urlStr += "?session_id=" + url.QueryEscape(h.authHeader)
+	}
+	resp, err := h.httpClient.Post(urlStr, "application/json", bytes.NewReader(payload))
 	if err != nil {
 		t.Fatalf("mocktest: push scenario: %v", err)
 	}
@@ -343,31 +392,68 @@ func probeHealth(client *http.Client, base string) bool {
 // Test entry point
 // ---------------------------------------------------------------------------
 
+// restToken is the fixed API token every mock client authenticates with; the
+// per-test isolation comes from the random PROJECT, not the token.
+const restToken = "test_tok"
+
+// randomProject returns a unique `test_proj_<12 hex>` project name. The random
+// suffix (NOT a counter) keeps the resulting Authorization header collision-free
+// across parallel test goroutines AND separate processes hitting one shared
+// mock. Mirrors the TS newMockClient()'s `test_proj_${randomUUID...}`.
+func randomProject(t *testing.T) string {
+	t.Helper()
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("mocktest: read random bytes for project: %v", err)
+	}
+	return "test_proj_" + hex.EncodeToString(b[:])
+}
+
 // New returns (client, harness) for a single test. The client is a real
-// rest.RestClient pointed at the local mock server with project=test_proj
-// and token=test_tok — matching the Python signalwire_client fixture.
+// rest.RestClient pointed at the local mock server with a UNIQUE RANDOM project
+// (`test_proj_<hex>`) and token=test_tok, so its `Authorization: Basic
+// base64(project:token)` header is unique. The returned harness is a per-test
+// view scoped to that header: it reads only this client's journal entries
+// (client-side filter) and arms scenarios only this client consumes
+// (server-side, keyed on the same header). This makes the shared singleton mock
+// safe under parallel (t.Parallel) execution with no SDK change and no
+// mock-server change. Mirrors the TS newMockClient().
 //
-// The mock's journal + scenarios are reset before the test runs, and the
-// reset is repeated via t.Cleanup so accidental leftover state from a panic
-// doesn't leak into the next test.
+// No global reset is needed: this client starts with zero entries in the
+// (auth-filtered) view. The t.Cleanup reset is a no-op for a scoped harness
+// (see Reset), so it never races a concurrent test.
+//
+// Tests that assert on the AccountSid in a LAML path must read it from
+// h.Project rather than hard-coding `test_proj`.
 func New(t *testing.T) (*rest.RestClient, *Harness) {
 	t.Helper()
-	h := ensureServer(t)
-	if h == nil {
+	shared := ensureServer(t)
+	if shared == nil {
 		// ensureServer already called t.Skipf.
 		return nil, nil
 	}
-	h.Reset(t)
-	t.Cleanup(func() { h.Reset(t) })
 
-	// Build a real client with throwaway credentials. The mock accepts
+	project := randomProject(t)
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte(project+":"+restToken))
+
+	// Build a real client with the per-test random project. The mock accepts
 	// any non-empty Basic Auth header.
-	client, err := rest.NewRestClient("test_proj", "test_tok", fmt.Sprintf("127.0.0.1:%d", h.Port))
+	client, err := rest.NewRestClient(project, restToken, fmt.Sprintf("127.0.0.1:%d", shared.Port))
 	if err != nil {
 		t.Fatalf("mocktest: NewRestClient: %v", err)
 	}
 	// Repoint the underlying HTTPClient at http:// (the constructor builds
 	// https:// + space). SetBaseURL exists for exactly this purpose.
-	client.SetBaseURL(h.URL)
+	client.SetBaseURL(shared.URL)
+
+	// Per-test harness view scoped to this client's auth header + project.
+	h := &Harness{
+		URL:        shared.URL,
+		Port:       shared.Port,
+		Project:    project,
+		authHeader: authHeader,
+		httpClient: shared.httpClient,
+	}
+	t.Cleanup(func() { h.Reset(t) })
 	return client, h
 }

--- a/pkg/rest/namespaces/calling_mock_test.go
+++ b/pkg/rest/namespaces/calling_mock_test.go
@@ -59,6 +59,7 @@ func commandAssert(t *testing.T, j mocktest.JournalEntry, command, expectedID st
 // Dial(map[string]any{...}) already forwards arbitrary keys, so no source
 // change is needed — this is a behavioral assertion only.
 func TestCallingNamespace_Dial_WithCodecsArray(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -101,6 +102,7 @@ func TestCallingNamespace_Dial_WithCodecsArray(t *testing.T) {
 // string form of codecs (also valid per the OpenAPI spec) reaches the wire
 // verbatim.
 func TestCallingNamespace_Dial_WithCodecsString(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -127,6 +129,7 @@ func TestCallingNamespace_Dial_WithCodecsString(t *testing.T) {
 }
 
 func TestCalling_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -149,6 +152,7 @@ func TestCalling_Update(t *testing.T) {
 }
 
 func TestCalling_Transfer(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -174,6 +178,7 @@ func TestCalling_Transfer(t *testing.T) {
 }
 
 func TestCalling_Disconnect(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -195,6 +200,7 @@ func TestCalling_Disconnect(t *testing.T) {
 // ----------------- Play -----------------
 
 func TestCalling_PlayPause(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -211,6 +217,7 @@ func TestCalling_PlayPause(t *testing.T) {
 }
 
 func TestCalling_PlayResume(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -227,6 +234,7 @@ func TestCalling_PlayResume(t *testing.T) {
 }
 
 func TestCalling_PlayStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -243,6 +251,7 @@ func TestCalling_PlayStop(t *testing.T) {
 }
 
 func TestCalling_PlayVolume(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -264,6 +273,7 @@ func TestCalling_PlayVolume(t *testing.T) {
 // ----------------- Record -----------------
 
 func TestCalling_Record(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -281,6 +291,7 @@ func TestCalling_Record(t *testing.T) {
 }
 
 func TestCalling_RecordPause(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -297,6 +308,7 @@ func TestCalling_RecordPause(t *testing.T) {
 }
 
 func TestCalling_RecordResume(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -315,6 +327,7 @@ func TestCalling_RecordResume(t *testing.T) {
 // ----------------- Collect -----------------
 
 func TestCalling_Collect(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -335,6 +348,7 @@ func TestCalling_Collect(t *testing.T) {
 }
 
 func TestCalling_CollectStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -351,6 +365,7 @@ func TestCalling_CollectStop(t *testing.T) {
 }
 
 func TestCalling_CollectStartInputTimers(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -369,6 +384,7 @@ func TestCalling_CollectStartInputTimers(t *testing.T) {
 // ----------------- Detect / tap / stream / denoise / transcribe -----------------
 
 func TestCalling_Detect(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -388,6 +404,7 @@ func TestCalling_Detect(t *testing.T) {
 }
 
 func TestCalling_DetectStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -404,6 +421,7 @@ func TestCalling_DetectStop(t *testing.T) {
 }
 
 func TestCalling_Tap(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -424,6 +442,7 @@ func TestCalling_Tap(t *testing.T) {
 }
 
 func TestCalling_TapStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -440,6 +459,7 @@ func TestCalling_TapStop(t *testing.T) {
 }
 
 func TestCalling_Stream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -456,6 +476,7 @@ func TestCalling_Stream(t *testing.T) {
 }
 
 func TestCalling_StreamStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -472,6 +493,7 @@ func TestCalling_StreamStop(t *testing.T) {
 }
 
 func TestCalling_Denoise(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -485,6 +507,7 @@ func TestCalling_Denoise(t *testing.T) {
 }
 
 func TestCalling_DenoiseStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -501,6 +524,7 @@ func TestCalling_DenoiseStop(t *testing.T) {
 }
 
 func TestCalling_Transcribe(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -520,6 +544,7 @@ func TestCalling_Transcribe(t *testing.T) {
 }
 
 func TestCalling_TranscribeStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -538,6 +563,7 @@ func TestCalling_TranscribeStop(t *testing.T) {
 // ----------------- AI -----------------
 
 func TestCalling_AIHold(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -551,6 +577,7 @@ func TestCalling_AIHold(t *testing.T) {
 }
 
 func TestCalling_AIUnhold(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -564,6 +591,7 @@ func TestCalling_AIUnhold(t *testing.T) {
 }
 
 func TestCalling_AIStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -579,6 +607,7 @@ func TestCalling_AIStop(t *testing.T) {
 // ----------------- Live transcribe / translate -----------------
 
 func TestCalling_LiveTranscribe(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -595,6 +624,7 @@ func TestCalling_LiveTranscribe(t *testing.T) {
 }
 
 func TestCalling_LiveTranslate(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -619,6 +649,7 @@ func TestCalling_LiveTranslate(t *testing.T) {
 // ----------------- Fax -----------------
 
 func TestCalling_SendFaxStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -632,6 +663,7 @@ func TestCalling_SendFaxStop(t *testing.T) {
 }
 
 func TestCalling_ReceiveFaxStop(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -647,6 +679,7 @@ func TestCalling_ReceiveFaxStop(t *testing.T) {
 // ----------------- SIP refer + custom user_event -----------------
 
 func TestCalling_Refer(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -663,6 +696,7 @@ func TestCalling_Refer(t *testing.T) {
 }
 
 func TestCalling_UserEvent(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/compat_accounts_mock_test.go
+++ b/pkg/rest/namespaces/compat_accounts_mock_test.go
@@ -25,6 +25,7 @@ const compatAccountsBase = "/api/laml/2010-04-01/Accounts"
 // ---------- CompatAccountsCreate ----------
 
 func TestCompatAccounts_Create_ReturnsAccountResource(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -43,6 +44,7 @@ func TestCompatAccounts_Create_ReturnsAccountResource(t *testing.T) {
 }
 
 func TestCompatAccounts_Create_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -79,6 +81,7 @@ func TestCompatAccounts_Create_JournalRecordsPost(t *testing.T) {
 // ---------- CompatAccountsGet ----------
 
 func TestCompatAccounts_Get_ReturnsAccountForSid(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -95,6 +98,7 @@ func TestCompatAccounts_Get_ReturnsAccountForSid(t *testing.T) {
 }
 
 func TestCompatAccounts_Get_JournalRecordsGetWithSid(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -121,6 +125,7 @@ func TestCompatAccounts_Get_JournalRecordsGetWithSid(t *testing.T) {
 // ---------- CompatAccountsUpdate ----------
 
 func TestCompatAccounts_Update_ReturnsUpdatedAccount(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -139,6 +144,7 @@ func TestCompatAccounts_Update_ReturnsUpdatedAccount(t *testing.T) {
 }
 
 func TestCompatAccounts_Update_JournalRecordsPostToAccountPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/compat_calls_streams_mock_test.go
+++ b/pkg/rest/namespaces/compat_calls_streams_mock_test.go
@@ -21,6 +21,7 @@ import (
 
 // TestCompatCalls_StartStream covers Calls.StartStream → POST /Calls/{sid}/Streams.
 func TestCompatCalls_StartStream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -58,7 +59,7 @@ func TestCompatCalls_StartStream(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_JX1/Streams"
+		wantPath := lamlAccountBase(mock) + "/Calls/CA_JX1/Streams"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -77,6 +78,7 @@ func TestCompatCalls_StartStream(t *testing.T) {
 
 // TestCompatCalls_StopStream covers Calls.StopStream → POST .../Streams/{stream_sid}.
 func TestCompatCalls_StopStream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -112,7 +114,7 @@ func TestCompatCalls_StopStream(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_S1/Streams/ST_S1"
+		wantPath := lamlAccountBase(mock) + "/Calls/CA_S1/Streams/ST_S1"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -128,6 +130,7 @@ func TestCompatCalls_StopStream(t *testing.T) {
 
 // TestCompatCalls_UpdateRecording covers Calls.UpdateRecording.
 func TestCompatCalls_UpdateRecording(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -163,7 +166,7 @@ func TestCompatCalls_UpdateRecording(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_R1/Recordings/RE_R1"
+		wantPath := lamlAccountBase(mock) + "/Calls/CA_R1/Recordings/RE_R1"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -185,4 +188,15 @@ func keys(m map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// lamlAccountBase returns the Twilio-compatible LAML account base path for the
+// harness's per-test random project, i.e.
+// "/api/laml/2010-04-01/Accounts/<project>". The AccountSid segment is the
+// project the client authenticates with; because each test now uses a UNIQUE
+// random project for journal/scenario isolation under parallel execution, a
+// LAML-path assertion must read it from the harness rather than hard-coding
+// "test_proj". Mirrors the TS tests reading mock.project.
+func lamlAccountBase(m *mocktest.Harness) string {
+	return "/api/laml/2010-04-01/Accounts/" + m.Project
 }

--- a/pkg/rest/namespaces/compat_conferences_mock_test.go
+++ b/pkg/rest/namespaces/compat_conferences_mock_test.go
@@ -20,11 +20,17 @@ import (
 	"github.com/signalwire/signalwire-go/pkg/rest/internal/mocktest"
 )
 
-const compatConfBase = "/api/laml/2010-04-01/Accounts/test_proj/Conferences"
+// compatConfBase is the Conferences collection base path for the harness's
+// per-test random project (see lamlAccountBase). It is a function rather than a
+// const because the AccountSid segment is now per-test (parallel isolation).
+func compatConfBase(m *mocktest.Harness) string {
+	return lamlAccountBase(m) + "/Conferences"
+}
 
 // ---------- Conference itself ----------
 
 func TestCompatConferences_List_ReturnsPaginatedList(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -51,6 +57,7 @@ func TestCompatConferences_List_ReturnsPaginatedList(t *testing.T) {
 }
 
 func TestCompatConferences_List_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -65,8 +72,8 @@ func TestCompatConferences_List_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	if j.Path != compatConfBase {
-		t.Errorf("path = %q, want %q", j.Path, compatConfBase)
+	if j.Path != compatConfBase(mock) {
+		t.Errorf("path = %q, want %q", j.Path, compatConfBase(mock))
 	}
 	if j.MatchedRoute == nil {
 		t.Error("matched_route is nil — spec gap: conferences.list")
@@ -74,6 +81,7 @@ func TestCompatConferences_List_JournalRecordsGet(t *testing.T) {
 }
 
 func TestCompatConferences_Get_ReturnsConferenceResource(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -92,6 +100,7 @@ func TestCompatConferences_Get_ReturnsConferenceResource(t *testing.T) {
 }
 
 func TestCompatConferences_Get_JournalRecordsGetWithSid(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -106,13 +115,14 @@ func TestCompatConferences_Get_JournalRecordsGetWithSid(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_GETSID"
+	wantPath := compatConfBase(mock) + "/CF_GETSID"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatConferences_Update_ReturnsUpdatedConference(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -133,6 +143,7 @@ func TestCompatConferences_Update_ReturnsUpdatedConference(t *testing.T) {
 }
 
 func TestCompatConferences_Update_JournalRecordsPostWithStatus(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -150,7 +161,7 @@ func TestCompatConferences_Update_JournalRecordsPostWithStatus(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_UPD"
+	wantPath := compatConfBase(mock) + "/CF_UPD"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -169,6 +180,7 @@ func TestCompatConferences_Update_JournalRecordsPostWithStatus(t *testing.T) {
 // ---------- Participants ----------
 
 func TestCompatConferences_GetParticipant_ReturnsParticipant(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -187,6 +199,7 @@ func TestCompatConferences_GetParticipant_ReturnsParticipant(t *testing.T) {
 }
 
 func TestCompatConferences_GetParticipant_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -201,13 +214,14 @@ func TestCompatConferences_GetParticipant_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_GP/Participants/CA_GP"
+	wantPath := compatConfBase(mock) + "/CF_GP/Participants/CA_GP"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatConferences_UpdateParticipant_ReturnsParticipant(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -228,6 +242,7 @@ func TestCompatConferences_UpdateParticipant_ReturnsParticipant(t *testing.T) {
 }
 
 func TestCompatConferences_UpdateParticipant_JournalRecordsPostWithMute(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -245,7 +260,7 @@ func TestCompatConferences_UpdateParticipant_JournalRecordsPostWithMute(t *testi
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_M/Participants/CA_M"
+	wantPath := compatConfBase(mock) + "/CF_M/Participants/CA_M"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -262,6 +277,7 @@ func TestCompatConferences_UpdateParticipant_JournalRecordsPostWithMute(t *testi
 }
 
 func TestCompatConferences_RemoveParticipant_ReturnsObject(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -278,6 +294,7 @@ func TestCompatConferences_RemoveParticipant_ReturnsObject(t *testing.T) {
 }
 
 func TestCompatConferences_RemoveParticipant_JournalRecordsDelete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -292,7 +309,7 @@ func TestCompatConferences_RemoveParticipant_JournalRecordsDelete(t *testing.T) 
 	if j.Method != "DELETE" {
 		t.Errorf("method = %q, want DELETE", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_RM/Participants/CA_RM"
+	wantPath := compatConfBase(mock) + "/CF_RM/Participants/CA_RM"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -301,6 +318,7 @@ func TestCompatConferences_RemoveParticipant_JournalRecordsDelete(t *testing.T) 
 // ---------- Recordings ----------
 
 func TestCompatConferences_ListRecordings_ReturnsPaginated(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -321,6 +339,7 @@ func TestCompatConferences_ListRecordings_ReturnsPaginated(t *testing.T) {
 }
 
 func TestCompatConferences_ListRecordings_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -335,13 +354,14 @@ func TestCompatConferences_ListRecordings_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_LRX/Recordings"
+	wantPath := compatConfBase(mock) + "/CF_LRX/Recordings"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatConferences_GetRecording_ReturnsRecording(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -360,6 +380,7 @@ func TestCompatConferences_GetRecording_ReturnsRecording(t *testing.T) {
 }
 
 func TestCompatConferences_GetRecording_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -374,13 +395,14 @@ func TestCompatConferences_GetRecording_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_GRX/Recordings/RE_GRX"
+	wantPath := compatConfBase(mock) + "/CF_GRX/Recordings/RE_GRX"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatConferences_UpdateRecording_ReturnsRecording(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -401,6 +423,7 @@ func TestCompatConferences_UpdateRecording_ReturnsRecording(t *testing.T) {
 }
 
 func TestCompatConferences_UpdateRecording_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -417,7 +440,7 @@ func TestCompatConferences_UpdateRecording_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_UR/Recordings/RE_UR"
+	wantPath := compatConfBase(mock) + "/CF_UR/Recordings/RE_UR"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -431,6 +454,7 @@ func TestCompatConferences_UpdateRecording_JournalRecordsPost(t *testing.T) {
 }
 
 func TestCompatConferences_DeleteRecording_NoException(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -447,6 +471,7 @@ func TestCompatConferences_DeleteRecording_NoException(t *testing.T) {
 }
 
 func TestCompatConferences_DeleteRecording_JournalRecordsDelete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -461,7 +486,7 @@ func TestCompatConferences_DeleteRecording_JournalRecordsDelete(t *testing.T) {
 	if j.Method != "DELETE" {
 		t.Errorf("method = %q, want DELETE", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_DRX/Recordings/RE_DRX"
+	wantPath := compatConfBase(mock) + "/CF_DRX/Recordings/RE_DRX"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -470,6 +495,7 @@ func TestCompatConferences_DeleteRecording_JournalRecordsDelete(t *testing.T) {
 // ---------- Streams ----------
 
 func TestCompatConferences_StartStream_ReturnsStream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -490,6 +516,7 @@ func TestCompatConferences_StartStream_ReturnsStream(t *testing.T) {
 }
 
 func TestCompatConferences_StartStream_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -507,7 +534,7 @@ func TestCompatConferences_StartStream_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_SSX/Streams"
+	wantPath := compatConfBase(mock) + "/CF_SSX/Streams"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -521,6 +548,7 @@ func TestCompatConferences_StartStream_JournalRecordsPost(t *testing.T) {
 }
 
 func TestCompatConferences_StopStream_ReturnsStream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -541,6 +569,7 @@ func TestCompatConferences_StopStream_ReturnsStream(t *testing.T) {
 }
 
 func TestCompatConferences_StopStream_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -557,7 +586,7 @@ func TestCompatConferences_StopStream_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatConfBase + "/CF_TSX/Streams/ST_TSX"
+	wantPath := compatConfBase(mock) + "/CF_TSX/Streams/ST_TSX"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}

--- a/pkg/rest/namespaces/compat_messages_faxes_mock_test.go
+++ b/pkg/rest/namespaces/compat_messages_faxes_mock_test.go
@@ -21,6 +21,7 @@ import (
 // ----------------- Messages -----------------
 
 func TestCompatMessages_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -54,7 +55,7 @@ func TestCompatMessages_Update(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_U1"
+		wantPath := lamlAccountBase(mock) + "/Messages/MM_U1"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -72,6 +73,7 @@ func TestCompatMessages_Update(t *testing.T) {
 }
 
 func TestCompatMessages_GetMedia(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -100,7 +102,7 @@ func TestCompatMessages_GetMedia(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_X/Media/ME_X"
+		wantPath := lamlAccountBase(mock) + "/Messages/MM_X/Media/ME_X"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -108,6 +110,7 @@ func TestCompatMessages_GetMedia(t *testing.T) {
 }
 
 func TestCompatMessages_DeleteMedia(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -134,7 +137,7 @@ func TestCompatMessages_DeleteMedia(t *testing.T) {
 		if j.Method != "DELETE" {
 			t.Errorf("method = %q, want DELETE", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_D/Media/ME_D"
+		wantPath := lamlAccountBase(mock) + "/Messages/MM_D/Media/ME_D"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -144,6 +147,7 @@ func TestCompatMessages_DeleteMedia(t *testing.T) {
 // ----------------- Faxes -----------------
 
 func TestCompatFaxes_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -176,7 +180,7 @@ func TestCompatFaxes_Update(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_U2"
+		wantPath := lamlAccountBase(mock) + "/Faxes/FX_U2"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -191,6 +195,7 @@ func TestCompatFaxes_Update(t *testing.T) {
 }
 
 func TestCompatFaxes_ListMedia(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -219,7 +224,7 @@ func TestCompatFaxes_ListMedia(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_LM_X/Media"
+		wantPath := lamlAccountBase(mock) + "/Faxes/FX_LM_X/Media"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -227,6 +232,7 @@ func TestCompatFaxes_ListMedia(t *testing.T) {
 }
 
 func TestCompatFaxes_GetMedia(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -255,7 +261,7 @@ func TestCompatFaxes_GetMedia(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_G/Media/ME_G"
+		wantPath := lamlAccountBase(mock) + "/Faxes/FX_G/Media/ME_G"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -263,6 +269,7 @@ func TestCompatFaxes_GetMedia(t *testing.T) {
 }
 
 func TestCompatFaxes_DeleteMedia(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -289,7 +296,7 @@ func TestCompatFaxes_DeleteMedia(t *testing.T) {
 		if j.Method != "DELETE" {
 			t.Errorf("method = %q, want DELETE", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_D/Media/ME_D"
+		wantPath := lamlAccountBase(mock) + "/Faxes/FX_D/Media/ME_D"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}

--- a/pkg/rest/namespaces/compat_misc_mock_test.go
+++ b/pkg/rest/namespaces/compat_misc_mock_test.go
@@ -23,6 +23,7 @@ import (
 // ---------- CompatApplicationsUpdate ----------
 
 func TestCompatApplications_Update_ReturnsApplication(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -43,6 +44,7 @@ func TestCompatApplications_Update_ReturnsApplication(t *testing.T) {
 }
 
 func TestCompatApplications_Update_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -60,7 +62,7 @@ func TestCompatApplications_Update_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/Applications/AP_UU"
+	wantPath := lamlAccountBase(mock) + "/Applications/AP_UU"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -79,6 +81,7 @@ func TestCompatApplications_Update_JournalRecordsPost(t *testing.T) {
 // ---------- CompatLamlBinsUpdate ----------
 
 func TestCompatLamlBins_Update_ReturnsLamlBin(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -100,6 +103,7 @@ func TestCompatLamlBins_Update_ReturnsLamlBin(t *testing.T) {
 }
 
 func TestCompatLamlBins_Update_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -117,7 +121,7 @@ func TestCompatLamlBins_Update_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/LamlBins/LB_UU"
+	wantPath := lamlAccountBase(mock) + "/LamlBins/LB_UU"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}

--- a/pkg/rest/namespaces/compat_phone_numbers_mock_test.go
+++ b/pkg/rest/namespaces/compat_phone_numbers_mock_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestCompatPhoneNumbers_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -52,7 +53,7 @@ func TestCompatPhoneNumbers_List(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers"
+		wantPath := lamlAccountBase(mock) + "/IncomingPhoneNumbers"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -60,6 +61,7 @@ func TestCompatPhoneNumbers_List(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -88,7 +90,7 @@ func TestCompatPhoneNumbers_Get(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_GET"
+		wantPath := lamlAccountBase(mock) + "/IncomingPhoneNumbers/PN_GET"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -96,6 +98,7 @@ func TestCompatPhoneNumbers_Get(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -129,7 +132,7 @@ func TestCompatPhoneNumbers_Update(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_UU"
+		wantPath := lamlAccountBase(mock) + "/IncomingPhoneNumbers/PN_UU"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -147,6 +150,7 @@ func TestCompatPhoneNumbers_Update(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -173,7 +177,7 @@ func TestCompatPhoneNumbers_Delete(t *testing.T) {
 		if j.Method != "DELETE" {
 			t.Errorf("method = %q, want DELETE", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers/PN_DEL"
+		wantPath := lamlAccountBase(mock) + "/IncomingPhoneNumbers/PN_DEL"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -181,6 +185,7 @@ func TestCompatPhoneNumbers_Delete(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_Purchase(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -214,7 +219,7 @@ func TestCompatPhoneNumbers_Purchase(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/IncomingPhoneNumbers"
+		wantPath := lamlAccountBase(mock) + "/IncomingPhoneNumbers"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -232,6 +237,7 @@ func TestCompatPhoneNumbers_Purchase(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_ImportNumber(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -265,7 +271,7 @@ func TestCompatPhoneNumbers_ImportNumber(t *testing.T) {
 		if j.Method != "POST" {
 			t.Errorf("method = %q, want POST", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/ImportedPhoneNumbers"
+		wantPath := lamlAccountBase(mock) + "/ImportedPhoneNumbers"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -280,6 +286,7 @@ func TestCompatPhoneNumbers_ImportNumber(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_ListAvailableCountries(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -310,7 +317,7 @@ func TestCompatPhoneNumbers_ListAvailableCountries(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers"
+		wantPath := lamlAccountBase(mock) + "/AvailablePhoneNumbers"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}
@@ -318,6 +325,7 @@ func TestCompatPhoneNumbers_ListAvailableCountries(t *testing.T) {
 }
 
 func TestCompatPhoneNumbers_SearchTollFree(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -352,7 +360,7 @@ func TestCompatPhoneNumbers_SearchTollFree(t *testing.T) {
 		if j.Method != "GET" {
 			t.Errorf("method = %q, want GET", j.Method)
 		}
-		const wantPath = "/api/laml/2010-04-01/Accounts/test_proj/AvailablePhoneNumbers/US/TollFree"
+		wantPath := lamlAccountBase(mock) + "/AvailablePhoneNumbers/US/TollFree"
 		if j.Path != wantPath {
 			t.Errorf("path = %q, want %q", j.Path, wantPath)
 		}

--- a/pkg/rest/namespaces/compat_queues_mock_test.go
+++ b/pkg/rest/namespaces/compat_queues_mock_test.go
@@ -18,11 +18,17 @@ import (
 	"github.com/signalwire/signalwire-go/pkg/rest/internal/mocktest"
 )
 
-const compatQueuesBase = "/api/laml/2010-04-01/Accounts/test_proj/Queues"
+// compatQueuesBase is the Queues collection base path for the harness's
+// per-test random project (see lamlAccountBase). Function, not const, because
+// the AccountSid segment is per-test (parallel isolation).
+func compatQueuesBase(m *mocktest.Harness) string {
+	return lamlAccountBase(m) + "/Queues"
+}
 
 // ---------- CompatQueuesUpdate ----------
 
 func TestCompatQueues_Update_ReturnsQueue(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -43,6 +49,7 @@ func TestCompatQueues_Update_ReturnsQueue(t *testing.T) {
 }
 
 func TestCompatQueues_Update_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -60,7 +67,7 @@ func TestCompatQueues_Update_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatQueuesBase + "/QU_UU"
+	wantPath := compatQueuesBase(mock) + "/QU_UU"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -80,6 +87,7 @@ func TestCompatQueues_Update_JournalRecordsPost(t *testing.T) {
 // ---------- CompatQueuesListMembers ----------
 
 func TestCompatQueues_ListMembers_ReturnsPaginated(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -100,6 +108,7 @@ func TestCompatQueues_ListMembers_ReturnsPaginated(t *testing.T) {
 }
 
 func TestCompatQueues_ListMembers_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -114,7 +123,7 @@ func TestCompatQueues_ListMembers_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatQueuesBase + "/QU_LMX/Members"
+	wantPath := compatQueuesBase(mock) + "/QU_LMX/Members"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -123,6 +132,7 @@ func TestCompatQueues_ListMembers_JournalRecordsGet(t *testing.T) {
 // ---------- CompatQueuesGetMember ----------
 
 func TestCompatQueues_GetMember_ReturnsMember(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -141,6 +151,7 @@ func TestCompatQueues_GetMember_ReturnsMember(t *testing.T) {
 }
 
 func TestCompatQueues_GetMember_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -155,7 +166,7 @@ func TestCompatQueues_GetMember_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatQueuesBase + "/QU_GMX/Members/CA_GMX"
+	wantPath := compatQueuesBase(mock) + "/QU_GMX/Members/CA_GMX"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -164,6 +175,7 @@ func TestCompatQueues_GetMember_JournalRecordsGet(t *testing.T) {
 // ---------- CompatQueuesDequeueMember ----------
 
 func TestCompatQueues_DequeueMember_ReturnsMember(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -184,6 +196,7 @@ func TestCompatQueues_DequeueMember_ReturnsMember(t *testing.T) {
 }
 
 func TestCompatQueues_DequeueMember_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -201,7 +214,7 @@ func TestCompatQueues_DequeueMember_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	const wantPath = compatQueuesBase + "/QU_DMX/Members/CA_DMX"
+	wantPath := compatQueuesBase(mock) + "/QU_DMX/Members/CA_DMX"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}

--- a/pkg/rest/namespaces/compat_recordings_transcriptions_mock_test.go
+++ b/pkg/rest/namespaces/compat_recordings_transcriptions_mock_test.go
@@ -19,12 +19,22 @@ import (
 	"github.com/signalwire/signalwire-go/pkg/rest/internal/mocktest"
 )
 
-const compatRecsBase = "/api/laml/2010-04-01/Accounts/test_proj/Recordings"
-const compatTransBase = "/api/laml/2010-04-01/Accounts/test_proj/Transcriptions"
+// compatRecsBase / compatTransBase are the Recordings / Transcriptions
+// collection base paths for the harness's per-test random project (see
+// lamlAccountBase). Functions, not consts, because the AccountSid segment is
+// per-test (parallel isolation).
+func compatRecsBase(m *mocktest.Harness) string {
+	return lamlAccountBase(m) + "/Recordings"
+}
+
+func compatTransBase(m *mocktest.Harness) string {
+	return lamlAccountBase(m) + "/Transcriptions"
+}
 
 // ---------- CompatRecordings ----------
 
 func TestCompatRecordings_List_ReturnsPaginated(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -45,6 +55,7 @@ func TestCompatRecordings_List_ReturnsPaginated(t *testing.T) {
 }
 
 func TestCompatRecordings_List_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -59,12 +70,13 @@ func TestCompatRecordings_List_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	if j.Path != compatRecsBase {
-		t.Errorf("path = %q, want %q", j.Path, compatRecsBase)
+	if j.Path != compatRecsBase(mock) {
+		t.Errorf("path = %q, want %q", j.Path, compatRecsBase(mock))
 	}
 }
 
 func TestCompatRecordings_Get_ReturnsRecording(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -83,6 +95,7 @@ func TestCompatRecordings_Get_ReturnsRecording(t *testing.T) {
 }
 
 func TestCompatRecordings_Get_JournalRecordsGetWithSid(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -97,13 +110,14 @@ func TestCompatRecordings_Get_JournalRecordsGetWithSid(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatRecsBase + "/RE_GET"
+	wantPath := compatRecsBase(mock) + "/RE_GET"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatRecordings_Delete_NoException(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -120,6 +134,7 @@ func TestCompatRecordings_Delete_NoException(t *testing.T) {
 }
 
 func TestCompatRecordings_Delete_JournalRecordsDelete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -134,7 +149,7 @@ func TestCompatRecordings_Delete_JournalRecordsDelete(t *testing.T) {
 	if j.Method != "DELETE" {
 		t.Errorf("method = %q, want DELETE", j.Method)
 	}
-	const wantPath = compatRecsBase + "/RE_DEL"
+	wantPath := compatRecsBase(mock) + "/RE_DEL"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -143,6 +158,7 @@ func TestCompatRecordings_Delete_JournalRecordsDelete(t *testing.T) {
 // ---------- CompatTranscriptions ----------
 
 func TestCompatTranscriptions_List_ReturnsPaginated(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -163,6 +179,7 @@ func TestCompatTranscriptions_List_ReturnsPaginated(t *testing.T) {
 }
 
 func TestCompatTranscriptions_List_JournalRecordsGet(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -177,12 +194,13 @@ func TestCompatTranscriptions_List_JournalRecordsGet(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	if j.Path != compatTransBase {
-		t.Errorf("path = %q, want %q", j.Path, compatTransBase)
+	if j.Path != compatTransBase(mock) {
+		t.Errorf("path = %q, want %q", j.Path, compatTransBase(mock))
 	}
 }
 
 func TestCompatTranscriptions_Get_ReturnsTranscription(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -201,6 +219,7 @@ func TestCompatTranscriptions_Get_ReturnsTranscription(t *testing.T) {
 }
 
 func TestCompatTranscriptions_Get_JournalRecordsGetWithSid(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -215,13 +234,14 @@ func TestCompatTranscriptions_Get_JournalRecordsGetWithSid(t *testing.T) {
 	if j.Method != "GET" {
 		t.Errorf("method = %q, want GET", j.Method)
 	}
-	const wantPath = compatTransBase + "/TR_GET"
+	wantPath := compatTransBase(mock) + "/TR_GET"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
 }
 
 func TestCompatTranscriptions_Delete_NoException(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -238,6 +258,7 @@ func TestCompatTranscriptions_Delete_NoException(t *testing.T) {
 }
 
 func TestCompatTranscriptions_Delete_JournalRecordsDelete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -252,7 +273,7 @@ func TestCompatTranscriptions_Delete_JournalRecordsDelete(t *testing.T) {
 	if j.Method != "DELETE" {
 		t.Errorf("method = %q, want DELETE", j.Method)
 	}
-	const wantPath = compatTransBase + "/TR_DEL"
+	wantPath := compatTransBase(mock) + "/TR_DEL"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}

--- a/pkg/rest/namespaces/compat_tokens_mock_test.go
+++ b/pkg/rest/namespaces/compat_tokens_mock_test.go
@@ -19,11 +19,17 @@ import (
 	"github.com/signalwire/signalwire-go/pkg/rest/internal/mocktest"
 )
 
-const compatTokensBase = "/api/laml/2010-04-01/Accounts/test_proj/tokens"
+// compatTokensBase is the tokens collection base path for the harness's
+// per-test random project (see lamlAccountBase). Function, not const, because
+// the AccountSid segment is per-test (parallel isolation).
+func compatTokensBase(m *mocktest.Harness) string {
+	return lamlAccountBase(m) + "/tokens"
+}
 
 // ---------- CompatTokensCreate ----------
 
 func TestCompatTokens_Create_ReturnsToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -44,6 +50,7 @@ func TestCompatTokens_Create_ReturnsToken(t *testing.T) {
 }
 
 func TestCompatTokens_Create_JournalRecordsPost(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -61,8 +68,8 @@ func TestCompatTokens_Create_JournalRecordsPost(t *testing.T) {
 	if j.Method != "POST" {
 		t.Errorf("method = %q, want POST", j.Method)
 	}
-	if j.Path != compatTokensBase {
-		t.Errorf("path = %q, want %q", j.Path, compatTokensBase)
+	if j.Path != compatTokensBase(mock) {
+		t.Errorf("path = %q, want %q", j.Path, compatTokensBase(mock))
 	}
 	body, ok := j.BodyMap()
 	if !ok {
@@ -79,6 +86,7 @@ func TestCompatTokens_Create_JournalRecordsPost(t *testing.T) {
 // ---------- CompatTokensUpdate ----------
 
 func TestCompatTokens_Update_ReturnsToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -99,6 +107,7 @@ func TestCompatTokens_Update_ReturnsToken(t *testing.T) {
 }
 
 func TestCompatTokens_Update_JournalRecordsPatch(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -116,7 +125,7 @@ func TestCompatTokens_Update_JournalRecordsPatch(t *testing.T) {
 	if j.Method != "PATCH" {
 		t.Errorf("method = %q, want PATCH", j.Method)
 	}
-	const wantPath = compatTokensBase + "/TK_UU"
+	wantPath := compatTokensBase(mock) + "/TK_UU"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}
@@ -132,6 +141,7 @@ func TestCompatTokens_Update_JournalRecordsPatch(t *testing.T) {
 // ---------- CompatTokensDelete ----------
 
 func TestCompatTokens_Delete_NoException(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -148,6 +158,7 @@ func TestCompatTokens_Delete_NoException(t *testing.T) {
 }
 
 func TestCompatTokens_Delete_JournalRecordsDelete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -162,7 +173,7 @@ func TestCompatTokens_Delete_JournalRecordsDelete(t *testing.T) {
 	if j.Method != "DELETE" {
 		t.Errorf("method = %q, want DELETE", j.Method)
 	}
-	const wantPath = compatTokensBase + "/TK_DEL"
+	wantPath := compatTokensBase(mock) + "/TK_DEL"
 	if j.Path != wantPath {
 		t.Errorf("path = %q, want %q", j.Path, wantPath)
 	}

--- a/pkg/rest/namespaces/fabric_mock_test.go
+++ b/pkg/rest/namespaces/fabric_mock_test.go
@@ -25,6 +25,7 @@ import (
 // ---------------- FabricAddresses ----------------
 
 func TestFabricAddresses_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -58,6 +59,7 @@ func TestFabricAddresses_List(t *testing.T) {
 }
 
 func TestFabricAddresses_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -85,6 +87,7 @@ func TestFabricAddresses_Get(t *testing.T) {
 // ---------------- CXMLApplications.Create deliberately fails ----------------
 
 func TestFabricCXMLApplications_CreateRaisesNotImplemented(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -107,6 +110,7 @@ func TestFabricCXMLApplications_CreateRaisesNotImplemented(t *testing.T) {
 // ---------------- CallFlows.ListAddresses uses singular path ----------------
 
 func TestFabricCallFlows_ListAddressesUsesSingularPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -132,6 +136,7 @@ func TestFabricCallFlows_ListAddressesUsesSingularPath(t *testing.T) {
 // ---------------- ConferenceRooms.ListAddresses uses singular path ----------------
 
 func TestFabricConferenceRooms_ListAddressesUsesSingularPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -157,6 +162,7 @@ func TestFabricConferenceRooms_ListAddressesUsesSingularPath(t *testing.T) {
 // ---------------- Subscribers SIP-endpoint per-id ops ----------------
 
 func TestFabricSubscribers_GetSIPEndpoint(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -180,6 +186,7 @@ func TestFabricSubscribers_GetSIPEndpoint(t *testing.T) {
 }
 
 func TestFabricSubscribers_UpdateSIPEndpointUsesPATCH(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -209,6 +216,7 @@ func TestFabricSubscribers_UpdateSIPEndpointUsesPATCH(t *testing.T) {
 }
 
 func TestFabricSubscribers_DeleteSIPEndpoint(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -234,6 +242,7 @@ func TestFabricSubscribers_DeleteSIPEndpoint(t *testing.T) {
 // ---------------- FabricTokens ----------------
 
 func TestFabricTokens_CreateInviteToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -262,6 +271,7 @@ func TestFabricTokens_CreateInviteToken(t *testing.T) {
 }
 
 func TestFabricTokens_CreateEmbedToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -291,6 +301,7 @@ func TestFabricTokens_CreateEmbedToken(t *testing.T) {
 }
 
 func TestFabricTokens_RefreshSubscriberToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -321,6 +332,7 @@ func TestFabricTokens_RefreshSubscriberToken(t *testing.T) {
 // ---------------- GenericResources ----------------
 
 func TestFabricResources_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -343,6 +355,7 @@ func TestFabricResources_List(t *testing.T) {
 }
 
 func TestFabricResources_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -362,6 +375,7 @@ func TestFabricResources_Get(t *testing.T) {
 }
 
 func TestFabricResources_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -384,6 +398,7 @@ func TestFabricResources_Delete(t *testing.T) {
 }
 
 func TestFabricResources_ListAddresses(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -406,6 +421,7 @@ func TestFabricResources_ListAddresses(t *testing.T) {
 }
 
 func TestFabricResources_AssignDomainApplication(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/logs_mock_test.go
+++ b/pkg/rest/namespaces/logs_mock_test.go
@@ -22,6 +22,7 @@ import (
 // ---------- Message Logs ----------
 
 func TestMessageLogs_List_ReturnsDict(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -53,6 +54,7 @@ func TestMessageLogs_List_ReturnsDict(t *testing.T) {
 }
 
 func TestMessageLogs_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -82,6 +84,7 @@ func TestMessageLogs_Get_UsesIDInPath(t *testing.T) {
 // ---------- Voice Logs ----------
 
 func TestVoiceLogs_List_ReturnsDict(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -113,6 +116,7 @@ func TestVoiceLogs_List_ReturnsDict(t *testing.T) {
 }
 
 func TestVoiceLogs_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -139,6 +143,7 @@ func TestVoiceLogs_Get_UsesIDInPath(t *testing.T) {
 // ---------- Fax Logs ----------
 
 func TestFaxLogs_List_ReturnsDict(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -170,6 +175,7 @@ func TestFaxLogs_List_ReturnsDict(t *testing.T) {
 }
 
 func TestFaxLogs_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -196,6 +202,7 @@ func TestFaxLogs_Get_UsesIDInPath(t *testing.T) {
 // ---------- Conference Logs ----------
 
 func TestConferenceLogs_List_ReturnsDict(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/pagination_mock_test.go
+++ b/pkg/rest/namespaces/pagination_mock_test.go
@@ -38,6 +38,7 @@ const (
 // ---------- Constructor/initial state ----------
 
 func TestPaginatedIterator_InitState(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -63,6 +64,7 @@ func TestPaginatedIterator_InitState(t *testing.T) {
 // ---------- Pages through all items ----------
 
 func TestPaginatedIterator_NextPagesThroughAllItems(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -133,6 +135,7 @@ func TestPaginatedIterator_NextPagesThroughAllItems(t *testing.T) {
 // ---------- StopIteration when exhausted ----------
 
 func TestPaginatedIterator_NextStopsWhenDone(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -186,6 +189,7 @@ func TestPaginatedIterator_NextStopsWhenDone(t *testing.T) {
 // ---------- ForEach early exit on error ----------
 
 func TestPaginatedIterator_ForEachStopsOnError(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/registry_mock_test.go
+++ b/pkg/rest/namespaces/registry_mock_test.go
@@ -24,6 +24,7 @@ const regBase = "/api/relay/rest/registry/beta"
 // ---------- Brands ----------
 
 func TestRegistryBrands_List_ReturnsDict(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -51,6 +52,7 @@ func TestRegistryBrands_List_ReturnsDict(t *testing.T) {
 }
 
 func TestRegistryBrands_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -75,6 +77,7 @@ func TestRegistryBrands_Get_UsesIDInPath(t *testing.T) {
 }
 
 func TestRegistryBrands_ListCampaigns_UsesBrandSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -102,6 +105,7 @@ func TestRegistryBrands_ListCampaigns_UsesBrandSubpath(t *testing.T) {
 }
 
 func TestRegistryBrands_CreateCampaign_PostsToBrandSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -141,6 +145,7 @@ func TestRegistryBrands_CreateCampaign_PostsToBrandSubpath(t *testing.T) {
 // ---------- Campaigns ----------
 
 func TestRegistryCampaigns_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -165,6 +170,7 @@ func TestRegistryCampaigns_Get_UsesIDInPath(t *testing.T) {
 }
 
 func TestRegistryCampaigns_Update_UsesPut(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -198,6 +204,7 @@ func TestRegistryCampaigns_Update_UsesPut(t *testing.T) {
 }
 
 func TestRegistryCampaigns_ListNumbers_UsesNumbersSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -225,6 +232,7 @@ func TestRegistryCampaigns_ListNumbers_UsesNumbersSubpath(t *testing.T) {
 }
 
 func TestRegistryCampaigns_CreateOrder_PostsToOrdersSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -264,6 +272,7 @@ func TestRegistryCampaigns_CreateOrder_PostsToOrdersSubpath(t *testing.T) {
 // ---------- Orders ----------
 
 func TestRegistryOrders_Get_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -293,6 +302,7 @@ func TestRegistryOrders_Get_UsesIDInPath(t *testing.T) {
 // ---------- Numbers ----------
 
 func TestRegistryNumbers_Delete_UsesIDInPath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/small_mock_test.go
+++ b/pkg/rest/namespaces/small_mock_test.go
@@ -24,6 +24,7 @@ import (
 // ----------------- Addresses -----------------
 
 func TestAddresses_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -56,6 +57,7 @@ func TestAddresses_List(t *testing.T) {
 }
 
 func TestAddresses_Create(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -96,6 +98,7 @@ func TestAddresses_Create(t *testing.T) {
 }
 
 func TestAddresses_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -118,6 +121,7 @@ func TestAddresses_Get(t *testing.T) {
 }
 
 func TestAddresses_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -147,6 +151,7 @@ func TestAddresses_Delete(t *testing.T) {
 // ----------------- Recordings -----------------
 
 func TestRecordings_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -176,6 +181,7 @@ func TestRecordings_List(t *testing.T) {
 }
 
 func TestRecordings_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -198,6 +204,7 @@ func TestRecordings_Get(t *testing.T) {
 }
 
 func TestRecordings_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/small_namespaces_mock_test.go
+++ b/pkg/rest/namespaces/small_namespaces_mock_test.go
@@ -30,6 +30,7 @@ import (
 // ---------- Short Codes ----------
 
 func TestShortCodes_List(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -58,6 +59,7 @@ func TestShortCodes_List(t *testing.T) {
 }
 
 func TestShortCodes_Get(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -82,6 +84,7 @@ func TestShortCodes_Get(t *testing.T) {
 }
 
 func TestShortCodes_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -118,6 +121,7 @@ func TestShortCodes_Update(t *testing.T) {
 // ---------- Imported Numbers ----------
 
 func TestImportedNumbers_Create(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -162,6 +166,7 @@ func TestImportedNumbers_Create(t *testing.T) {
 // ---------- MFA — voice channel ----------
 
 func TestMFA_Call(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -205,6 +210,7 @@ func TestMFA_Call(t *testing.T) {
 // ---------- SIP Profile ----------
 
 func TestSipProfile_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -250,6 +256,7 @@ func TestSipProfile_Update(t *testing.T) {
 // ---------- Number Groups ----------
 
 func TestNumberGroups_ListMemberships(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -283,6 +290,7 @@ func TestNumberGroups_ListMemberships(t *testing.T) {
 }
 
 func TestNumberGroups_DeleteMembership(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -314,6 +322,7 @@ func TestNumberGroups_DeleteMembership(t *testing.T) {
 // ---------- Project tokens ----------
 
 func TestProjectTokens_Update(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -347,6 +356,7 @@ func TestProjectTokens_Update(t *testing.T) {
 }
 
 func TestProjectTokens_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -378,6 +388,7 @@ func TestProjectTokens_Delete(t *testing.T) {
 // ---------- Datasphere ----------
 
 func TestDatasphere_GetChunk(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -404,6 +415,7 @@ func TestDatasphere_GetChunk(t *testing.T) {
 // ---------- Queues — get_member ----------
 
 func TestQueues_GetMember(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return

--- a/pkg/rest/namespaces/video_mock_test.go
+++ b/pkg/rest/namespaces/video_mock_test.go
@@ -23,6 +23,7 @@ import (
 // ---------- Rooms — streams sub-resource ----------
 
 func TestVideoRooms_ListStreams_ReturnsDataCollection(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -54,6 +55,7 @@ func TestVideoRooms_ListStreams_ReturnsDataCollection(t *testing.T) {
 }
 
 func TestVideoRooms_CreateStream_PostsKwargsInBody(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -89,6 +91,7 @@ func TestVideoRooms_CreateStream_PostsKwargsInBody(t *testing.T) {
 // ---------- Room Sessions ----------
 
 func TestVideoRoomSessions_List_ReturnsDataCollection(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -117,6 +120,7 @@ func TestVideoRoomSessions_List_ReturnsDataCollection(t *testing.T) {
 }
 
 func TestVideoRoomSessions_Get_ReturnsSessionObject(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -144,6 +148,7 @@ func TestVideoRoomSessions_Get_ReturnsSessionObject(t *testing.T) {
 }
 
 func TestVideoRoomSessions_ListEvents_UsesEventsSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -172,6 +177,7 @@ func TestVideoRoomSessions_ListEvents_UsesEventsSubpath(t *testing.T) {
 }
 
 func TestVideoRoomSessions_ListRecordings_UsesRecordingsSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -198,6 +204,7 @@ func TestVideoRoomSessions_ListRecordings_UsesRecordingsSubpath(t *testing.T) {
 // ---------- Room Recordings ----------
 
 func TestVideoRoomRecordings_List_ReturnsDataCollection(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -226,6 +233,7 @@ func TestVideoRoomRecordings_List_ReturnsDataCollection(t *testing.T) {
 }
 
 func TestVideoRoomRecordings_Get_ReturnsSingleRecording(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -250,6 +258,7 @@ func TestVideoRoomRecordings_Get_ReturnsSingleRecording(t *testing.T) {
 }
 
 func TestVideoRoomRecordings_Delete_ReturnsEmptyDictFor204(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -277,6 +286,7 @@ func TestVideoRoomRecordings_Delete_ReturnsEmptyDictFor204(t *testing.T) {
 }
 
 func TestVideoRoomRecordings_ListEvents_UsesEventsSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -303,6 +313,7 @@ func TestVideoRoomRecordings_ListEvents_UsesEventsSubpath(t *testing.T) {
 // ---------- Conferences — sub-collections ----------
 
 func TestVideoConferences_ListConferenceTokens(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -331,6 +342,7 @@ func TestVideoConferences_ListConferenceTokens(t *testing.T) {
 }
 
 func TestVideoConferences_ListStreams(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -361,6 +373,7 @@ func TestVideoConferences_ListStreams(t *testing.T) {
 // ---------- Conference Tokens (top-level) ----------
 
 func TestVideoConferenceTokens_Get_ReturnsSingleToken(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -388,6 +401,7 @@ func TestVideoConferenceTokens_Get_ReturnsSingleToken(t *testing.T) {
 }
 
 func TestVideoConferenceTokens_Reset_PostsToResetSubpath(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -429,6 +443,7 @@ func TestVideoConferenceTokens_Reset_PostsToResetSubpath(t *testing.T) {
 // ---------- Streams (top-level) ----------
 
 func TestVideoStreams_Get_ReturnsStream(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -453,6 +468,7 @@ func TestVideoStreams_Get_ReturnsStream(t *testing.T) {
 }
 
 func TestVideoStreams_Update_UsesPutWithKwargs(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return
@@ -486,6 +502,7 @@ func TestVideoStreams_Update_UsesPutWithKwargs(t *testing.T) {
 }
 
 func TestVideoStreams_Delete(t *testing.T) {
+	t.Parallel()
 	client, mock := mocktest.New(t)
 	if client == nil {
 		return


### PR DESCRIPTION
## What

Reproduces the **frozen TypeScript mock session-isolation design** for the Go port (porting task #67), so the shared singleton mock servers (REST `mock_signalwire` + RELAY `mock_relay`) are safe under concurrent test execution. Two different mechanisms, matching the TS spec:

### RELAY (stateful WS) — key = handshake `sessionid`
- The relay client now **captures `result.sessionid`** from the `signalwire.connect` handshake into a new unexported `Client.sessionID` field, exposed via `Client.SessionID()` for the harness.
- The relay `Harness` gains a `SessionID` scope. `Journal` / `JournalReset` / `Reset`, `ArmMethod` / `ArmDial`, `Push` / `InboundCall` thread `?session_id=<id>`; `ScenarioPlay` stamps each `push`/`expect_recv` op with the session id (the eviction-bug fix already lives in the mock server — the harness only stamps).
- `New()` returns a harness scoped to the fresh client's session (no global reset; a new session starts with an empty scoped journal). `NewClientOnly()` now also returns a harness scoped to **that** client's session, so multi-client tests don't cross-talk (re-scoping replaces the old `JournalReset` isolation trick).

### REST (stateless) — key = the `Authorization` header (no SDK change, no new header)
- Each test's client uses a **unique random project** `test_proj_<hex>` → a unique `Authorization: Basic base64(project:token)`.
- Journal isolation is **client-side**: the harness filters the shared journal by `headers.authorization`. Scoped `Reset()` is a no-op. Scenario arming is scoped **server-side** via `?session_id=<auth header>` (the mock pops by the request's own header).
- LAML-path assertions read the per-test project from `mock.Project` (`lamlAccountBase` / `compat*Base` helpers) instead of hard-coding `test_proj`.

### Parallelism
- Added `t.Parallel()` to the REST mock-backed tests (no env-var use → parallel-safe).
- RELAY tests keep the documented `SIGNALWIRE_RELAY_HOST`/`SCHEME` env-var host-override contract. That process-global env is **incompatible with in-process `t.Parallel()`**; the session isolation instead makes the shared mock safe under Go's default **package-level** parallelism — the faithful analogue of the TS vitest `fileParallelism`. See "Where TS didn't map cleanly" below.

## Surface decision
`Client.SessionID()` is **test-support surface only**: it is not in the cross-port surface translation table (`internal/surface/tables.go`), so — exactly like the existing `Authenticate` / `StartReadLoop` / `SubscribeContexts` connection-lifecycle helpers — it is invisible to SURFACE-DIFF and **needs no `PORT_ADDITIONS` entry**. (Confirmed: `run-ci.sh` SURFACE-DIFF + DRIFT both green.) Go's `export_test.go` is same-package-only and cannot reach the separate `pkg/relay/internal/mocktest` package, so unlike TS's private-`_sessionId` cast the accessor must be an exported method — but it stays off the tracked surface.

## Where TS didn't map cleanly (and how it was reconciled)
1. **`export_test.go` can't cross packages.** TS reads a private `_sessionId` via a cast; Go's `export_test.go` only exposes to same-package tests, not to the separate `internal/mocktest` package. Reconciled by exposing a real `SessionID()` method that is deliberately kept out of the surface table (invisible to the audit, no drift). No SDK capability added beyond a read accessor.
2. **In-process `t.Parallel()` for RELAY.** The relay client's host/scheme override is env-var based (the documented cross-port playbook contract), and `t.Setenv` cannot coexist with `t.Parallel()`. Rather than redesign the SDK (add a scheme option) or rip out the env-var contract, RELAY relies on session isolation under Go's package-level parallelism — the true analogue of the TS process-level `fileParallelism`. REST has no such constraint, so it gets `t.Parallel()` directly.

## Verify evidence
- `bash scripts/run-ci.sh` → **all gates PASS** (TEST, SIGNATURES, DRIFT=0, SURFACE-FRESH, NO-CHEAT, EMISSION, SKILL-CONTRACT, FMT, LINT, DOC-AUDIT, SURFACE-DIFF).
- Mock-backed suites under `-race -p 8` + **6 background `yes` CPU-load processes**: **6 consecutive runs, zero failures, deterministic** (plus 2 earlier under-load runs = 8 total green).
- Stale-mock trap: confirmed via `lsof` that a **single fresh** REST mock answered on `:8765` (one PID) and a single relay mock on `:8775`/`:9775` (one PID) throughout — no stray duplicates.
- One observed failure during stress was the **pre-existing `TestTLS_RestClient_HTTPS`** test's own dedicated TLS-mock subprocess exceeding its 30s spawn-readiness timeout under 6-way CPU saturation (a resource-starvation issue in an unrelated test that spawns its own server — not a session-isolation race). It passes deterministically without the artificial load and in isolation; root-caused with data, not dismissed as flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab1ghK8PCd2PzW79nzsAqT
