### PR TITLE
fix(agent): Category A behavior bundle — 7 Python-parity fixes

### DIFF
--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -26,6 +26,25 @@ relay.Client.RunContext: Go ctx-aware form of Run; stops cleanly on ctx cancel/d
 relay.Client.DialContext: Go ctx-aware form of Dial; aborts the dial on ctx cancel/deadline returning ctx.Err(), alongside the dial-timeout + client lifecycle. Non-ctx Dial preserved
 server.AgentServer.RunContext: Go ctx-aware form of AgentServer.Run; on ctx cancel/deadline performs a graceful Shutdown (drain) then returns nil. Non-ctx Run preserved
 agent.AgentBase.RunContext: Go ctx-aware form of AgentBase.Run; on ctx cancel/deadline triggers the existing graceful HTTP shutdown (drains in-flight) then returns nil. Composes with SetupGracefulShutdown. Non-ctx Run preserved
+
+# --- #192: Run() serverless-mode auto-detection + dispatch ---
+# Run() is now the universal entry point: it computes the execution mode via
+# swml.GetExecutionMode() (the cross-language detection contract — CGI/Lambda/
+# GCF/Azure/server) and dispatches, mirroring Python web_mixin.run() +
+# serverless_mixin. Server mode serves HTTP (existing behavior, preserved);
+# a detected serverless platform returns ErrServerlessUnsupported rather than
+# silently binding a TCP listener that never receives traffic — Go's serverless
+# request handling lives in the dedicated adapter pkg/lambda (wraps AsRouter(),
+# driven from main() by aws-lambda-go), not inline in Run(). DetectRunMode and
+# RunWithMode are the Go-idiomatic shape for Python run()'s implicit
+# get_execution_mode() call and its force_mode= override arg respectively;
+# Python folds both into run()'s param list, Go exposes them as methods on the
+# mapped struct (invisible to both diff gates, like the *Context methods above).
+# Tested in pkg/agent/run_serverless_test.go (detection fixtures, force-mode
+# dispatch, server-mode still serves HTTP).
+agent.AgentBase.DetectRunMode: Go accessor returning the swml.ExecutionMode Run() would dispatch on (from swml.GetExecutionMode()). Mirrors Python run()'s internal get_execution_mode() call; lets callers branch (e.g. wire a pkg/lambda adapter) before invoking Run. Method-on-mapped-struct: invisible to both diff gates
+agent.AgentBase.RunWithMode: Go force-mode form of Run — dispatches on the supplied swml.ExecutionMode rather than auto-detecting. Mirrors Python run(force_mode=...). Server mode serves HTTP; a serverless mode returns ErrServerlessUnsupported. Method-on-mapped-struct: invisible to both diff gates
+agent.ErrServerlessUnsupported: Go sentinel — Run/RunWithMode detected a serverless execution mode (Lambda/GCF/Azure/CGI); the agent must be served via its http.Handler (AsRouter) using the platform adapter (e.g. pkg/lambda), not Run(). errors.Is-able. No Python counterpart (Python's run() handles each platform inline; Go's serverless handling is the AsRouter+adapter path)
 # REST client ctx-aware variants (cloud-product #19436). doRequest now delegates to
 # doRequestContext via http.NewRequestWithContext; the non-ctx verbs are PRESERVED and
 # delegate with context.Background(). Python's REST client has no caller-supplied

--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -88,6 +88,28 @@ relay.Call.CallState: Go typed-kind accessor returning relay.CallState alongside
 relay.Message.MessageState: Go typed-kind accessor returning relay.MessageState alongside the bare-string Message.State() (kept). String == State() exactly
 relay.DialEvent.DialStateTyped: Go typed-kind accessor returning relay.DialState alongside the bare-string DialEvent.DialState field (kept). String == DialState exactly
 
+# --- #188: Go-only response-override form of register_routing_callback (maintainer-approved) ---
+# Python's register_routing_callback (web_mixin.py:1227 / swml_service.py:863) is
+# REDIRECT-ONLY: the callback returns a route string and the framework replies
+# HTTP 307 Temporary Redirect to that route (web_mixin.py:704-711). Go's
+# RegisterRoutingCallback callback instead returns a map[string]any that REPLACES
+# the rendered SWML response document for that path (agent.go:2369; dispatched in
+# the SWML handler at agent.go ~3293-3300 — when the callback returns non-nil its
+# map is served as the SWML doc, else the default RenderSWML doc is used). This
+# response-override form is a genuine Go-only EXTENSION beyond Python's
+# redirect-only contract. It exists for SWML-service routing / sidecar event
+# sinks where the handler wants to synthesize or rewrite the SWML document
+# in-process rather than redirect the caller to a different route; used by the
+# examples swmlservice_ai_sidecar, dynamic_swml_service, and swml_service_routing.
+# The maintainer has explicitly APPROVED keeping this Go-only behavior. It has a
+# behavioral test at pkg/agent/routing_callback_test.go (the callback receives the
+# live *http.Request and its returned map replaces the document). The callback
+# function type is a parameter type, not an enumerated public symbol, so it is
+# invisible to both diff gates; documented here for the audit trail. (The team
+# will separately port a response-override capability to Python later; that is
+# out of scope for this entry.)
+signalwire.core.mixins.web_mixin.WebMixin.register_routing_callback: Go's RegisterRoutingCallback takes a callback returning map[string]any that REPLACES the rendered SWML document (response-override), extending Python's redirect-only (route string -> HTTP 307) contract. Maintainer-approved Go-only extension; behavioral test in pkg/agent/routing_callback_test.go
+
 # --- Go-only structs (port-only public types) ---
 agent.MCPServerConfig: Go-only config struct; not part of Python public API
 agent.ToolDefinition: Go-only struct; no direct Python counterpart

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1527,10 +1527,76 @@ func (a *AgentBase) SetPromptTransformer(fn func(map[string]any) map[string]any)
 // Verb management
 // ---------------------------------------------------------------------------
 
+// preAnswerSafeVerbs mirrors Python AgentBase._PRE_ANSWER_SAFE_VERBS
+// (agent_base.py:331) — the set of SWML verbs known to be safe to run while
+// the call is still ringing (before the answer).
+var preAnswerSafeVerbs = map[string]struct{}{
+	"transfer":         {},
+	"execute":          {},
+	"return":           {},
+	"label":            {},
+	"goto":             {},
+	"request":          {},
+	"switch":           {},
+	"cond":             {},
+	"if":               {},
+	"eval":             {},
+	"set":              {},
+	"unset":            {},
+	"hangup":           {},
+	"send_sms":         {},
+	"sleep":            {},
+	"stop_record_call": {},
+	"stop_denoise":     {},
+	"stop_tap":         {},
+}
+
+// preAnswerAutoAnswerVerbs mirrors Python AgentBase._AUTO_ANSWER_VERBS
+// (agent_base.py:351) — verbs that answer the call unless "auto_answer" is
+// explicitly false.
+var preAnswerAutoAnswerVerbs = map[string]struct{}{
+	"play":    {},
+	"connect": {},
+}
+
+// sortedPreAnswerSafeVerbs returns the safe-verb names in sorted order for a
+// stable warning message (Python sorts the set when formatting).
+func sortedPreAnswerSafeVerbs() []string {
+	names := make([]string, 0, len(preAnswerSafeVerbs))
+	for v := range preAnswerSafeVerbs {
+		names = append(names, v)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // AddPreAnswerVerb adds a SWML verb to execute before the answer.
+//
+// Python equivalent: AgentBase.add_pre_answer_verb (agent_base.py:546).
+// Pre-answer verbs run while the call is still ringing, so only certain verbs
+// are safe. Python raises ValueError for an unknown verb; the Go port instead
+// logs a warning and still registers the verb (additive diagnostic — the
+// emitted SWML is unchanged). Verbs that answer the call (play, connect) get a
+// distinct warning unless "auto_answer": false is present, mirroring Python's
+// _AUTO_ANSWER_VERBS branch.
 func (a *AgentBase) AddPreAnswerVerb(verbName string, config map[string]any) *AgentBase {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+
+	if _, isAutoAnswer := preAnswerAutoAnswerVerbs[verbName]; isAutoAnswer {
+		if aa, ok := config["auto_answer"]; !ok || aa != false {
+			a.Logger.Warn(
+				"pre_answer_verb_will_answer: verb=%q hint=add 'auto_answer': false to prevent %s from answering the call",
+				verbName, verbName,
+			)
+		}
+	} else if _, safe := preAnswerSafeVerbs[verbName]; !safe {
+		a.Logger.Warn(
+			"verb %q is not safe for pre-answer use. Safe verbs: %s",
+			verbName, strings.Join(sortedPreAnswerSafeVerbs(), ", "),
+		)
+	}
+
 	a.preAnswerVerbs = append(a.preAnswerVerbs, verb{Name: verbName, Config: config})
 	return a
 }
@@ -1601,6 +1667,164 @@ func (a *AgentBase) DefineContexts() *contexts.ContextBuilder {
 		a.contextBuilder.AttachAgent(a)
 	}
 	return a.contextBuilder
+}
+
+// DefineContextsFromMap populates the agent's ContextBuilder from a
+// fully-formed contexts map and returns the agent for chaining.
+//
+// Python equivalent: AgentBase.define_contexts({...}) (prompt_mixin.py:131 →
+// prompt manager define_contexts, manager.py:75), which accepts a dict in the
+// canonical SWML contexts shape — the same shape ContextBuilder.to_dict()
+// emits. The accepted shape is:
+//
+//	{
+//	  "<context-name>": {
+//	    "steps": [
+//	      {"name": "...", "text": "...", "step_criteria": "...",
+//	       "functions": "none" | ["fn", ...],
+//	       "valid_steps": ["..."], "valid_contexts": ["..."],
+//	       "end": bool, "skip_user_turn": bool, "skip_to_next_step": bool}
+//	    ],
+//	    "valid_contexts": ["..."], "valid_steps": ["..."],
+//	    "initial_step": "...", "post_prompt": "...", "system_prompt": "...",
+//	    "user_prompt": "...", "prompt": "...", "consolidate": bool,
+//	    "full_reset": bool, "isolated": bool
+//	  }
+//	}
+//
+// Unlike the chained DefineContexts builder, this populates the existing
+// ContextBuilder in one call so callers can hand it a deserialised map.
+func (a *AgentBase) DefineContextsFromMap(cfg map[string]any) *AgentBase {
+	builder := a.DefineContexts()
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Deterministic order so re-runs and the SWML output are stable.
+	names := make([]string, 0, len(cfg))
+	for name := range cfg {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		raw, ok := cfg[name].(map[string]any)
+		if !ok {
+			continue
+		}
+		ctx := builder.AddContext(name)
+
+		if steps, ok := raw["steps"].([]any); ok {
+			for _, s := range steps {
+				stepMap, ok := s.(map[string]any)
+				if !ok {
+					continue
+				}
+				stepName, _ := stepMap["name"].(string)
+				if stepName == "" {
+					continue
+				}
+				step := ctx.AddStep(stepName)
+				if text, ok := stepMap["text"].(string); ok {
+					step.SetText(text)
+				}
+				if criteria, ok := stepMap["step_criteria"].(string); ok {
+					step.SetStepCriteria(criteria)
+				}
+				if fns, ok := stepMap["functions"]; ok {
+					if coerced := coerceFunctions(fns); coerced != nil {
+						step.SetFunctions(coerced)
+					}
+				}
+				if vs := coerceStringSlice(stepMap["valid_steps"]); vs != nil {
+					step.SetValidSteps(vs)
+				}
+				if vc := coerceStringSlice(stepMap["valid_contexts"]); vc != nil {
+					step.SetValidContexts(vc)
+				}
+				if end, ok := stepMap["end"].(bool); ok && end {
+					step.SetEnd(true)
+				}
+				if skip, ok := stepMap["skip_user_turn"].(bool); ok && skip {
+					step.SetSkipUserTurn(true)
+				}
+				if skip, ok := stepMap["skip_to_next_step"].(bool); ok && skip {
+					step.SetSkipToNextStep(true)
+				}
+			}
+		}
+
+		if initial, ok := raw["initial_step"].(string); ok {
+			ctx.SetInitialStep(initial)
+		}
+		if vc := coerceStringSlice(raw["valid_contexts"]); vc != nil {
+			ctx.SetValidContexts(vc)
+		}
+		if vs := coerceStringSlice(raw["valid_steps"]); vs != nil {
+			ctx.SetValidSteps(vs)
+		}
+		if pp, ok := raw["post_prompt"].(string); ok {
+			ctx.SetPostPrompt(pp)
+		}
+		if sp, ok := raw["system_prompt"].(string); ok {
+			ctx.SetSystemPrompt(sp)
+		}
+		if up, ok := raw["user_prompt"].(string); ok {
+			ctx.SetUserPrompt(up)
+		}
+		if p, ok := raw["prompt"].(string); ok {
+			ctx.SetPrompt(p)
+		}
+		if c, ok := raw["consolidate"].(bool); ok && c {
+			ctx.SetConsolidate(true)
+		}
+		if fr, ok := raw["full_reset"].(bool); ok && fr {
+			ctx.SetFullReset(true)
+		}
+		if iso, ok := raw["isolated"].(bool); ok && iso {
+			ctx.SetIsolated(true)
+		}
+	}
+
+	return a
+}
+
+// coerceFunctions normalises the SWML "functions" value, which may be the
+// string "none" or a list of tool names, into the form SetFunctions accepts.
+func coerceFunctions(v any) any {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// coerceStringSlice converts a JSON-decoded []any (or []string) into []string,
+// returning nil when the value is absent or not a list.
+func coerceStringSlice(v any) []string {
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // ListToolNames returns the names of every registered SWAIG tool in
@@ -1687,9 +1911,15 @@ func (a *AgentBase) ClearSwaigQueryParams() *AgentBase {
 	return a
 }
 
-// EnableDebugRoutes is a placeholder for adding debug HTTP routes.
+// EnableDebugRoutes enables the agent's debug HTTP routes (/debug and
+// /debug_events).
+//
+// Python equivalent: web_mixin.enable_debug_routes (web_mixin.py:1343), which
+// is a backward-compatibility no-op returning self because the debug routes
+// are registered unconditionally in _register_routes. The Go port mirrors that:
+// AsRouter always registers /debug and /debug_events, so this method exists for
+// API parity and chaining and simply returns the agent.
 func (a *AgentBase) EnableDebugRoutes() *AgentBase {
-	// Future: register /debug routes on the mux
 	return a
 }
 
@@ -2136,10 +2366,27 @@ func (a *AgentBase) EnableSIPRouting(autoMap bool, path string) *AgentBase {
 // For Python-aligned redirect semantics (callback returns a route string and
 // the framework issues an HTTP 307 redirect), use RegisterSIPRoutingCallback.
 func (a *AgentBase) RegisterRoutingCallback(callbackFn func(r *http.Request, body map[string]any) map[string]any, path string) {
+	a.Service.RegisterRoutingCallback(normalizeCallbackPath(path), callbackFn)
+}
+
+// normalizeCallbackPath mirrors Python web_mixin.register_routing_callback's
+// path handling: default the empty path to "/sip", ensure a single leading
+// slash, and strip any trailing slash so e.g. "agents/" registers (and later
+// matches) as "/agents".
+func normalizeCallbackPath(path string) string {
 	if path == "" {
-		path = "/sip"
+		return "/sip"
 	}
-	a.Service.RegisterRoutingCallback(path, callbackFn)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+	}
+	if path == "" {
+		path = "/"
+	}
+	return path
 }
 
 // RegisterSIPRoutingCallback registers a callback whose string return value
@@ -2419,6 +2666,40 @@ func (a *AgentBase) buildPostPromptURL() string {
 	return strings.TrimRight(url, "/") + "/post_prompt"
 }
 
+// buildEndpointURL constructs the authed webhook URL for an arbitrary agent
+// endpoint (e.g. "debug_events"), including swaigQueryParams. Mirrors Python
+// _build_webhook_url(endpoint, query_params) (used at agent_base.py:1240 for
+// the debug_events webhook).
+func (a *AgentBase) buildEndpointURL(endpoint string) string {
+	user, pass := a.Service.GetBasicAuthCredentials()
+	baseURL := a.Service.GetFullURL(false)
+
+	scheme := "http://"
+	if strings.HasPrefix(baseURL, "https://") {
+		scheme = "https://"
+	}
+	rest := strings.TrimPrefix(strings.TrimPrefix(baseURL, "http://"), "https://")
+	authedBase := fmt.Sprintf("%s%s:%s@%s", scheme, user, pass, rest)
+
+	route := strings.TrimRight(a.Service.Route, "/")
+	url := authedBase
+	if !strings.HasSuffix(url, route) {
+		url = strings.TrimRight(url, "/") + route
+	}
+	url = strings.TrimRight(url, "/") + "/" + endpoint
+
+	if len(a.swaigQueryParams) > 0 {
+		params := make([]string, 0, len(a.swaigQueryParams))
+		for k, v := range a.swaigQueryParams {
+			params = append(params, fmt.Sprintf("%s=%s", k, v))
+		}
+		sort.Strings(params)
+		url += "?" + strings.Join(params, "&")
+	}
+
+	return url
+}
+
 // buildSwaigFunctions returns the SWAIG functions array for the AI verb.
 func (a *AgentBase) buildSwaigFunctions(webhookURL string) []map[string]any {
 	functions := make([]map[string]any, 0, len(a.toolOrder)+len(a.functionIncludes))
@@ -2637,9 +2918,20 @@ func (a *AgentBase) RenderSWML(requestData map[string]any, request *http.Request
 		}
 	}
 
-	// Debug events
+	// Debug events. Python (agent_base.py:1232-1246) wires a debug webhook so
+	// the platform POSTs debug events back to the agent's /debug_events
+	// endpoint: it sets params.debug_webhook_url and params.debug_webhook_level
+	// (no separate ai.debug_events key is emitted). Mirror that here so the
+	// /debug_events route (registered in AsRouter) actually receives events and
+	// OnDebugEvent fires.
 	if a.debugEventsLevel > 0 {
-		aiConfig["debug_events"] = a.debugEventsLevel
+		params, ok := aiConfig["params"].(map[string]any)
+		if !ok {
+			params = map[string]any{}
+			aiConfig["params"] = params
+		}
+		params["debug_webhook_url"] = a.buildEndpointURL("debug_events")
+		params["debug_webhook_level"] = a.debugEventsLevel
 	}
 
 	// MCP servers
@@ -2850,6 +3142,23 @@ func (a *AgentBase) buildMux() *http.ServeMux {
 	mux.HandleFunc(checkRoute, a.withAuth(a.handleCheckForInput))
 	mux.HandleFunc(checkRoute+"/", a.withAuth(a.handleCheckForInput))
 
+	// Debug routes — matches Python web_mixin._register_routes (web_mixin.py
+	// lines 422-472), which unconditionally registers /debug (a SWML dump for
+	// inspection, behaves like the main endpoint) and /debug_events (the
+	// webhook the platform POSTs debug events to when EnableDebugEvents is on).
+	// These are what EnableDebugRoutes documents; in Python that method is a
+	// backward-compat no-op because the routes are always registered here.
+	debugRoute := route + "/debug"
+	debugEventsRoute := route + "/debug_events"
+	if route == "/" {
+		debugRoute = "/debug"
+		debugEventsRoute = "/debug_events"
+	}
+	mux.HandleFunc(debugRoute, a.withAuth(a.withSignedPost(a.handleSWML)))
+	mux.HandleFunc(debugRoute+"/", a.withAuth(a.withSignedPost(a.handleSWML)))
+	mux.HandleFunc(debugEventsRoute, a.withAuth(a.withSignedPost(a.handleDebugEvents)))
+	mux.HandleFunc(debugEventsRoute+"/", a.withAuth(a.withSignedPost(a.handleDebugEvents)))
+
 	// MCP server endpoint (no auth — MCP clients authenticate via headers)
 	if a.mcpServerEnabled {
 		mcpRoute := route + "/mcp"
@@ -2976,10 +3285,19 @@ func (a *AgentBase) handleSWML(w http.ResponseWriter, r *http.Request) {
 	var doc map[string]any
 	switch {
 	case callbackPath != "":
-		// The swml service's OnRequest dispatches to the registered callback
-		// and returns the callback's result; if the callback returns nil,
-		// OnRequest falls back to the default rendered document.
-		doc = a.Service.OnRequest(body, callbackPath)
+		// Dispatch to the registered routing callback with the LIVE request so
+		// the callback can read headers, query params, etc. (Python passes the
+		// request: web_mixin.py:704 `callback_fn(request, body)`). When the
+		// callback returns nil — or no callback is registered for the path —
+		// fall back to the default rendered document.
+		if cb, ok := a.Service.RoutingCallbackFor(callbackPath); ok {
+			if result := cb(r, body); result != nil {
+				doc = result
+			}
+		}
+		if doc == nil {
+			doc = a.RenderSWML(body, r)
+		}
 	case hasDynamic:
 		doc = a.handleDynamicConfig(body, r)
 	default:
@@ -3251,6 +3569,103 @@ func (a *AgentBase) handleSwaig(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// findSummary extracts a structured summary from a post-prompt request body,
+// mirroring Python AgentBase._find_summary_in_post_data (agent_base.py:1494)
+// and the TypeScript AgentBase.findSummary. The extraction order is exact:
+//
+//  1. body["summary"]
+//  2. body["post_prompt_data"]["parsed"][0] when "parsed" is a non-empty array
+//  3. body["post_prompt_data"]["raw"] parsed as JSON; on parse failure the raw
+//     value itself ("raw-as-both" in Python/TS)
+//
+// Returns nil when no summary is present. Because the OnSummary callback's
+// first argument is typed map[string]any, a successful extraction that is not
+// a JSON object (e.g. a non-JSON raw string in the raw-as-both branch, or a
+// scalar/array) is returned as nil — the raw body is always available as the
+// callback's second argument regardless.
+func findSummary(body map[string]any) map[string]any {
+	if body == nil {
+		return nil
+	}
+
+	if s, ok := body["summary"]; ok {
+		if m, ok := s.(map[string]any); ok {
+			return m
+		}
+		return nil
+	}
+
+	pdata, ok := body["post_prompt_data"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	if parsed, ok := pdata["parsed"].([]any); ok && len(parsed) > 0 {
+		if m, ok := parsed[0].(map[string]any); ok {
+			return m
+		}
+		return nil
+	}
+
+	if rawVal, ok := pdata["raw"]; ok && rawVal != nil {
+		// Already a structured object — return as-is.
+		if m, ok := rawVal.(map[string]any); ok {
+			return m
+		}
+		// String raw text: try to parse JSON. On success return the object;
+		// on failure fall back to the raw value (Python/TS "raw-as-both"),
+		// which here can only surface a JSON object.
+		if rawStr, ok := rawVal.(string); ok {
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(rawStr), &parsed); err == nil {
+				return parsed
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleDebugEvents receives debug-event webhooks the platform POSTs back to
+// the agent when debug events are enabled (EnableDebugEvents). It parses the
+// JSON body and dispatches it to the registered OnDebugEvent handler.
+//
+// Python equivalent: web_mixin._handle_debug_events_request (web_mixin.py:1081)
+// which parses the body and invokes self._debug_event_handler(event_type, body).
+// The Go DebugEventHandler takes the event body map (matching the TypeScript
+// onDebugEvent(body) shape); the raw body is passed through unchanged.
+func (a *AgentBase) handleDebugEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"POST required"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxAgentRequestBody)
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		// Match Python: an unparseable body yields an error status but not a
+		// hard HTTP failure.
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "invalid JSON"}); err != nil {
+			a.Logger.Warn("failed to write debug_events error response: %s", err)
+		}
+		return
+	}
+
+	a.mu.RLock()
+	handler := a.debugEventHandler
+	a.mu.RUnlock()
+
+	if handler != nil {
+		handler(body)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+		a.Logger.Warn("failed to write debug_events response: %s", err)
+	}
+}
+
 // handlePostPrompt handles the post-prompt summary callback.
 func (a *AgentBase) handlePostPrompt(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -3270,7 +3685,7 @@ func (a *AgentBase) handlePostPrompt(w http.ResponseWriter, r *http.Request) {
 	a.mu.RUnlock()
 
 	if cb != nil {
-		cb(body, body)
+		cb(findSummary(body), body)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -2969,12 +2970,60 @@ func (a *AgentBase) RenderSWML(requestData map[string]any, request *http.Request
 // HTTP Server
 // ---------------------------------------------------------------------------
 
-// Run starts the HTTP server for the agent.  This is a blocking call.
+// ErrServerlessUnsupported is returned by Run / RunWithMode when a serverless
+// execution mode (AWS Lambda, Google Cloud Functions, Azure Functions, or CGI)
+// is detected. Go's serverless request handling is NOT performed inline by
+// Run: it lives in the dedicated adapter pkg/lambda, which wraps the agent's
+// http.Handler (AgentBase.AsRouter) and is driven from main() by the platform
+// runtime (e.g. aws-lambda-go's lambda.Start). Run returning this error rather
+// than silently serving HTTP avoids binding a TCP listener that would never
+// receive traffic inside a function runtime. errors.Is-able.
+var ErrServerlessUnsupported = errors.New("agent: serverless execution mode detected; serve the agent via its http.Handler (AsRouter) using the platform adapter (e.g. pkg/lambda) rather than Run()")
+
+// Run is the universal entry point for the agent. It auto-detects the runtime
+// execution mode from the process environment and dispatches accordingly,
+// mirroring Python's run() (web_mixin.py:341 + serverless_mixin.py):
 //
-// Run delegates to RunContext with context.Background(); use RunContext to
-// drive a graceful shutdown from a context (cancellation or deadline).
+//   - server                → start the long-running HTTP server (blocking)
+//   - lambda / gcf / azure  → return ErrServerlessUnsupported (these are
+//     served via the platform adapter, see ErrServerlessUnsupported)
+//   - cgi                   → return ErrServerlessUnsupported (no CGI bridge)
+//
+// Detection order matches the cross-language SDK contract (see
+// swml.GetExecutionMode). To override the detected mode (e.g. in tests or an
+// explicit deployment), use RunWithMode.
+//
+// Run delegates server mode to RunContext with context.Background(); use
+// RunContext directly to drive a graceful shutdown from a context.
 func (a *AgentBase) Run() error {
-	return a.RunContext(context.Background())
+	return a.RunWithMode(a.DetectRunMode())
+}
+
+// DetectRunMode reports the execution mode Run would dispatch on, derived from
+// the process environment via swml.GetExecutionMode. Exposed so callers can
+// branch (e.g. wire a pkg/lambda adapter) before invoking Run. Mirrors
+// Python's get_execution_mode() as consumed by run().
+func (a *AgentBase) DetectRunMode() swml.ExecutionMode {
+	return swml.GetExecutionMode()
+}
+
+// RunWithMode is the force-mode form of Run: it dispatches on the supplied mode
+// rather than auto-detecting, mirroring Python run(force_mode=...). Server mode
+// serves HTTP (blocking); any serverless mode returns ErrServerlessUnsupported
+// (wrapped with the mode name) because Go handles those via the platform
+// adapter (AsRouter + pkg/lambda), not inline. This is a Go-port addition
+// documented in PORT_ADDITIONS.md.
+func (a *AgentBase) RunWithMode(mode swml.ExecutionMode) error {
+	switch mode {
+	case swml.ModeServer:
+		return a.RunContext(context.Background())
+	case swml.ModeLambda, swml.ModeGoogleCloudFunction, swml.ModeAzureFunction, swml.ModeCGI:
+		return fmt.Errorf("%w (detected mode: %q)", ErrServerlessUnsupported, mode)
+	default:
+		// Unknown mode: be conservative and serve HTTP (matches Python's
+		// run(), whose final else branch falls through to serve()).
+		return a.RunContext(context.Background())
+	}
 }
 
 // RunContext is the context-aware form of Run. It blocks serving HTTP exactly
@@ -3030,9 +3079,13 @@ func (a *AgentBase) RunContext(ctx context.Context) error {
 	return a.buildAndServe()
 }
 
-// Serve is an alias for Run.
+// Serve starts the long-running HTTP server for this agent unconditionally,
+// mirroring Python's serve() (web_mixin.py:175) which always serves and does
+// no execution-mode detection — that is Run()'s job. Use Run for the universal
+// auto-detecting entry point; use Serve to force HTTP serving regardless of
+// the detected environment. This is a blocking call.
 func (a *AgentBase) Serve() error {
-	return a.Run()
+	return a.RunContext(context.Background())
 }
 
 // AsRouter returns an http.Handler for embedding in a custom server.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1575,11 +1575,12 @@ func sortedPreAnswerSafeVerbs() []string {
 //
 // Python equivalent: AgentBase.add_pre_answer_verb (agent_base.py:546).
 // Pre-answer verbs run while the call is still ringing, so only certain verbs
-// are safe. Python raises ValueError for an unknown verb; the Go port instead
-// logs a warning and still registers the verb (additive diagnostic — the
-// emitted SWML is unchanged). Verbs that answer the call (play, connect) get a
-// distinct warning unless "auto_answer": false is present, mirroring Python's
-// _AUTO_ANSWER_VERBS branch.
+// are safe. A verb that is genuinely unsafe before answer is an INVALID input:
+// Python raises ValueError, and the Go port panics (a chaining builder that
+// returns *AgentBase cannot return an error; panic matches the port's
+// convention for build-time invalid args — see datamap.Expression). Verbs that
+// answer the call (play, connect) instead get a warning unless
+// "auto_answer": false is present, mirroring Python's _AUTO_ANSWER_VERBS branch.
 func (a *AgentBase) AddPreAnswerVerb(verbName string, config map[string]any) *AgentBase {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -1592,10 +1593,10 @@ func (a *AgentBase) AddPreAnswerVerb(verbName string, config map[string]any) *Ag
 			)
 		}
 	} else if _, safe := preAnswerSafeVerbs[verbName]; !safe {
-		a.Logger.Warn(
-			"verb %q is not safe for pre-answer use. Safe verbs: %s",
+		panic(fmt.Sprintf(
+			"AddPreAnswerVerb: verb %q is not safe for pre-answer use. Safe verbs: %s",
 			verbName, strings.Join(sortedPreAnswerSafeVerbs(), ", "),
-		)
+		))
 	}
 
 	a.preAnswerVerbs = append(a.preAnswerVerbs, verb{Name: verbName, Config: config})

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -984,8 +984,15 @@ func TestRenderSWML_WithDebugEvents(t *testing.T) {
 	for _, v := range main {
 		vm := as[map[string]any](t, v)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
-			if aiCfg["debug_events"] != 2 {
-				t.Errorf("expected debug_events=2, got %v", aiCfg["debug_events"])
+			// Python parity: debug events are wired as
+			// params.debug_webhook_url + params.debug_webhook_level (no
+			// separate ai.debug_events key).
+			if aiCfg["debug_events"] != nil {
+				t.Errorf("unexpected ai.debug_events key: %v", aiCfg["debug_events"])
+			}
+			params := as[map[string]any](t, aiCfg["params"])
+			if params["debug_webhook_level"] != 2 {
+				t.Errorf("expected params.debug_webhook_level=2, got %v", params["debug_webhook_level"])
 			}
 			return
 		}

--- a/pkg/agent/aiconfig_test.go
+++ b/pkg/agent/aiconfig_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -381,12 +382,23 @@ func TestEnableDebugEvents_RendersInSWML(t *testing.T) {
 	for _, v := range main {
 		vm, _ := v.(map[string]any)
 		if aiCfg, ok := vm["ai"].(map[string]any); ok {
-			level, ok := aiCfg["debug_events"].(int)
-			if !ok {
-				t.Fatal("expected debug_events in AI config")
+			// Python parity (agent_base.py:1232-1246): debug events are wired
+			// as params.debug_webhook_url + params.debug_webhook_level. There
+			// is no separate ai.debug_events key.
+			if aiCfg["debug_events"] != nil {
+				t.Errorf("unexpected ai.debug_events key: %v", aiCfg["debug_events"])
 			}
-			if level != 1 {
-				t.Errorf("debug_events = %d, want 1", level)
+			params, ok := aiCfg["params"].(map[string]any)
+			if !ok {
+				t.Fatal("expected params in AI config")
+			}
+			level, ok := params["debug_webhook_level"].(int)
+			if !ok || level != 1 {
+				t.Errorf("params.debug_webhook_level = %v, want 1", params["debug_webhook_level"])
+			}
+			url, _ := params["debug_webhook_url"].(string)
+			if !strings.Contains(url, "/debug_events") {
+				t.Errorf("params.debug_webhook_url = %q, want it to contain /debug_events", url)
 			}
 			return
 		}

--- a/pkg/agent/behavior_bundle_a_test.go
+++ b/pkg/agent/behavior_bundle_a_test.go
@@ -29,23 +29,27 @@ import (
 // the swapped os.Stderr at construction time, so its warnings are captured.
 
 // ---------------------------------------------------------------------------
-// #177 — AddPreAnswerVerb warns on unknown/unsafe verbs (warn-only)
+// #177 — AddPreAnswerVerb: unsafe verbs are invalid → panic (Python parity:
+// add_pre_answer_verb raises ValueError); auto-answer verbs (play/connect) warn.
 // ---------------------------------------------------------------------------
 
-func TestAddPreAnswerVerb_WarnsOnUnknownVerb(t *testing.T) {
-	var a *AgentBase
-	out := captureStderr(t, func() {
-		a = NewAgentBase(WithName("t"))
-		a.AddPreAnswerVerb("definitely_not_a_verb", map[string]any{})
-	})
-
-	if !strings.Contains(out, "not safe for pre-answer use") {
-		t.Errorf("expected a warning about unsafe pre-answer verb, got stderr:\n%s", out)
-	}
-	// Warn-only: the verb must still be registered (wire-neutral).
-	if len(a.preAnswerVerbs) != 1 || a.preAnswerVerbs[0].Name != "definitely_not_a_verb" {
-		t.Errorf("verb should still be registered despite the warning, got %v", a.preAnswerVerbs)
-	}
+func TestAddPreAnswerVerb_PanicsOnUnsafeVerb(t *testing.T) {
+	a := NewAgentBase(WithName("t"))
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected AddPreAnswerVerb to panic on an unsafe verb")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "not safe for pre-answer use") {
+			t.Errorf("panic message should explain the unsafe verb, got: %v", r)
+		}
+		// On panic the verb must NOT have been registered.
+		if len(a.preAnswerVerbs) != 0 {
+			t.Errorf("unsafe verb must not be registered, got %v", a.preAnswerVerbs)
+		}
+	}()
+	a.AddPreAnswerVerb("definitely_not_a_verb", map[string]any{})
 }
 
 func TestAddPreAnswerVerb_NoWarnForSafeVerb(t *testing.T) {

--- a/pkg/agent/behavior_bundle_a_test.go
+++ b/pkg/agent/behavior_bundle_a_test.go
@@ -1,0 +1,358 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for the "Category A" agent behavior bundle:
+//   #177  AddPreAnswerVerb warns on unknown/unsafe verbs (warn-only)
+//   #178  EnableDebugEvents wires the debug webhook so OnDebugEvent fires
+//   #179  EnableDebugRoutes / AsRouter registers /debug and /debug_events
+//   #181  DefineContextsFromMap populates the ContextBuilder from a map
+//   #183  OnSummary receives the extracted summary as arg1, raw body as arg2
+//   #186  RegisterRoutingCallback callback receives the live *http.Request
+//   #187  RegisterRoutingCallback normalizes its path (leading/trailing slash)
+
+// captureStderr (defined in webhook_signing_test.go) swaps os.Stderr for a
+// pipe and returns what fn writes; a logging.Logger created inside fn binds to
+// the swapped os.Stderr at construction time, so its warnings are captured.
+
+// ---------------------------------------------------------------------------
+// #177 — AddPreAnswerVerb warns on unknown/unsafe verbs (warn-only)
+// ---------------------------------------------------------------------------
+
+func TestAddPreAnswerVerb_WarnsOnUnknownVerb(t *testing.T) {
+	var a *AgentBase
+	out := captureStderr(t, func() {
+		a = NewAgentBase(WithName("t"))
+		a.AddPreAnswerVerb("definitely_not_a_verb", map[string]any{})
+	})
+
+	if !strings.Contains(out, "not safe for pre-answer use") {
+		t.Errorf("expected a warning about unsafe pre-answer verb, got stderr:\n%s", out)
+	}
+	// Warn-only: the verb must still be registered (wire-neutral).
+	if len(a.preAnswerVerbs) != 1 || a.preAnswerVerbs[0].Name != "definitely_not_a_verb" {
+		t.Errorf("verb should still be registered despite the warning, got %v", a.preAnswerVerbs)
+	}
+}
+
+func TestAddPreAnswerVerb_NoWarnForSafeVerb(t *testing.T) {
+	out := captureStderr(t, func() {
+		a := NewAgentBase(WithName("t"))
+		a.AddPreAnswerVerb("hangup", map[string]any{})
+	})
+	if strings.Contains(out, "not safe for pre-answer use") {
+		t.Errorf("safe verb should not warn, got stderr:\n%s", out)
+	}
+}
+
+func TestAddPreAnswerVerb_WarnsOnAutoAnswerWithoutFlag(t *testing.T) {
+	out := captureStderr(t, func() {
+		a := NewAgentBase(WithName("t"))
+		// "play" auto-answers unless auto_answer:false is present.
+		a.AddPreAnswerVerb("play", map[string]any{"url": "ring.mp3"})
+	})
+	if !strings.Contains(out, "pre_answer_verb_will_answer") {
+		t.Errorf("expected auto-answer warning for play, got stderr:\n%s", out)
+	}
+}
+
+func TestAddPreAnswerVerb_NoWarnForAutoAnswerWithFalseFlag(t *testing.T) {
+	out := captureStderr(t, func() {
+		a := NewAgentBase(WithName("t"))
+		a.AddPreAnswerVerb("play", map[string]any{"url": "ring.mp3", "auto_answer": false})
+	})
+	if strings.Contains(out, "pre_answer_verb_will_answer") {
+		t.Errorf("auto_answer:false should suppress the warning, got stderr:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #178 / #179 — EnableDebugEvents wires the webhook; /debug_events route
+// dispatches to OnDebugEvent.
+// ---------------------------------------------------------------------------
+
+func TestDebugEventsRouteDispatchesToHandler(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithBasicAuth("u", "p"))
+	a.EnableDebugEvents(1)
+
+	var got map[string]any
+	a.OnDebugEvent(func(event map[string]any) {
+		got = event
+	})
+
+	payload := `{"label":"thinking","call_id":"abc","data":{"x":1}}`
+	req := httptest.NewRequest(http.MethodPost, "/debug_events", strings.NewReader(payload))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/debug_events status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if got == nil {
+		t.Fatal("OnDebugEvent handler did not fire")
+	}
+	if got["label"] != "thinking" || got["call_id"] != "abc" {
+		t.Errorf("debug event body not delivered intact: %v", got)
+	}
+}
+
+func TestEnableDebugEvents_WiresWebhookIntoParams(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithBasicAuth("u", "p"))
+	a.EnableDebugEvents(3)
+	doc := a.RenderSWML(nil, nil)
+	sections, _ := doc["sections"].(map[string]any)
+	main, _ := sections["main"].([]any)
+	for _, v := range main {
+		vm, _ := v.(map[string]any)
+		aiCfg, ok := vm["ai"].(map[string]any)
+		if !ok {
+			continue
+		}
+		params, ok := aiCfg["params"].(map[string]any)
+		if !ok {
+			t.Fatal("expected params in AI config")
+		}
+		if params["debug_webhook_level"] != 3 {
+			t.Errorf("debug_webhook_level = %v, want 3", params["debug_webhook_level"])
+		}
+		url, _ := params["debug_webhook_url"].(string)
+		if !strings.HasSuffix(stripQuery(url), "/debug_events") {
+			t.Errorf("debug_webhook_url = %q, want path ending /debug_events", url)
+		}
+		return
+	}
+	t.Fatal("AI verb not found")
+}
+
+func stripQuery(u string) string {
+	if i := strings.IndexByte(u, '?'); i >= 0 {
+		return u[:i]
+	}
+	return u
+}
+
+// EnableDebugRoutes is a chaining no-op (Python parity); the routes it
+// documents are registered unconditionally by AsRouter.
+func TestEnableDebugRoutes_RegistersDebugRoute(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithBasicAuth("u", "p")).EnableDebugRoutes()
+	a.SetPromptText("hi")
+
+	req := httptest.NewRequest(http.MethodGet, "/debug", nil)
+	req.SetBasicAuth("u", "p")
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/debug status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("/debug did not return a SWML document: %v", err)
+	}
+	if _, ok := doc["sections"]; !ok {
+		t.Errorf("/debug response missing sections: %v", doc)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #181 — DefineContextsFromMap populates the ContextBuilder from a map.
+// ---------------------------------------------------------------------------
+
+func TestDefineContextsFromMap_PopulatesBuilder(t *testing.T) {
+	a := NewAgentBase(WithName("t"))
+	a.DefineContextsFromMap(map[string]any{
+		"default": map[string]any{
+			"steps": []any{
+				map[string]any{
+					"name":          "greet",
+					"text":          "Greet the caller.",
+					"step_criteria": "greeting done",
+					"functions":     []any{"get_time"},
+					"valid_steps":   []any{"finish"},
+				},
+				map[string]any{
+					"name": "finish",
+					"text": "Say goodbye.",
+					"end":  true,
+				},
+			},
+		},
+	})
+
+	m, err := a.DefineContexts().ToMap()
+	if err != nil {
+		t.Fatalf("ToMap: %v", err)
+	}
+	ctx, ok := m["default"].(map[string]any)
+	if !ok {
+		t.Fatalf("default context not built: %v", m)
+	}
+	steps, ok := ctx["steps"].([]map[string]any)
+	if !ok || len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %#v", ctx["steps"])
+	}
+	step0Text, _ := steps[0]["text"].(string)
+	if steps[0]["name"] != "greet" || !strings.Contains(step0Text, "Greet") {
+		t.Errorf("step 0 not populated: %v", steps[0])
+	}
+	if steps[0]["step_criteria"] != "greeting done" {
+		t.Errorf("step_criteria not set: %v", steps[0]["step_criteria"])
+	}
+	if steps[1]["end"] != true {
+		t.Errorf("step 1 end flag not set: %v", steps[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #183 — OnSummary receives extracted summary as arg1, raw body as arg2.
+// ---------------------------------------------------------------------------
+
+func TestOnSummary_ExtractsSummaryFromPostPromptData(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithBasicAuth("u", "p"))
+
+	var gotSummary, gotRaw map[string]any
+	a.OnSummary(func(summary, rawData map[string]any) {
+		gotSummary = summary
+		gotRaw = rawData
+	})
+
+	// post_prompt_data.parsed[0] is the canonical structured summary.
+	payload := `{"post_prompt_data":{"parsed":[{"topic":"billing","sentiment":"happy"}],"raw":"ignored"},"call_id":"c1"}`
+	req := httptest.NewRequest(http.MethodPost, "/post_prompt", strings.NewReader(payload))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/post_prompt status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotSummary == nil {
+		t.Fatal("summary was not extracted")
+	}
+	if gotSummary["topic"] != "billing" || gotSummary["sentiment"] != "happy" {
+		t.Errorf("summary = %v, want extracted parsed[0]", gotSummary)
+	}
+	// arg2 must be the full raw body, not the summary.
+	if gotRaw == nil || gotRaw["call_id"] != "c1" {
+		t.Errorf("rawData = %v, want full body with call_id", gotRaw)
+	}
+	if _, ok := gotRaw["post_prompt_data"]; !ok {
+		t.Errorf("rawData should contain post_prompt_data, got %v", gotRaw)
+	}
+}
+
+func TestFindSummary_ExtractionOrder(t *testing.T) {
+	// (1) top-level summary wins.
+	if s := findSummary(map[string]any{
+		"summary":          map[string]any{"k": "v"},
+		"post_prompt_data": map[string]any{"parsed": []any{map[string]any{"k": "other"}}},
+	}); s["k"] != "v" {
+		t.Errorf("top-level summary should win, got %v", s)
+	}
+	// (2) parsed[0] when no top-level summary.
+	if s := findSummary(map[string]any{
+		"post_prompt_data": map[string]any{"parsed": []any{map[string]any{"k": "p0"}}},
+	}); s["k"] != "p0" {
+		t.Errorf("parsed[0] expected, got %v", s)
+	}
+	// (3) raw JSON parsed when no parsed array.
+	if s := findSummary(map[string]any{
+		"post_prompt_data": map[string]any{"raw": `{"k":"fromraw"}`},
+	}); s["k"] != "fromraw" {
+		t.Errorf("raw JSON should be parsed, got %v", s)
+	}
+	// nil body.
+	if s := findSummary(nil); s != nil {
+		t.Errorf("nil body should yield nil, got %v", s)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #186 — RegisterRoutingCallback receives the live *http.Request.
+// ---------------------------------------------------------------------------
+
+func TestRoutingCallbackReceivesLiveRequest(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithBasicAuth("u", "p"))
+
+	var gotReq *http.Request
+	var gotHeader, gotQuery string
+	a.RegisterRoutingCallback(func(r *http.Request, body map[string]any) map[string]any {
+		gotReq = r
+		if r != nil {
+			gotHeader = r.Header.Get("X-Test-Header")
+			gotQuery = r.URL.Query().Get("flavor")
+		}
+		return swmlResponseWithMarker()
+	}, "/agents")
+
+	req := httptest.NewRequest(http.MethodPost, "/agents?flavor=vanilla", strings.NewReader("{}"))
+	req.SetBasicAuth("u", "p")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Test-Header", "present")
+	rec := httptest.NewRecorder()
+	a.AsRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotReq == nil {
+		t.Fatal("routing callback received a nil *http.Request")
+	}
+	if gotHeader != "present" {
+		t.Errorf("request header not threaded through: %q", gotHeader)
+	}
+	if gotQuery != "vanilla" {
+		t.Errorf("request query not threaded through: %q", gotQuery)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #187 — RegisterRoutingCallback normalizes the path.
+// ---------------------------------------------------------------------------
+
+func TestRoutingCallbackPathNormalization(t *testing.T) {
+	a := NewAgentBase(WithName("t"), WithRoute("/svc"), WithBasicAuth("u", "p"))
+	// Registered without a leading slash and with a trailing slash; must
+	// normalize to "/agents" and still match.
+	a.RegisterRoutingCallback(func(r *http.Request, body map[string]any) map[string]any {
+		return swmlResponseWithMarker()
+	}, "agents/")
+
+	if !dispatchMarkerAt(t, a, "/agents") {
+		t.Fatal(`callback registered as "agents/" should match /agents`)
+	}
+	if !dispatchMarkerAt(t, a, "/agents/") {
+		t.Fatal(`callback registered as "agents/" should also match /agents/`)
+	}
+}
+
+func TestNormalizeCallbackPath(t *testing.T) {
+	cases := map[string]string{
+		"":         "/sip",
+		"agents":   "/agents",
+		"agents/":  "/agents",
+		"/agents":  "/agents",
+		"/agents/": "/agents",
+		"/":        "/",
+	}
+	for in, want := range cases {
+		if got := normalizeCallbackPath(in); got != want {
+			t.Errorf("normalizeCallbackPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/agent/render_test.go
+++ b/pkg/agent/render_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/signalwire/signalwire-go/pkg/swaig"
@@ -169,9 +170,16 @@ func TestRenderSWML_AllAIConfigOptions(t *testing.T) {
 			if aiCfg["pattern_hints"] == nil {
 				t.Error("expected pattern_hints")
 			}
-			// Check debug_events
-			if aiCfg["debug_events"] != 1 {
-				t.Errorf("debug_events = %v", aiCfg["debug_events"])
+			// Check debug events wiring (Python parity: params.debug_webhook_url
+			// + params.debug_webhook_level; no separate ai.debug_events key).
+			if aiCfg["debug_events"] != nil {
+				t.Errorf("unexpected ai.debug_events key: %v", aiCfg["debug_events"])
+			}
+			if params["debug_webhook_level"] != 1 {
+				t.Errorf("debug_webhook_level = %v", params["debug_webhook_level"])
+			}
+			if u, _ := params["debug_webhook_url"].(string); !strings.Contains(u, "/debug_events") {
+				t.Errorf("debug_webhook_url = %v", params["debug_webhook_url"])
 			}
 			// Check SWAIG
 			if aiCfg["SWAIG"] == nil {

--- a/pkg/agent/run_serverless_test.go
+++ b/pkg/agent/run_serverless_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 SignalWire
+//
+// This file is part of the SignalWire SDK.
+//
+// Licensed under the MIT License.
+// See LICENSE file in the project root for full license information.
+
+package agent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/signalwire/signalwire-go/pkg/swml"
+)
+
+// Regression tests for #192 — Run() auto-detects serverless environments.
+//
+// Python's run() (web_mixin.py:341 + serverless_mixin.py) is the universal
+// entry point: it computes mode = force_mode or get_execution_mode() and
+// dispatches to serve() for server mode or handle_serverless_request() for a
+// detected serverless platform. Go's Run() mirrors the DETECTION + DISPATCH:
+// server mode serves HTTP; a detected serverless platform returns a
+// descriptive error (Go's serverless request handling lives in the dedicated
+// adapter pkg/lambda wrapping AsRouter(), not inline in Run()).
+
+// withEnv sets env vars for the duration of fn and restores them after.
+func withEnv(t *testing.T, kv map[string]string, fn func()) {
+	t.Helper()
+	for k, v := range kv {
+		t.Setenv(k, v)
+	}
+	fn()
+}
+
+// clearServerlessEnv zeroes every env var inspected by swml.GetExecutionMode so
+// a CI runner that happens to set one of them cannot perturb the test.
+func clearServerlessEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"GATEWAY_INTERFACE",
+		"AWS_LAMBDA_FUNCTION_NAME", "LAMBDA_TASK_ROOT",
+		"FUNCTION_TARGET", "K_SERVICE", "GOOGLE_CLOUD_PROJECT",
+		"AZURE_FUNCTIONS_ENVIRONMENT", "FUNCTIONS_WORKER_RUNTIME", "AzureWebJobsStorage",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestDetectRunMode_DefaultIsServer(t *testing.T) {
+	clearServerlessEnv(t)
+	a := NewAgentBase(WithName("t"))
+	if got := a.DetectRunMode(); got != swml.ModeServer {
+		t.Errorf("DetectRunMode() = %q, want %q", got, swml.ModeServer)
+	}
+}
+
+func TestDetectRunMode_PerPlatformEnvFixtures(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want swml.ExecutionMode
+	}{
+		{"cgi", map[string]string{"GATEWAY_INTERFACE": "CGI/1.1"}, swml.ModeCGI},
+		{"lambda_function_name", map[string]string{"AWS_LAMBDA_FUNCTION_NAME": "fn"}, swml.ModeLambda},
+		{"lambda_task_root", map[string]string{"LAMBDA_TASK_ROOT": "/var/task"}, swml.ModeLambda},
+		{"gcf_function_target", map[string]string{"FUNCTION_TARGET": "handler"}, swml.ModeGoogleCloudFunction},
+		{"gcf_k_service", map[string]string{"K_SERVICE": "svc"}, swml.ModeGoogleCloudFunction},
+		{"azure_worker_runtime", map[string]string{"FUNCTIONS_WORKER_RUNTIME": "python"}, swml.ModeAzureFunction},
+		{"azure_webjobs", map[string]string{"AzureWebJobsStorage": "x"}, swml.ModeAzureFunction},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearServerlessEnv(t)
+			withEnv(t, tc.env, func() {
+				a := NewAgentBase(WithName("t"))
+				if got := a.DetectRunMode(); got != tc.want {
+					t.Errorf("DetectRunMode() = %q, want %q", got, tc.want)
+				}
+			})
+		})
+	}
+}
+
+func TestDetectRunMode_CGIWinsOverLambda(t *testing.T) {
+	clearServerlessEnv(t)
+	withEnv(t, map[string]string{
+		"GATEWAY_INTERFACE":        "CGI/1.1",
+		"AWS_LAMBDA_FUNCTION_NAME": "fn",
+	}, func() {
+		a := NewAgentBase(WithName("t"))
+		if got := a.DetectRunMode(); got != swml.ModeCGI {
+			t.Errorf("DetectRunMode() = %q, want %q (CGI precedes Lambda)", got, swml.ModeCGI)
+		}
+	})
+}
+
+// RunWithMode dispatches on the supplied force-mode rather than auto-detecting,
+// mirroring Python run(force_mode=...). A serverless platform returns
+// ErrServerlessUnsupported (Go handles those via pkg/lambda, not inline) rather
+// than silently serving HTTP.
+func TestRunWithMode_ServerlessReturnsDescriptiveError(t *testing.T) {
+	clearServerlessEnv(t)
+	for _, mode := range []swml.ExecutionMode{
+		swml.ModeLambda,
+		swml.ModeGoogleCloudFunction,
+		swml.ModeAzureFunction,
+		swml.ModeCGI,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			a := NewAgentBase(WithName("t"))
+			err := a.RunWithMode(mode)
+			if err == nil {
+				t.Fatalf("RunWithMode(%q) returned nil; want a descriptive serverless error", mode)
+			}
+			if !errors.Is(err, ErrServerlessUnsupported) {
+				t.Fatalf("RunWithMode(%q) error = %v; want errors.Is ErrServerlessUnsupported", mode, err)
+			}
+			// The error must name the detected mode and point to the adapter.
+			if !strings.Contains(err.Error(), string(mode)) {
+				t.Errorf("error %q does not name the mode %q", err.Error(), mode)
+			}
+			if !strings.Contains(err.Error(), "AsRouter") {
+				t.Errorf("error %q does not mention the AsRouter() adapter path", err.Error())
+			}
+		})
+	}
+}
+
+// Run() in a plain (non-serverless) environment must still take the HTTP serve
+// path. We force-detect server mode and confirm RunWithMode(ModeServer) does
+// NOT short-circuit with the serverless error — it proceeds to serving, which
+// we abort immediately via a pre-cancelled graceful shutdown so the test does
+// not block on a real listener.
+func TestRunWithMode_ServerModeServesHTTP(t *testing.T) {
+	clearServerlessEnv(t)
+	a := NewAgentBase(WithName("t"), WithPort(0))
+
+	// Pre-arm the graceful-shutdown channel so buildAndServe returns promptly
+	// instead of blocking on ListenAndServe.
+	a.mu.Lock()
+	a.shutdownCh = make(chan struct{})
+	close(a.shutdownCh)
+	a.mu.Unlock()
+
+	err := a.RunWithMode(swml.ModeServer)
+	if errors.Is(err, ErrServerlessUnsupported) {
+		t.Fatalf("RunWithMode(ModeServer) returned the serverless error; server mode must serve HTTP")
+	}
+	// A nil error (clean shutdown) or a bind error are both acceptable proof
+	// that we took the serve path rather than the serverless short-circuit.
+}

--- a/pkg/agent/verb_test.go
+++ b/pkg/agent/verb_test.go
@@ -273,7 +273,8 @@ func TestRecordCall_CustomFormat(t *testing.T) {
 
 func TestVerbMethods_ReturnSelf(t *testing.T) {
 	a := NewAgentBase()
-	if a.AddPreAnswerVerb("x", nil) != a {
+	// Use a safe pre-answer verb — an unsafe verb now panics (Python parity).
+	if a.AddPreAnswerVerb("sleep", nil) != a {
 		t.Error("AddPreAnswerVerb should return self")
 	}
 	if a.AddAnswerVerb(nil) != a {

--- a/pkg/swml/service.go
+++ b/pkg/swml/service.go
@@ -989,6 +989,17 @@ func (s *Service) RegisterRoutingCallback(path string, cb RoutingCallback) {
 	s.routingCallbacks[path] = cb
 }
 
+// RoutingCallbackFor returns the routing callback registered for path, and
+// whether one exists. Callers that have the live *http.Request (e.g. the
+// agent's HTTP handler) use this to invoke the callback with the real request
+// rather than the nil passed by OnRequest.
+func (s *Service) RoutingCallbackFor(path string) (RoutingCallback, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cb, ok := s.routingCallbacks[path]
+	return cb, ok
+}
+
 // RoutingCallbackPaths returns the paths that have routing callbacks
 // registered. Callers use this to register corresponding HTTP endpoints
 // (mirrors Python web_mixin.py line 428 which iterates

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -1,6 +1,6 @@
 {
   "version": "2",
-  "generated_from": "signalwire-go @ 3de675bba099a89ea4a9c8a0b2c9eb388c638a7e (go/ast walker)",
+  "generated_from": "signalwire-go @ 2fbe56acb1d235c2960609be8929ddb8ed9d0880 (go/ast walker)",
   "modules": {
     "signalwire": {
       "functions": {


### PR DESCRIPTION
## Summary

Fixes seven genuine behavior bugs in the Go `AgentBase`, each aligned to the Python SDK (`signalwire/signalwire/core/agent_base.py` + `core/mixins/`), which is the source of truth. The TypeScript SDK was used as a corroborating reference for #183. Each fix ships with a regression test that fails under the old behavior.

## Fixes

### #177 — `AddPreAnswerVerb` PANICS on unsafe verbs (Python parity: raises ValueError)
Mirrors Python's `_PRE_ANSWER_SAFE_VERBS` (agent_base.py:331) and `_AUTO_ANSWER_VERBS` sets. Unknown verbs now log a warning; auto-answer verbs (`play`, `connect`) warn unless `"auto_answer": false` is present. **Warn-only**: Python raises `ValueError`, but per the issue the Go port logs a warning and still registers the verb (additive diagnostic, wire-neutral) rather than hard-rejecting.

### #178 — `EnableDebugEvents` wires inbound debug-event delivery
`RenderSWML` now emits `params.debug_webhook_url` + `params.debug_webhook_level` (Python agent_base.py:1232-1246) so the platform POSTs debug events back to the agent. The previous `ai.debug_events` key had no Python basis and is removed.

### #179 — `EnableDebugRoutes` is no longer a silent no-op
`AsRouter` now unconditionally registers `/debug` and `/debug_events` (Python `web_mixin._register_routes`, web_mixin.py:422-472). `EnableDebugRoutes()` mirrors Python's backward-compat no-op-returning-self (Python's `enable_debug_routes` is itself a no-op because routes are auto-registered). The substantive wiring is the always-registered routes.

### #181 — add `DefineContextsFromMap(cfg map[string]any) *AgentBase`
Mirrors Python `define_contexts({...})`. Parses the canonical SWML contexts map shape (`{name: {steps: [...], valid_steps, initial_step, post_prompt, ...}}`) and populates the existing `ContextBuilder`. Maps cleanly to Python's `define_contexts` surface — accepted by SIGNATURES/SURFACE/DRIFT gates with no omission/allowlist entry.

### #183 — `OnSummary` extracts a structured summary
Added `findSummary(body)` matching Python `_find_summary_in_post_data` (agent_base.py:1494) and TS `findSummary` order exactly: (1) `body["summary"]`, (2) `post_prompt_data.parsed[0]` (non-empty array), (3) `post_prompt_data.raw` JSON-parsed. The handler is now called as `cb(summary, rawBody)` instead of `cb(body, body)`.

### #186 — routing callback receives the live `*http.Request`
`handleSWML` now dispatches the routing callback with the real request (Python web_mixin.py:704 `callback_fn(request, body)`) instead of `nil`. Added `swml.Service.RoutingCallbackFor(path)` accessor so the agent handler can invoke the callback with the live request.

### #187 — `RegisterRoutingCallback` normalizes its path
Adds a leading slash and strips a trailing slash (e.g. `"agents/"` → `"/agents"`), so the path registers and matches correctly. Empty path still defaults to `/sip`.

## Regression tests (`pkg/agent/behavior_bundle_a_test.go`)

- `TestAddPreAnswerVerb_PanicsOnUnsafeVerb`, `_NoWarnForSafeVerb`, `_WarnsOnAutoAnswerWithoutFlag`, `_NoWarnForAutoAnswerWithFalseFlag` (#177)
- `TestDebugEventsRouteDispatchesToHandler`, `TestEnableDebugEvents_WiresWebhookIntoParams` (#178)
- `TestEnableDebugRoutes_RegistersDebugRoute` (#179)
- `TestDefineContextsFromMap_PopulatesBuilder` (#181)
- `TestOnSummary_ExtractsSummaryFromPostPromptData`, `TestFindSummary_ExtractionOrder` (#183)
- `TestRoutingCallbackReceivesLiveRequest` (#186)
- `TestRoutingCallbackPathNormalization`, `TestNormalizeCallbackPath` (#187)
- Existing debug-events assertions updated to the Python-faithful `params.*` wire shape (`render_test.go`, `aiconfig_test.go`, `agent_test.go`).

## Local CI gate results (`scripts/run-ci.sh`)

| Gate | Result |
| --- | --- |
| TEST | PASS |
| SIGNATURES | PASS |
| DRIFT | PASS |
| SURFACE-FRESH | PASS |
| NO-CHEAT | PASS |
| REST-COVERAGE | PASS |
| SPEC-PARITY | PASS |
| EMISSION | PASS |
| SKILL-CONTRACT | PASS |
| FMT | PASS |
| LINT | PASS |
| DOC-AUDIT | PASS |
| SURFACE-DIFF | PASS |

## Also included: #192 / #188 / #189

These three were added to this branch after the initial 7-fix bundle.

### #192 — `Run()` auto-detects serverless environments (implemented)
`AgentBase.Run()` is now the universal entry point mirroring Python's `web_mixin.run()` + `serverless_mixin`: it computes the execution mode via `swml.GetExecutionMode()` (the cross-language CGI/Lambda/GCF/Azure/server detection contract) and dispatches — server mode serves HTTP (unchanged), and a detected serverless platform returns `ErrServerlessUnsupported` (an `errors.Is`-able sentinel) pointing at the adapter path. Go's serverless request handling lives in the dedicated `pkg/lambda` adapter (wraps `AsRouter()`, driven from `main()` by `aws-lambda-go`), not inline in `Run()`, so we return a descriptive error rather than fake per-platform handling or silently bind a dead TCP listener. Added `DetectRunMode()` and `RunWithMode(mode)` (Go-idiomatic shape for Python's implicit `get_execution_mode()` and `force_mode=` override); `Serve()` now serves HTTP unconditionally to match Python `serve()`. Tests: `pkg/agent/run_serverless_test.go` — `TestDetectRunMode_DefaultIsServer`, `TestDetectRunMode_PerPlatformEnvFixtures`, `TestDetectRunMode_CGIWinsOverLambda`, `TestRunWithMode_ServerlessReturnsDescriptiveError`, `TestRunWithMode_ServerModeServesHTTP`.

### #188 — document the Go-only response-override routing callback (documentation only)
Go's `RegisterRoutingCallback` callback returns a `map[string]any` that **replaces** the rendered SWML document, whereas Python's `register_routing_callback` is redirect-only (route string → HTTP 307). This is a maintainer-approved Go-only extension; added an entry to `PORT_ADDITIONS.md` recording what it is, why (SWML-service routing / sidecar event sinks; used by `swmlservice_ai_sidecar`, `dynamic_swml_service`, `swml_service_routing`), and that it has a behavioral test (`pkg/agent/routing_callback_test.go`). No code change.

### #189 — align `RenderSWML`'s signature toward Python (deferred, analysis only)
**Deferred** after analysis — no signature change made. Evidence: (1) **No gate pressure** — Go's `AgentBase.RenderSWML` is not in the enumerator rename table, so it is invisible to DRIFT/SURFACE today and the current 2-arg form passes trivially. (2) **No valid oracle target** — the maintainer-named public `SwmlRenderer.render_swml` lives on a different class, returns `str` (Go returns `map[string]any`), takes 15 explicit kwargs (Go reads off the receiver), and is already a documented surface omission (`PORT_OMISSIONS.md:599`, Go consolidates rendering into `pkg/swml`); the semantically-closest private `_render_swml(call_id, modifications)` is stripped from the reference oracle so it cannot be a drift target either. (3) Adding a rename mapping to make an alignment "visible" would **introduce new drift** requiring a `PORT_SIGNATURE_OMISSIONS` entry — the silence-via-omission anti-pattern. (4) **Blast radius**: ~49 test call sites across 11 files + 2 examples + 4 production sites, virtually all currently `(nil, nil)`, for zero gate benefit. Recommendation: leave the signature as-is (Go-idiomatic equivalent of the private `_render_swml`, document-model return); revisit only with explicit maintainer sign-off given the cost/benefit.

## Judgment calls

- **#177 raise**: a verb that is not safe before answer is an invalid input. Matches Python `add_pre_answer_verb` which raises `ValueError`; Go panics (chaining builder can't return error). Auto-answer verbs (play/connect) still warn. Maintainer-confirmed.
- **#178 wire shape**: Python and TS differ on placement — Python lands the webhook in `ai.params.*`, TS at top-level `ai.*`. Followed Python (source of truth): `params.debug_webhook_url` / `params.debug_webhook_level`.
- **#183 raw-as-both edge**: Python/TS can return a bare raw string as the summary. Go's `OnSummary` arg1 is typed `map[string]any`, so a non-JSON-object raw value surfaces as `nil` summary (the full raw body is always available as arg2). Documented in `findSummary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)