### PR TITLE
docs(readme): audit + fix — Go version, REST example type, verified counts/sections/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ func main() {
 		"url":  "https://example.com/call-handler",
 	})
 
-	results, _ := client.PhoneNumbers.Search(map[string]string{"area_code": "512"})
+	results, _ := client.PhoneNumbers.Search(map[string]any{"area_code": "512"})
 	fmt.Println(results)
 }
 ```
@@ -220,7 +220,7 @@ See the **[REST documentation](rest/README.md)** for the full guide, API referen
 go get github.com/signalwire/signalwire-go
 ```
 
-Requires Go 1.22 or later.
+Requires Go 1.25 or later.
 
 ## Documentation
 

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -807,88 +807,64 @@ agent.add_skill("datasphere", {
 ```
 
 #### Native Vector Search Skill (`native_vector_search`)
-Provides local document search capabilities using vector similarity and keyword search. This skill works entirely offline with local `.swsearch` index files or can connect to remote search servers.
+Provides knowledge-base search by querying a **remote search server** over HTTP. The Go skill is **remote-only**: it requires a `remote_url` and does not build or read local index files. (This differs from the Python SDK, which also supports local `.swsearch` index files.)
+
+The skill connects to a search server that exposes `/health` and `/search` HTTP endpoints. On setup it validates `remote_url` (SSRF protection — http/https only, no private/loopback hosts unless `SWML_ALLOW_PRIVATE_URLS` is set) and checks the server's `/health` endpoint. Basic-auth credentials may be embedded in the URL (`http://user:pass@host:8001`).
 
 **Requirements:**
-- Packages: `sentence-transformers`, `scikit-learn`, `numpy` (install with `pip install signalwire-agents[search]`)
+- A reachable remote search server (no local packages or index files required).
 
 **Parameters:**
-- `tool_name` (default: "search_knowledge"): Custom name for the search tool
-- `description` (default: "Search the local knowledge base for information"): Tool description
-- `index_file` (optional): Path to local `.swsearch` index file
-- `remote_url` (optional): URL of remote search server (e.g., "http://localhost:8001")
-- `index_name` (default: "default"): Index name on remote server (for remote mode)
-- `build_index` (default: False): Auto-build index if missing
-- `source_dir` (optional): Source directory for auto-building index
-- `file_types` (default: ["md", "txt"]): File types to include when building index
-- `count` (default: 3): Number of search results to return
-- `distance_threshold` (default: 0.0): Minimum similarity score for results
+- `remote_url` (**required**): URL of the remote search server (e.g., `http://localhost:8001`, or `http://user:pass@host:8001` for basic auth)
+- `index_name` (default: `"default"`): Name of the index to query on the remote server
+- `tool_name` (default: `"search_knowledge"`): Custom name for the search tool
+- `description` (default: `"Search the knowledge base for information"`): Tool description shown to the AI
+- `count` (default: 5): Number of search results to return
+- `similarity_threshold` (default: 0.0): Minimum similarity score for results (0.0 = no limit, 1.0 = exact match)
 - `tags` (optional): List of tags to filter search results
-- `response_prefix` (optional): Text to prepend to all search responses
-- `response_postfix` (optional): Text to append to all search responses
-- `no_results_message` (default: "No information found for '{query}'"): Custom message when no results found
+- `response_prefix` (optional): Text to prepend to search responses
+- `response_postfix` (optional): Text to append to search responses
+- `max_content_length` (default: 32768): Maximum total response size in characters (distributed across results)
+- `no_results_message` (default: `"No information found for '{query}'"`): Message when no results are found; `{query}` is substituted
+- `hints` (optional): Additional speech-recognition hints for this skill
 
 **Multiple Instance Support:**
-The native vector search skill supports multiple instances with different indexes and tool names:
+The native vector search skill supports multiple instances with different remote indexes and tool names:
 
 **Example:**
 ```python
-# Local mode with auto-build
+# Basic remote search
 agent.add_skill("native_vector_search", {
-    "tool_name": "search_docs",
-    "description": "Search SDK concepts guide",
-    "build_index": True,
-    "source_dir": "./docs",
-    "index_file": "concepts.swsearch",
-    "count": 5
-})
-# Creates tool: search_docs
-
-# Remote mode connecting to search server
-agent.add_skill("native_vector_search", {
-    "tool_name": "search_knowledge",
-    "description": "Search the knowledge base",
     "remote_url": "http://localhost:8001",
     "index_name": "concepts",
+    "tool_name": "search_knowledge",
+    "description": "Search the knowledge base",
     "count": 3
 })
 # Creates tool: search_knowledge
 
-# Multiple local indexes
+# Second instance against a different index/server
 agent.add_skill("native_vector_search", {
+    "remote_url": "http://search.internal:8001",
+    "index_name": "examples",
     "tool_name": "search_examples",
     "description": "Search code examples",
-    "index_file": "examples.swsearch",
     "response_prefix": "From the examples:"
 })
 # Creates tool: search_examples
 
-# Voice-optimized responses using concepts guide
+# Voice-optimized responses
 agent.add_skill("native_vector_search", {
+    "remote_url": "http://localhost:8001",
+    "index_name": "concepts",
     "tool_name": "search_docs",
-    "index_file": "concepts.swsearch",
     "response_prefix": "Based on the comprehensive SDK guide:",
     "response_postfix": "Would you like more specific information?",
     "no_results_message": "I couldn't find information about '{query}' in the concepts guide."
 })
 ```
 
-**Building Search Indexes:**
-Before using local mode, you need to build search indexes:
-
-```bash
-# Build index from documentation
-python -m signalwire_agents.cli.build_search docs --output docs.swsearch
-
-# Build with custom settings
-python -m signalwire_agents.cli.build_search ./knowledge \
-    --output knowledge.swsearch \
-    --file-types md,txt,pdf \
-    --chunk-size 500 \
-    --verbose
-```
-
-For complete documentation on the search system, see [Search Overview](search_overview.md).
+The remote search server is a separate component that hosts the indexes; the Go SDK does not include a CLI for building indexes.
 
 ### Skill Management
 
@@ -1098,7 +1074,7 @@ class DynamicSkillAgent(AgentBase):
 
 4. **Test skills in isolation**: Create simple test scripts to verify skill functionality
 
-For more detailed information about the skills system architecture and advanced customization, see the [Skills System README](SKILLS_SYSTEM_README.md).
+For more detailed information about the skills system architecture and advanced customization, see the [Skills System Guide](skills_system.md).
 
 ## Multilingual Support
 
@@ -3041,18 +3017,4 @@ For working examples of dynamic agent configuration, see these files in the `exa
 
 These examples demonstrate the progression from static to dynamic configuration and show real-world use cases like multi-tenant applications, A/B testing, and personalization.
 
-For more examples, see the `examples` directory in the SignalWire AI Agent SDK repository. 
-
-# Build index from the comprehensive concepts guide
-sw-search docs/agent_guide.md --output concepts.swsearch
-
-# Build from multiple sources
-sw-search docs/agent_guide.md examples README.md --output comprehensive.swsearch
-
-# Traditional directory approach with custom settings
-sw-search ./knowledge \
-    --output knowledge.swsearch \
-    --file-types md,txt,pdf \
-    --chunking-strategy sentence \
-    --max-sentences-per-chunk 8 \
-    --verbose
+For more examples, see the `examples` directory in the SignalWire AI Agent SDK repository.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -679,7 +679,7 @@ Add a modular skill to the agent.
 - `math`: Mathematical calculations
 - `web_search`: Google Custom Search integration
 - `datasphere`: SignalWire DataSphere search
-- `native_vector_search`: Local document search
+- `native_vector_search`: Remote document search via a search server
 
 **Usage:**
 ```python
@@ -2983,27 +2983,41 @@ agent.add_skill("datasphere", {
 ```
 
 #### `native_vector_search` Skill
-Local document search with vector similarity and keyword search.
+Remote document search against a SignalWire search server. This skill is
+**remote-only** in the Go SDK — it queries a running search server over HTTP and
+has no local index file.
 
 **Parameters:**
-- `index_path` (str): Path to search index file (required)
-- `tool_name` (Optional[str]): Custom tool name (default: "search_documents")
-- `max_results` (Optional[int]): Maximum results to return (default: 5)
-- `similarity_threshold` (Optional[float]): Minimum similarity score 0.0-1.0 (default: 0.0). Higher values are stricter, lower values are more permissive. Typical range: 0.2-0.4 for all-MiniLM-L6-v2, 0.3-0.5 for all-mpnet-base-v2
+- `remote_url` (string, **required**): URL of the remote search server (e.g.
+  `http://localhost:8001` or `http://user:pass@host:8001`). Basic-auth credentials
+  may be embedded in the URL.
+- `index_name` (string): Name of the index on the remote server (default: `"default"`)
+- `tool_name` (string): Custom tool name (default: `"search_knowledge"`)
+- `count` (int): Number of results to return (default: 5)
+- `similarity_threshold` (float): Minimum similarity score 0.0-1.0 (default: 0.0).
+  Higher values are stricter; lower values are more permissive.
+- `tags` ([]string): Tags to filter search results
+- `response_prefix` (string): Text prepended to results (default: "")
+- `response_postfix` (string): Text appended to results (default: "")
+- `max_content_length` (int): Maximum total response size in characters (default: 32768)
+- `no_results_message` (string): Message when no results found; use `{query}` as a placeholder (default: `"No information found for '{query}'"`)
+- `hints` ([]string): Speech-recognition hints for this skill
+- `description` (string): Tool description shown to the AI (default: `"Search the knowledge base for information"`)
 
-**Usage:**
-```python
-# Basic local search
-agent.add_skill("native_vector_search", {
-    "index_path": "./knowledge.swsearch"
+**Usage (Go):**
+```go
+// Basic remote search
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url": "http://localhost:8001",
 })
 
-# With custom settings
-agent.add_skill("native_vector_search", {
-    "index_path": "./docs.swsearch",
-    "tool_name": "search_docs",
-    "max_results": 10,
-    "similarity_threshold": 0.25
+// With custom settings
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url":           "http://user:pass@search.example.com:8001",
+    "index_name":           "docs",
+    "tool_name":            "search_docs",
+    "count":                10,
+    "similarity_threshold": 0.25,
 })
 ```
 

--- a/docs/cli_guide.md
+++ b/docs/cli_guide.md
@@ -4,42 +4,53 @@ This guide covers the command-line tools included with the SignalWire Agents SDK
 
 ## Overview
 
-The `swaig-test` CLI tool provides a complete testing environment for:
-- **SWAIG Functions**: SWAIG (SignalWire AI Gateway) is the platform's AI tool-calling system. Test both webhook and DataMap functions with automatic type detection
-- **SWML Generation**: SWML (SignalWire Markup Language) is the JSON document format that defines agent behavior during calls. Test static and dynamic SWML documents with realistic fake data
-- **Mock Requests**: Complete FastAPI Request simulation for dynamic agent testing
+The Go `swaig-test` CLI tool tests an agent by exercising its **HTTP endpoints**.
+Unlike the Python SDK's `swaig-test` (which dynamically loads agent source files), the
+Go tool operates against a **running agent server** via `--url`, or introspects a
+compiled example binary via `--example`. It can:
+- **Dump SWML**: Fetch the agent's rendered SWML document (`--dump-swml`).
+- **List tools**: List the agent's registered SWAIG functions (`--list-tools`).
+- **Execute a function**: Invoke a SWAIG function by name with `--param key=value`
+  arguments (`--exec`). SWAIG (SignalWire AI Gateway) is the platform's AI
+  tool-calling system; SWML (SignalWire Markup Language) is the JSON document format
+  that defines agent behavior during calls.
 
-The tool automatically detects function types, provides appropriate execution environments, and simulates the SignalWire platform locally while making real HTTP requests for DataMap functions.
+> **Important:** This document was largely ported from the Python SDK guide. The
+> Python tool's file-loading model, fake-data/override flags, mock-request flags,
+> agent auto-selection, and multi-platform serverless simulation do **not** exist in
+> the Go tool. See [Command Line Options](#command-line-options) for the authoritative
+> Go flag set. Sections below that load `.py` files or use Python-only flags are kept
+> as conceptual illustrations of SWAIG/DataMap/SWML behavior, not literal Go commands.
 
 ## Key Features
 
-- **`--exec` Syntax**: Modern CLI-style function arguments
-- **Agent Auto-Selection**: Automatically chooses agent when only one exists in file
-- **Agent Discovery**: Lists available agents when no arguments provided
-- **Auto-Detection**: Automatically detects webhook vs DataMap functions - no manual flags needed
-- **Complete DataMap Simulation**: Full processing including URL templates, responses, and fallbacks
-- **SWML Testing**: Generate and test SWML documents with realistic fake call data
-- **Dynamic Agent Support**: Test request-dependent SWML generation with mock request objects
-- **Real HTTP Execution**: DataMap functions make actual HTTP requests to real APIs
-- **Comprehensive Simulation**: Generate realistic post_data with all SignalWire metadata
-- **Advanced Template Engine**: Supports all DataMap variable syntax (`${args.param}`, `${response.field}`, `${array[0].property}`)
-- **Flexible CLI Syntax**: Support both `--exec` and JSON argument styles
-- **Override System**: Precise control over test data with dot notation paths
-- **Mock Request Objects**: Complete FastAPI Request simulation for dynamic agents
-- **Verbose Debugging**: Detailed execution tracing for both function types
-- **Flexible Data Modes**: Choose between minimal, comprehensive, or custom post_data
-- **Serverless Environment Simulation**: Complete platform simulation for Lambda, CGI, Cloud Functions, and Azure Functions with environment variable management
-- **Automatic Log Suppression**: Logs are suppressed by default unless `--verbose` flag is used
-- **Enhanced Parameter Display**: Shows all JSON Schema constraints including enum values, min/max, patterns, and more
+- **HTTP-based testing**: Tests a running agent server over HTTP via `--url`.
+- **Binary introspection**: Lists tools from a compiled example via `--example` (no HTTP).
+- **SWML dumping**: Fetch and pretty-print (or `--raw` compact) the rendered SWML document.
+- **Function execution**: Invoke SWAIG functions with repeatable `--param key=value` arguments.
+- **Lambda serverless simulation**: `--simulate-serverless lambda` applies Lambda
+  mode-detection env vars around the invocation. (Only `lambda` is implemented in Go;
+  other platforms return a clear "not implemented" error.)
+- **Verbose debugging**: `--verbose` shows request/response details.
 
 ## Installation
 
-Install as part of the signalwire_agents package:
+`swaig-test` is a Go command in this repository (`cmd/swaig-test`). Build or run it
+with the Go toolchain (Go 1.25 or later):
 
 ```bash
-pip install -e .
+# Run directly from the repo
+go run ./cmd/swaig-test --help
+
+# Or install the binary onto your PATH
+go install github.com/signalwire/signalwire-go/cmd/swaig-test@latest
 swaig-test --help
 ```
+
+> **Note:** Unlike the Python SDK's `swaig-test` (which dynamically loads agent
+> source files), the Go `swaig-test` operates against a **running agent server**
+> over HTTP via `--url`, or introspects a compiled example binary via `--example`.
+> The flag set is correspondingly smaller — see [Command Line Options](#command-line-options).
 
 ## Quick Start
 
@@ -180,12 +191,23 @@ swaig-test examples/my_agent.py --simulate-serverless lambda --env DEBUG=1 --env
 
 ### Supported Serverless Platforms
 
-| Platform | Simulation Flag | Key Features |
-|----------|-----------------|--------------|
-| **AWS Lambda** | `--simulate-serverless lambda` | Function URLs, API Gateway, environment detection |
-| **CGI** | `--simulate-serverless cgi` | HTTP host, script paths, HTTPS simulation |
-| **Google Cloud Functions** | `--simulate-serverless cloud_function` | Function URLs, project configuration |
-| **Azure Functions** | `--simulate-serverless azure_function` | Function URLs, environment settings |
+In the Go SDK, only **AWS Lambda** is implemented for `--simulate-serverless`. The
+other platform names below are recognized but return a clear "not implemented in this
+port" error rather than running — they are listed here for reference only.
+
+| Platform | Simulation Flag | Status |
+|----------|-----------------|--------|
+| **AWS Lambda** | `--simulate-serverless lambda` | Supported (requires `--url`) |
+| **CGI** | `--simulate-serverless cgi` | Not implemented (errors) |
+| **Google Cloud Functions** | `--simulate-serverless cloud_function` | Not implemented (errors) |
+| **Azure Functions** | `--simulate-serverless azure_function` | Not implemented (errors) |
+
+The Python-only platform-configuration flags shown in the subsections below
+(`--aws-function-name`, `--cgi-host`, `--gcp-project`, `--azure-env`, `--env`,
+`--env-file`, etc.) do **not** exist in the Go tool. The Go Lambda simulation uses
+fixed preset env vars and requires `--url`; for in-process Lambda dispatch with custom
+options, use the library functions `SimulateDumpSWMLViaLambda` /
+`SimulateExecToolViaLambda` in `cmd/swaig-test/simulate.go`.
 
 ### Platform-Specific Configuration
 
@@ -1346,57 +1368,34 @@ Available SWAIG functions:
 
 ## Command Line Options
 
-### Core Options
+The Go `swaig-test` accepts the following flags (from `cmd/swaig-test`). It targets a
+**running agent server** over HTTP via `--url`, or introspects a compiled example
+binary via `--example`. Exactly one of `--dump-swml`, `--list-tools`, or `--exec`
+selects the action.
 
 | Option | Description |
 |--------|-------------|
-| `--exec FUNCTION` | Execute function with CLI-style arguments (recommended) |
-| `--agent-class CLASS` | Specify agent class for multi-agent files |
-| `--route ROUTE` | Select agent by route path (e.g., /matti-agent) |
-| `--list-agents` | List all available agents in the file |
-| `--list-tools` | List all available SWAIG functions and their types |
-| `--verbose`, `-v` | Enable detailed execution tracing and debugging (also shows logs) |
-| `--fake-full-data` | Generate comprehensive post_data with all SignalWire metadata |
-| `--minimal` | Use minimal post_data (essential keys only) |
-| `--custom-data` | JSON string with custom post_data overrides |
+| `--url URL` | Agent URL, e.g. `http://user:pass@localhost:3000/`. Basic-auth credentials may be embedded in the URL. |
+| `--example NAME` | Introspect a binary in `./examples/<NAME>/` via the `SWAIG_LIST_TOOLS` env var (no HTTP, no port binding). Mutually exclusive with `--url`; currently only supports `--list-tools`. |
+| `--dump-swml` | Dump the SWML document from the agent (HTTP GET). |
+| `--list-tools` | List available SWAIG tools. |
+| `--exec NAME` | Execute a SWAIG tool by name (HTTP POST). |
+| `--param key=value` | Parameter for `--exec`, as `key=value` (repeatable). Values that parse as JSON numbers/booleans/null are converted; everything else is kept as a string. |
+| `--raw` | Output compact JSON instead of pretty-printed. |
+| `--verbose` | Show request/response details. |
+| `--simulate-serverless PLATFORM` | Simulate a serverless environment around the invocation. Currently only `lambda` is supported; it sets Lambda mode-detection env vars and clears `SWML_PROXY_URL_BASE` so platform-specific URL generation is exercised. Requires `--url`. |
 
-### SWML Testing Options
-
-| Option | Description |
-|--------|-------------|
-| `--dump-swml` | Generate SWML document with fake call data |
-| `--raw` | Output raw JSON only (no headers, pipeable) |
-| `--call-type` | Call type: `sip` or `webrtc` (default: webrtc) |
-| `--call-direction` | Call direction: `inbound` or `outbound` (default: inbound) |
-| `--call-state` | Call state (default: created) |
-| `--call-id` | Override call_id |
-| `--project-id` | Override project_id |
-| `--space-id` | Override space_id |
-| `--from-number` | Override from address |
-| `--to-extension` | Override to address |
-
-### Data Override Options
-
-| Option | Description |
-|--------|-------------|
-| `--user-vars` | JSON for vars.userVariables |
-| `--query-params` | JSON for query parameters (merged into userVariables) |
-| `--override` | Override values using dot notation (repeatable) |
-| `--override-json` | Override with JSON values using dot notation (repeatable) |
-
-### Mock Request Options
-
-| Option | Description |
-|--------|-------------|
-| `--header` | Add HTTP headers for mock request (repeatable) |
-| `--method` | HTTP method for mock request (default: POST) |
-| `--body` | JSON string for mock request body |
-
-### Alternative Syntax
-
-| Option | Description |
-|--------|-------------|
-| `--args` | Separator for CLI-style function arguments |
+> **Note:** The Go tool does **not** have the Python CLI's file-loading flags
+> (`--agent-class`, `--route`, `--list-agents`), fake-data/override flags
+> (`--fake-full-data`, `--minimal`, `--custom-data`, `--call-type`,
+> `--call-direction`, `--call-state`, `--call-id`, `--project-id`, `--space-id`,
+> `--from-number`, `--to-extension`, `--user-vars`, `--query-params`, `--override`,
+> `--override-json`), or mock-request flags (`--header`, `--method`, `--body`,
+> `--args`). Many of the example commands later in this guide were ported from the
+> Python documentation and use those flags or load `.py` files; treat them as
+> conceptual illustrations of SWAIG/DataMap/SWML behavior rather than literal Go
+> `swaig-test` invocations. For function arguments, the Go tool uses repeatable
+> `--param key=value` flags rather than JSON-string positional arguments.
 
 ## Real-World Examples
 
@@ -2136,112 +2135,8 @@ This demonstrates both:
 5. **Clear environment variables** between platform tests to avoid conflicts
 6. **Use `--verbose`** to debug environment setup and URL generation
 
----
-
-## sw-search - Build and Query Search Indexes
-
-Build local search indexes from document collections for use with the native vector search skill.
-
-```bash
-sw-search <source_dir> [options]
-```
-
-### Building Indexes
-
-**Arguments:**
-- `source_dir` - Directory containing documents to index
-
-**Options:**
-- `--output FILE` - Output .swsearch file (default: `<source_dir>.swsearch`)
-- `--chunk-size SIZE` - Chunk size in words (default: 50)
-- `--chunk-overlap SIZE` - Overlap between chunks in words (default: 10)
-- `--file-types TYPES` - Comma-separated file extensions (default: md,txt,rst)
-- `--exclude PATTERNS` - Comma-separated glob patterns to exclude
-- `--model MODEL` - Embedding model name (default: sentence-transformers/all-mpnet-base-v2)
-- `--tags TAGS` - Comma-separated tags to add to all chunks
-- `--verbose` - Show detailed progress information
-- `--validate` - Validate the created index after building
-- `--chunking-strategy STRATEGY` - Chunking strategy: sentence, sliding, paragraph, page, semantic, topic, qa (default: sentence)
-- `--max-sentences-per-chunk NUM` - Maximum sentences per chunk (default: 3)
-- `--semantic-threshold FLOAT` - Threshold for semantic chunking (default: 0.5)
-- `--topic-threshold FLOAT` - Threshold for topic-based chunking (default: 0.3)
-- `--index-nlp-backend BACKEND` - NLP backend for processing (default: basic)
-- `--split-newlines` - Split on newlines in addition to sentence boundaries
-- `--languages LANGS` - Comma-separated language codes (default: en)
-
-### Validating Indexes
-
-```bash
-sw-search validate <index_file> [--verbose]
-```
-
-### Searching Indexes
-
-```bash
-sw-search search <index_file> <query> [options]
-```
-
-**Options:**
-- `--count COUNT` - Number of results to return (default: 5)
-- `--distance-threshold FLOAT` - Minimum similarity score (default: 0.0)
-- `--tags TAGS` - Comma-separated tags to filter by
-- `--verbose` - Show detailed information
-- `--json` - Output results as JSON
-- `--no-content` - Hide content in results (show only metadata)
-- `--query-nlp-backend BACKEND` - NLP backend for query processing
-
-### Remote Search
-
-```bash
-sw-search remote <endpoint> <query> [options]
-```
-
-**Options:**
-- `--index-name NAME` - Name of the index to search (required)
-- `--count COUNT` - Number of results to return (default: 5)
-- `--distance-threshold FLOAT` - Minimum similarity score (default: 0.0)
-- `--tags TAGS` - Comma-separated tags to filter by
-- `--json` - Output results as JSON
-- `--timeout SECONDS` - Request timeout in seconds (default: 30)
-
-### Examples
-
-```bash
-# Build from a directory
-sw-search docs --output docs.swsearch
-
-# Build from multiple sources
-sw-search docs examples README.md --output comprehensive.swsearch
-
-# Validate an index
-sw-search validate docs.swsearch
-
-# Search within an index
-sw-search search docs.swsearch "how to create an agent"
-sw-search search docs.swsearch "API reference" --count 3 --verbose
-
-# Search remote index via API
-sw-search remote http://localhost:8001/search "query" --index-name docs
-```
-
-For complete documentation on the search system, see [Search Overview](search_overview.md).
-
----
-
-## Installation
-
-All CLI tools are included when you install the SignalWire Agents SDK:
-
-```bash
-pip install signalwire-agents
-
-# For search functionality
-pip install signalwire-agents[search]
-```
-
 ## Getting Help
 
 ```bash
-sw-search --help
 swaig-test --help
 ```

--- a/docs/cloud_functions_guide.md
+++ b/docs/cloud_functions_guide.md
@@ -1,474 +1,144 @@
-# SignalWire AI Agents - Cloud Functions Deployment Guide
+# SignalWire AI Agents (Go) - Serverless Deployment Guide
 
-This guide covers deploying SignalWire AI Agents to Google Cloud Functions and Azure Functions.
+This guide covers deploying SignalWire AI Agents built with the Go SDK to serverless
+platforms.
 
-## Overview
+## Platform Support
 
-SignalWire AI Agents now support deployment to major cloud function platforms:
+The Go SDK ships a serverless adapter for **AWS Lambda** only (package
+`github.com/signalwire/signalwire-go/pkg/lambda`).
 
-- **Google Cloud Functions** - Serverless compute platform on Google Cloud
-- **Azure Functions** - Serverless compute service on Microsoft Azure
-- **AWS Lambda** - Already supported (see existing documentation)
+- **AWS Lambda** — Supported via `pkg/lambda` (Function URLs and API Gateway HTTP API v2).
+- **Google Cloud Functions** — Not yet implemented in the Go SDK. There is no GCF
+  adapter package. (`swaig-test --simulate-serverless cloud_function` returns a
+  "not implemented in this port" error.)
+- **Azure Functions** — Not yet implemented in the Go SDK. There is no Azure adapter
+  package. (`swaig-test --simulate-serverless azure_function` returns a "not
+  implemented in this port" error.)
 
-## Google Cloud Functions
+> The Python SDK supports GCF and Azure deployment; the Go port does not yet. If you
+> need GCF or Azure today, run the agent as a normal HTTP server (see
+> [web_service.md](web_service.md)) behind the platform's HTTP trigger, or use AWS
+> Lambda with the adapter below.
 
-### Environment Detection
+## AWS Lambda
 
-The agent automatically detects Google Cloud Functions environment using these variables:
-- `FUNCTION_TARGET` - The function entry point
-- `K_SERVICE` - Knative service name (Cloud Run/Functions)
-- `GOOGLE_CLOUD_PROJECT` - Google Cloud project ID
+The Lambda adapter wraps the `http.Handler` produced by `agent.AsRouter()` (any
+`http.Handler` works) and translates Lambda invocation events into synthetic
+`*http.Request` values. Two event shapes are supported:
 
-### Deployment Steps
+- **Lambda Function URLs** (`HandleFunctionURL`) — the simplest deployment; no API
+  Gateway required. This is the recommended path.
+- **API Gateway HTTP API v2** (`HandleAPIGatewayV2`) — for deployments that front the
+  function with an API Gateway HTTP API.
 
-1. **Create your agent file** (`main.py`):
-```python
-import functions_framework
-from your_agent_module import YourAgent
+### Function URL deployment (recommended)
 
-# Create agent instance
-agent = YourAgent(
-    name="my-agent",
-    # Configure your agent parameters
+```go
+package main
+
+import (
+	awslambda "github.com/aws/aws-lambda-go/lambda"
+	"github.com/signalwire/signalwire-go/pkg/agent"
+	swlambda "github.com/signalwire/signalwire-go/pkg/lambda"
 )
 
-@functions_framework.http
-def agent_handler(request):
-    """HTTP Cloud Function entry point"""
-    return agent.handle_serverless_request(event=request)
-```
-
-2. **Create requirements.txt**:
-```
-functions-framework==3.*
-signalwire-agents
-# Add your other dependencies
-```
-
-3. **Deploy using gcloud**:
-```bash
-gcloud functions deploy my-agent \
-    --runtime python39 \
-    --trigger-http \
-    --entry-point agent_handler \
-    --allow-unauthenticated
-```
-
-### Environment Variables
-
-Set these environment variables for your function:
-
-```bash
-# SignalWire credentials
-export SIGNALWIRE_PROJECT_ID="your-project-id"
-export SIGNALWIRE_TOKEN="your-token"
-
-# Agent configuration
-export AGENT_USERNAME="your-username"
-export AGENT_PASSWORD="your-password"
-
-# Optional: Custom region/project settings
-export FUNCTION_REGION="us-central1"
-export GOOGLE_CLOUD_PROJECT="your-project-id"
-```
-
-### URL Format
-
-Google Cloud Functions URLs follow this pattern:
-```
-https://{region}-{project-id}.cloudfunctions.net/{function-name}
-```
-
-With authentication:
-```
-https://username:password@{region}-{project-id}.cloudfunctions.net/{function-name}
-```
-
-## Azure Functions
-
-### Environment Detection
-
-The agent automatically detects Azure Functions environment using these variables:
-- `AZURE_FUNCTIONS_ENVIRONMENT` - Azure Functions runtime environment
-- `FUNCTIONS_WORKER_RUNTIME` - Runtime language (python, node, etc.)
-- `AzureWebJobsStorage` - Azure storage connection string
-
-### Deployment Steps
-
-1. **Create your function app structure**:
-```
-my-agent-function/
-├── __init__.py
-├── function.json
-└── requirements.txt
-```
-
-2. **Create `__init__.py`**:
-```python
-import azure.functions as func
-from your_agent_module import YourAgent
-
-# Create agent instance
-agent = YourAgent(
-    name="my-agent",
-    # Configure your agent parameters
+var a = agent.NewAgentBase(
+	agent.WithName("MyAgent"),
+	agent.WithRoute("/my-agent"),
 )
 
-def main(req: func.HttpRequest) -> func.HttpResponse:
-    """Azure Function entry point"""
-    return agent.handle_serverless_request(event=req)
-```
+var handler = swlambda.NewHandler(a.AsRouter())
 
-3. **Create `function.json`**:
-```json
-{
-  "scriptFile": "__init__.py",
-  "bindings": [
-    {
-      "authLevel": "anonymous",
-      "type": "httpTrigger",
-      "direction": "in",
-      "name": "req",
-      "methods": ["get", "post"]
-    },
-    {
-      "type": "http",
-      "direction": "out",
-      "name": "$return"
-    }
-  ]
+func main() {
+	awslambda.Start(handler.HandleFunctionURL)
 }
 ```
 
-4. **Create `requirements.txt`**:
-```
-azure-functions
-signalwire-agents
-# Add your other dependencies
-```
+Because `agent.AsRouter()` installs routes relative to the agent's route (e.g.
+`/my-agent`, `/my-agent/swaig`), the Lambda event's request path must line up with that
+route. Lambda Function URLs preserve the full request path unchanged, so no rewriting
+is needed in the common case.
 
-5. **Deploy using Azure CLI**:
-```bash
-# Create function app
-az functionapp create \
-    --resource-group myResourceGroup \
-    --consumption-plan-location westus \
-    --runtime python \
-    --runtime-version 3.9 \
-    --functions-version 4 \
-    --name my-agent-function \
-    --storage-account mystorageaccount
+### API Gateway HTTP API v2 deployment
 
-# Deploy code
-func azure functionapp publish my-agent-function
+```go
+func main() {
+	awslambda.Start(handler.HandleAPIGatewayV2)
+}
 ```
 
-### Environment Variables
+The classic REST API (v1) payload is intentionally not supported as a first-class path.
+Users who need v1 can wrap it via `github.com/awslabs/aws-lambda-go-api-proxy`.
 
-Set these in your Azure Function App settings:
+### Building and deploying
+
+Build a Linux binary named `bootstrap` (required by the `provided.al2`/`al2023`
+runtimes) and package it for upload:
 
 ```bash
-# SignalWire credentials
-SIGNALWIRE_PROJECT_ID="your-project-id"
-SIGNALWIRE_TOKEN="your-token"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap ./cmd/my-agent
+zip function.zip bootstrap
 
-# Agent configuration
-AGENT_USERNAME="your-username"
-AGENT_PASSWORD="your-password"
-
-# Azure-specific (usually auto-set)
-AZURE_FUNCTIONS_ENVIRONMENT="Development"
-WEBSITE_SITE_NAME="my-agent-function"
+aws lambda create-function \
+  --function-name my-agent \
+  --runtime provided.al2023 \
+  --handler bootstrap \
+  --zip-file fileb://function.zip \
+  --role arn:aws:iam::<account-id>:role/<lambda-role>
 ```
 
-### URL Format
+### Environment detection and URL generation
 
-Azure Functions URLs follow this pattern:
-```
-https://{function-app-name}.azurewebsites.net/api/{function-name}
+The SDK detects the Lambda environment from standard Lambda environment variables
+(e.g. `AWS_LAMBDA_FUNCTION_NAME`, `AWS_REGION`, and `AWS_LAMBDA_FUNCTION_URL` when using
+Function URLs) and generates webhook URLs accordingly. Setting `SWML_PROXY_URL_BASE`
+overrides URL generation with a fixed base; clear it if you want the platform-derived
+URLs.
+
+## Testing Lambda locally
+
+Use the `swaig-test` CLI to exercise an agent with the Lambda mode-detection
+environment applied. The Go tool requires a running agent server (`--url`):
+
+```bash
+# Apply Lambda env vars around a SWML dump against a running agent
+swaig-test --url http://user:pass@localhost:3000/my-agent \
+  --simulate-serverless lambda --dump-swml
+
+# Execute a function under the simulated Lambda environment
+swaig-test --url http://user:pass@localhost:3000/my-agent \
+  --simulate-serverless lambda \
+  --exec search_knowledge --param query=test
 ```
 
-With authentication:
-```
-https://username:password@{function-app-name}.azurewebsites.net/api/{function-name}
-```
+For true in-process Lambda adapter dispatch (constructing the agent *after* the Lambda
+environment is active, so env-captured state reflects the simulated environment), call
+the library functions `SimulateDumpSWMLViaLambda` / `SimulateExecToolViaLambda` in
+`cmd/swaig-test/simulate.go` directly from a Go test.
+
+See the [CLI Guide](cli_guide.md) for the full `swaig-test` flag set.
 
 ## Authentication
 
-Both platforms support HTTP Basic Authentication:
-
-### Automatic Authentication
-The agent automatically validates credentials in cloud function environments:
-
-```python
-agent = YourAgent(
-    name="my-agent",
-    username="your-username",
-    password="your-password"
-)
-```
-
-### Authentication Flow
-1. Client sends request with `Authorization: Basic <credentials>` header
-2. Agent validates credentials against configured username/password
-3. If invalid, returns 401 with `WWW-Authenticate` header
-4. If valid, processes the request normally
-
-## Testing
-
-### SignalWire Agent Testing Tool
-
-The SignalWire AI Agents SDK includes a testing tool (`swaig-test`) that can simulate cloud function environments for comprehensive testing before deployment.
-
-#### Cloud Function Environment Simulation
-
-**Google Cloud Functions:**
-```bash
-# Test SWML generation in GCP environment
-swaig-test examples/my_agent.py --simulate-serverless cloud_function --gcp-project my-project --dump-swml
-
-# Test function execution
-swaig-test examples/my_agent.py --simulate-serverless cloud_function --gcp-project my-project --exec my_function --param value
-
-# With custom region and service
-swaig-test examples/my_agent.py --simulate-serverless cloud_function \
-  --gcp-project my-project \
-  --gcp-region us-west1 \
-  --gcp-service my-service \
-  --dump-swml
-```
-
-**Azure Functions:**
-```bash
-# Test SWML generation in Azure environment
-swaig-test examples/my_agent.py --simulate-serverless azure_function --dump-swml
-
-# Test function execution
-swaig-test examples/my_agent.py --simulate-serverless azure_function --exec my_function --param value
-
-# With custom environment and URL
-swaig-test examples/my_agent.py --simulate-serverless azure_function \
-  --azure-env Production \
-  --azure-function-url https://myapp.azurewebsites.net/api/myfunction \
-  --dump-swml
-```
-
-#### Environment Variable Testing
-
-Test with custom environment variables:
-```bash
-# Set individual environment variables
-swaig-test examples/my_agent.py --simulate-serverless cloud_function \
-  --env GOOGLE_CLOUD_PROJECT=my-project \
-  --env DEBUG=1 \
-  --exec my_function
-
-# Load from environment file
-swaig-test examples/my_agent.py --simulate-serverless azure_function \
-  --env-file production.env \
-  --dump-swml
-```
-
-#### Authentication Testing
-
-Test authentication in cloud function environments:
-```bash
-# Test with authentication (uses agent's configured credentials)
-swaig-test examples/my_agent.py --simulate-serverless cloud_function \
-  --gcp-project my-project \
-  --dump-swml --verbose
-
-# The tool automatically tests:
-# - Basic auth credential embedding in URLs
-# - Authentication challenge responses
-# - Platform-specific auth handling
-```
-
-#### URL Generation Testing
-
-Verify that URLs are generated correctly for each platform:
-```bash
-# Check URL generation with verbose output
-swaig-test examples/my_agent.py --simulate-serverless cloud_function \
-  --gcp-project my-project \
-  --dump-swml --verbose
-
-# Extract webhook URLs from SWML
-swaig-test examples/my_agent.py --simulate-serverless azure_function \
-  --dump-swml --raw | jq '.sections.main[1].ai.SWAIG.functions[].web_hook_url'
-```
-
-#### Available Testing Options
-
-**Platform Selection:**
-- `--simulate-serverless cloud_function` - Google Cloud Functions
-- `--simulate-serverless azure_function` - Azure Functions  
-- `--simulate-serverless lambda` - AWS Lambda
-- `--simulate-serverless cgi` - CGI environment
-
-**Google Cloud Platform Options:**
-- `--gcp-project PROJECT_ID` - Set Google Cloud project ID
-- `--gcp-region REGION` - Set Google Cloud region (default: us-central1)
-- `--gcp-service SERVICE` - Set service name
-- `--gcp-function-url URL` - Override function URL
-
-**Azure Functions Options:**
-- `--azure-env ENVIRONMENT` - Set Azure environment (default: Development)
-- `--azure-function-url URL` - Override Azure Function URL
-
-**Environment Variables:**
-- `--env KEY=value` - Set individual environment variables
-- `--env-file FILE` - Load environment variables from file
-
-**Output Options:**
-- `--dump-swml` - Generate and display SWML document
-- `--verbose` - Show detailed information
-- `--raw` - Output raw JSON (useful for piping to jq)
-
-#### Complete Testing Workflow
+The agent validates HTTP Basic Auth credentials configured on the agent. Configure
+them with the relevant `AgentOption`s when constructing the agent, then send an
+`Authorization: Basic <credentials>` header (or embed `user:pass@` in the URL when
+testing). An unauthenticated request to a protected agent returns 401 with a
+`WWW-Authenticate` header.
 
 ```bash
-# 1. List available agents and tools
-swaig-test examples/my_agent.py --list-agents
-swaig-test examples/my_agent.py --list-tools
+# Should return 401
+curl https://<function-url>/my-agent
 
-# 2. Test SWML generation for each platform
-swaig-test examples/my_agent.py --simulate-serverless cloud_function --gcp-project test-project --dump-swml
-swaig-test examples/my_agent.py --simulate-serverless azure_function --dump-swml
-
-# 3. Test specific function execution
-swaig-test examples/my_agent.py --simulate-serverless cloud_function --gcp-project test-project --exec search_knowledge --query "test"
-
-# 4. Test with production-like environment
-swaig-test examples/my_agent.py --simulate-serverless azure_function --env-file production.env --exec my_function --param value
-
-# 5. Verify authentication and URL generation
-swaig-test examples/my_agent.py --simulate-serverless cloud_function --gcp-project prod-project --dump-swml --verbose
-```
-
-### Local Testing
-
-**Google Cloud Functions:**
-```bash
-# Install Functions Framework
-pip install functions-framework
-
-# Run locally
-functions-framework --target=agent_handler --debug
-```
-
-**Azure Functions:**
-```bash
-# Install Azure Functions Core Tools
-npm install -g azure-functions-core-tools@4
-
-# Run locally
-func start
-```
-
-### Testing Authentication
-
-```bash
-# Test without auth (should return 401)
-curl https://your-function-url/
-
-# Test with valid auth
-curl -u username:password https://your-function-url/
-
-# Test SWAIG function call
-curl -u username:password \
-  -H "Content-Type: application/json" \
-  -d '{"call_id": "test", "argument": {"parsed": [{"param": "value"}]}}' \
-  https://your-function-url/your_function_name
+# With valid credentials
+curl -u username:password https://<function-url>/my-agent
 ```
 
 ## Best Practices
 
-### Performance
-- Use connection pooling for database connections
-- Implement proper caching strategies
-- Minimize cold start times with smaller deployment packages
-
-### Security
-- Always use HTTPS endpoints
-- Implement proper authentication
-- Use environment variables for sensitive data
-- Consider using cloud-native secret management
-
-### Monitoring
-- Enable cloud platform logging
-- Monitor function execution times
-- Set up alerts for errors and timeouts
-- Use distributed tracing for complex workflows
-
-### Cost Optimization
-- Right-size memory allocation
-- Implement proper timeout settings
-- Use reserved capacity for predictable workloads
-- Monitor and optimize function execution patterns
-
-## Troubleshooting
-
-### Common Issues
-
-**Environment Detection:**
-```python
-# Check detected mode
-from signalwire_agents.core.logging_config import get_execution_mode
-print(f"Detected mode: {get_execution_mode()}")
-```
-
-**URL Generation:**
-```python
-# Check generated URLs
-agent = YourAgent(name="test")
-print(f"Base URL: {agent.get_full_url()}")
-print(f"Auth URL: {agent.get_full_url(include_auth=True)}")
-```
-
-**Authentication Issues:**
-- Verify username/password are set correctly
-- Check that Authorization header is being sent
-- Ensure credentials match exactly (case-sensitive)
-
-### Debugging
-
-Enable debug logging:
-```python
-import logging
-logging.basicConfig(level=logging.DEBUG)
-```
-
-Check environment variables:
-```python
-import os
-for key, value in os.environ.items():
-    if 'FUNCTION' in key or 'AZURE' in key or 'GOOGLE' in key:
-        print(f"{key}: {value}")
-```
-
-## Migration from Other Platforms
-
-### From AWS Lambda
-- Update environment variable names
-- Modify request/response handling if needed
-- Update deployment scripts
-
-### From Traditional Servers
-- Add cloud function entry point
-- Configure environment variables
-- Update URL generation logic
-- Test authentication flow
-
-## Examples
-
-See `examples/lambda_agent.py` for a complete AWS Lambda deployment example.
-
-## Support
-
-For issues specific to cloud function deployment:
-1. Check the troubleshooting section above
-2. Verify environment variables are set correctly
-3. Test authentication flow manually
-4. Check cloud platform logs for detailed error messages
-5. Refer to platform-specific documentation for deployment issues 
+- Minimize cold-start time by keeping the deployment package small and using
+  `CGO_ENABLED=0` static binaries.
+- Always use HTTPS endpoints.
+- Use environment variables / a secret manager for credentials; do not hard-code them.
+- Enable platform logging and set sensible timeouts.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,29 +118,12 @@ Configuration values are applied in this order (highest to lowest):
 }
 ```
 
-### Search Service Configuration
-
-```json
-{
-  "service": {
-    "port": "${SEARCH_PORT|8001}",
-    "indexes": {
-      "docs": "${DOCS_INDEX|./docs.swsearch}",
-      "api": "${API_INDEX|./api.swsearch}"
-    }
-  },
-  "security": {
-    "ssl_enabled": "${SEARCH_SSL|false}",
-    "auth": {
-      "basic": {
-        "enabled": true,
-        "user": "${SEARCH_USER|search}",
-        "password": "${SEARCH_PASSWORD}"
-      }
-    }
-  }
-}
-```
+> **Note on search:** The Go SDK does not host a search service or build local
+> `.swsearch` indexes. Knowledge-base search is provided by the built-in
+> `native_vector_search` skill, which connects to a **remote** search server
+> (see the [Skills System](skills_system.md) guide). That remote server is operated
+> and configured separately; the Go SDK only needs the server's `remote_url` and an
+> `index_name` passed as skill parameters.
 
 ### MCP Gateway Configuration
 
@@ -297,11 +280,6 @@ class MyAgent(AgentBase):
     def __init__(self):
         # Auto-detects config.json if present
         super().__init__(name="my-agent", config_file="agent_config.json")
-
-# Search Service
-from signalwire_agents.search import SearchService
-
-service = SearchService(config_file="search_config.json")
 
 # MCP Gateway
 from mcp_gateway.gateway_service import MCPGateway

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -318,34 +318,33 @@ Each inbound request creates an **ephemeral copy** of the agent. The callback cu
 
 ## Search System
 
-The SDK includes a complete hybrid search engine for local knowledge bases:
+The Go SDK provides knowledge-base search through the built-in `native_vector_search`
+skill, which connects to a **remote search server** over HTTP. The skill is
+remote-only: it does not build or read local index files, and the Go SDK ships no
+index-building CLI or local search backend. You run the search server separately
+(it exposes `/health` and `/search` endpoints) and point the skill at it:
 
-**Building indexes:**
-```bash
-sw-search ./docs --output knowledge.swsearch
-sw-search ./docs ./examples --file-types md,txt,py --chunking-strategy sentence
-sw-search validate ./knowledge.swsearch
-sw-search search ./knowledge.swsearch "how do I configure SSL?"
-```
-
-**In agents:**
-```python
-agent.add_skill("native_vector_search", {
-    "index_path": "knowledge.swsearch",
-    "tool_name": "search_docs",
-    "description": "Search product documentation"
+```go
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url":  "http://localhost:8001",       // required
+    "index_name":  "knowledge",                    // index to query on the server
+    "tool_name":   "search_docs",
+    "description":  "Search product documentation",
 })
 ```
 
-The search system supports:
-- **Document processing:** PDF, DOCX, Excel, PowerPoint, HTML, Markdown, plain text
-- **Chunking strategies:** sentence, sliding window, paragraph, page, semantic, topic, QA-optimized, markdown-aware, JSON
-- **Embedding models:** mini (384d, fast), base (768d), large
-- **Hybrid search:** Vector similarity + keyword matching + filename search + metadata search
-- **Backends:** SQLite (`.swsearch` files for local/serverless) or PostgreSQL (pgvector for production)
-- **Installation tiers:** `search-queryonly` (~400MB, query only), `search` (~500MB, basic), `search-full` (~600MB, document processing), `search-all` (~700MB, everything)
+The skill:
+- Sends the AI's query to the remote server's `/search` endpoint and formats the
+  returned results (content, source filename/section, and relevance score) for the AI.
+- Supports HTTP Basic auth via `http://user:pass@host:8001` in `remote_url`.
+- Validates the URL for SSRF protection (private/loopback addresses are rejected
+  unless `SWML_ALLOW_PRIVATE_URLS` is set).
+- Accepts `count`, `similarity_threshold`, `tags`, `response_prefix`,
+  `response_postfix`, `max_content_length`, and `no_results_message` parameters to
+  tune queries and response formatting.
 
-The `.swsearch` format is a self-contained SQLite database with embeddings, chunks, and metadata -- deploy it alongside your agent to Lambda or any serverless platform.
+How documents are ingested, chunked, embedded, and stored is the responsibility of
+the remote search server, not the Go SDK.
 
 ---
 
@@ -466,7 +465,7 @@ The SDK handles auth automatically:
 | Multi-language | Manually construct language arrays | `add_language()` one-liner |
 | State machine | Manually build contexts JSON | Fluent `define_contexts()` API |
 | Structured data collection | Build gather configs by hand | `add_gather_question()` chain |
-| Search/RAG | Build entire pipeline | `add_skill("native_vector_search")` |
+| Search/RAG | Wire up a search client | `AddSkill("native_vector_search", ...)` against a remote search server |
 | Multi-agent | Separate deployments + router | `AgentServer` with route registration |
 | Dynamic config | Custom middleware | `set_dynamic_config_callback()` |
 | Post-call analytics | Parse raw webhook payload | `on_summary()` callback |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security Configuration Guide
 
-This guide covers the security features and configuration options available in SignalWire AI Agents SDK for both SWML-based services (SWML -- SignalWire Markup Language -- is the JSON document format that defines agent behavior) and the standalone Search Service.
+This guide covers the security features and configuration options available in the SignalWire AI Agents SDK for SWML-based services (SWML -- SignalWire Markup Language -- is the JSON document format that defines agent behavior).
 
 ## Overview
 
@@ -83,24 +83,23 @@ agent = MyAgent()
 agent.run()
 ```
 
-### Search Service
+### Remote Search Server
 
-The standalone search service also supports the same security configuration:
+The Go SDK does not run a search service or build local index files. Knowledge-base
+search is provided by the built-in `native_vector_search` skill, which connects to a
+**remote** search server over HTTP. Security for that server is configured on the
+server itself; the skill authenticates to it using HTTP Basic credentials embedded in
+the `remote_url` (`http://user:pass@host:8001`).
 
-```python
-from signalwire_agents.search import SearchService
+The skill also performs SSRF validation on `remote_url`: requests to private,
+loopback, and link-local addresses are rejected unless `SWML_ALLOW_PRIVATE_URLS` is
+set to a truthy value (intended for local/test environments only).
 
-# Basic usage - security configured from environment
-service = SearchService(port=8001, indexes={"docs": "index.swsearch"})
-service.start()
-
-# Override SSL settings programmatically
-service.start(
-    host="0.0.0.0",
-    port=8001,
-    ssl_cert="/path/to/cert.pem",
-    ssl_key="/path/to/key.pem"
-)
+```go
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url": "https://user:pass@search.example.com:8001",
+    "index_name": "docs",
+})
 ```
 
 ## Security Headers
@@ -208,12 +207,11 @@ The security configuration is backward compatible. Existing environment variable
 
 The following are new security features:
 
-1. **Search Service HTTPS**: The search service now supports HTTPS using the same environment variables
-2. **Security Headers**: Automatically added when appropriate
-3. **CORS Configuration**: Fine-grained control over CORS origins
-4. **Host Validation**: Restrict which hosts can access the service
-5. **Rate Limiting**: Built-in rate limiting support
-6. **HSTS**: HTTP Strict Transport Security for HTTPS connections
+1. **Security Headers**: Automatically added when appropriate
+2. **CORS Configuration**: Fine-grained control over CORS origins
+3. **Host Validation**: Restrict which hosts can access the service
+4. **Rate Limiting**: Built-in rate limiting support
+5. **HSTS**: HTTP Strict Transport Security for HTTPS connections
 
 ## Troubleshooting
 

--- a/docs/skills_system.md
+++ b/docs/skills_system.md
@@ -102,57 +102,62 @@ Perform mathematical calculations.
 - `calculate(expression)` - Evaluate mathematical expressions safely
 
 ### Native Vector Search (`native_vector_search`)
-Search local document collections using vector similarity and keyword search.
+Search a knowledge base hosted on a **remote search server** using vector similarity
+and keyword search. The Go SDK skill is **remote-only**: it connects to a running
+search server over HTTP and does not build or read any local index files. There is
+no local `.swsearch` index, no SQLite/pgvector backend, and no index-building CLI in
+the Go SDK -- the search server is operated separately and exposes `/health` and
+`/search` HTTP endpoints.
 
 **Requirements:**
-- Packages: `sentence-transformers`, `scikit-learn`, `numpy`
-- Install with: `pip install signalwire-agents[search]`
+- A reachable remote search server (the `remote_url` parameter is required).
+- No additional Go packages -- the skill is a built-in and uses only the standard
+  library HTTP client.
 
 **Parameters:**
+- `remote_url` (required) - URL of the remote search server, e.g.
+  `http://localhost:8001` or `http://user:pass@host:8001` (embedded credentials are
+  sent as HTTP Basic auth). The URL is validated for SSRF protection; private and
+  loopback addresses are rejected unless `SWML_ALLOW_PRIVATE_URLS` is set.
+- `index_name` (default: "default") - Name of the index to query on the remote server
 - `tool_name` (default: "search_knowledge") - Custom name for the search tool
-- `index_file` (optional) - Path to local `.swsearch` index file
-- `remote_url` (optional) - URL of remote search server
-- `index_name` (default: "default") - Index name on remote server
-- `build_index` (default: False) - Auto-build index if missing
-- `source_dir` (optional) - Source directory for auto-building
-- `count` (default: 3) - Number of search results to return
-- `distance_threshold` (default: 0.0) - Minimum similarity score
+- `count` (default: 5) - Number of search results to return (1-20)
+- `similarity_threshold` (default: 0.0) - Minimum similarity score (0.0 = no limit, 1.0 = exact match)
+- `tags` (optional) - List of tags to filter search results
 - `response_prefix` (optional) - Text to prepend to responses
 - `response_postfix` (optional) - Text to append to responses
+- `max_content_length` (default: 32768) - Maximum total response size in characters
+- `no_results_message` (default: `"No information found for '{query}'"`) - Message when no results are found; `{query}` is substituted
+- `hints` (optional) - Additional speech-recognition hints
+- `description` (default: "Search the knowledge base for information") - Tool description shown to the AI
 
 **Tools provided:**
-- `search_knowledge(query, count)` - Search documents with hybrid vector/keyword search
+- `search_knowledge(query, count)` (or your custom `tool_name`) - Search the remote index
 
 **Usage examples:**
-```python
-# Local mode with auto-build from concepts guide
-agent.add_skill("native_vector_search", {
-    "tool_name": "search_docs",
-    "build_index": True,
-    "source_dir": "./docs",  # Will build from directory
-    "index_file": "concepts.swsearch"
-})
-
-# Or build from specific concepts guide file
-agent.add_skill("native_vector_search", {
-    "tool_name": "search_concepts",
-    "index_file": "concepts.swsearch"  # Pre-built from concepts guide
-})
-
-# Remote mode
-agent.add_skill("native_vector_search", {
+```go
+// Connect to a remote search server
+agent.AddSkill("native_vector_search", map[string]any{
     "remote_url": "http://localhost:8001",
-    "index_name": "knowledge"
+    "index_name": "knowledge",
 })
 
-# Multiple instances for different document collections
-agent.add_skill("native_vector_search", {
-    "tool_name": "search_examples",
-    "index_file": "examples.swsearch"
+// Custom tool name, more results, and a similarity floor
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url":           "http://search.internal:8001",
+    "index_name":           "docs",
+    "tool_name":            "search_docs",
+    "count":                10,
+    "similarity_threshold": 0.5,
+})
+
+// Multiple instances querying different indexes on the same server
+agent.AddSkill("native_vector_search", map[string]any{
+    "remote_url": "http://localhost:8001",
+    "index_name": "examples",
+    "tool_name":  "search_examples",
 })
 ```
-
-For complete documentation, see [Search Overview](search_overview.md).
 
 ### SWML Transfer (`swml_transfer`)
 Transfer calls between agents using pattern matching.

--- a/docs/swml_service_guide.md
+++ b/docs/swml_service_guide.md
@@ -27,10 +27,10 @@ The class is designed to be extended for specific use cases, while providing a f
 
 ## Installation
 
-The `SWMLService` class is part of the SignalWire AI Agent SDK. Install it using pip:
+The `SWMLService` type is part of the SignalWire AI Agents Go SDK. Add it to your module with `go get`:
 
 ```bash
-pip install signalwire-agents
+go get github.com/signalwire/signalwire-go
 ```
 
 ## Basic Usage

--- a/relay/docs/README.md
+++ b/relay/docs/README.md
@@ -1,17 +1,16 @@
 # RELAY Client Documentation
 
-Detailed documentation for the SignalWire RELAY client lives alongside the Go source code in the `pkg/relay/docs/` directory.
+Detailed documentation for the SignalWire RELAY client.
 
 ## Available Guides
 
-- [Getting Started](../../pkg/relay/docs/getting-started.md) -- installation, environment variables, first call handler
-- [Call Methods Reference](../../pkg/relay/docs/call-methods.md) -- every method on the `Call` object with signatures and examples
-- [Events](../../pkg/relay/docs/events.md) -- event types, `RelayEvent` struct, call state transitions
-- [Messaging](../../pkg/relay/docs/messaging.md) -- sending and receiving SMS/MMS with the RELAY client
-- [Client Reference](../../pkg/relay/docs/client-reference.md) -- `NewRelayClient` options, `Run()`, `Stop()`, `Dial()`, reconnect behavior
+- [Getting Started](getting-started.md) -- installation, environment variables, first call handler
+- [Call Methods Reference](call-methods.md) -- every method on the `Call` object with signatures and examples
+- [Events](events.md) -- event types, `RelayEvent` struct, call state transitions
+- [Messaging](messaging.md) -- sending and receiving SMS/MMS with the RELAY client
+- [Client Reference](client-reference.md) -- `NewRelayClient` options, `Run()`, `Stop()`, `Dial()`, reconnect behavior
 
 ## Quick Links
 
 - [Package source code](../../pkg/relay/) -- the Go implementation
 - [Examples](../examples/) -- runnable example programs
-- [RELAY Implementation Guide](../../pkg/relay/RELAY_IMPLEMENTATION_GUIDE.md) -- internal architecture notes

--- a/relay/docs/call-methods.md
+++ b/relay/docs/call-methods.md
@@ -2,17 +2,22 @@
 
 A `Call` object represents a live phone call. You get one from the `OnCall` handler (inbound) or `client.Dial()` (outbound).
 
-## Properties
+## Accessors
 
-| Property | Type | Description |
+These are methods (not fields) -- call them with `()`:
+
+| Accessor | Type | Description |
 |----------|------|-------------|
-| `CallID` | `string` | Unique call identifier |
-| `NodeID` | `string` | Server node handling the call |
-| `State` | `string` | Current state: `created`, `ringing`, `answered`, `ending`, `ended` |
-| `Direction` | `string` | `inbound` or `outbound` |
-| `Tag` | `string` | Correlation tag |
-| `Device` | `map[string]any` | Device info (type, params) |
-| `SegmentID` | `string` | Segment identifier |
+| `CallID()` | `string` | Unique call identifier |
+| `NodeID()` | `string` | Server node handling the call |
+| `State()` | `string` | Current state: `created`, `ringing`, `answered`, `ending`, `ended` |
+| `CallState()` | `CallState` | Current state as a typed `CallState` value |
+| `Direction()` | `string` | `inbound` or `outbound` |
+| `Tag()` | `string` | Correlation tag |
+| `Device()` | `map[string]any` | Device info (type, params) |
+| `SegmentID()` | `string` | Segment identifier |
+| `ProjectID()` | `string` | Project ID owning the call |
+| `Context()` | `string` | Context the call arrived on |
 
 ## Actions: Blocking vs Fire-and-Forget
 
@@ -24,7 +29,7 @@ Methods like `Play()`, `Record()`, `Detect()`, etc. return **Action** objects. T
 action := call.Play([]map[string]any{
 	{"type": "tts", "params": map[string]any{"text": "Hello"}},
 })
-event := action.Wait(context.Background()) // blocks until playback finishes
+event, _ := action.Wait(context.Background()) // blocks until playback finishes
 // execution continues only after play is done
 ```
 
@@ -51,7 +56,7 @@ action := call.Play([]map[string]any{
 })
 
 go func() {
-	event := action.Wait(context.Background())
+	event, _ := action.Wait(context.Background())
 	fmt.Printf("Done: %v\n", event.Params)
 }()
 // continues immediately; goroutine fires when playback finishes
@@ -61,7 +66,7 @@ go func() {
 
 | Method | Returns |
 |--------|---------|
-| `action.Wait(ctx)` | Blocks until the action completes, returns the terminal `*RelayEvent` |
+| `action.Wait(ctx)` | Blocks until the action completes, returns `(*RelayEvent, error)` |
 | `action.IsDone()` | `true` if the action has completed |
 | `action.Result()` | The terminal `*RelayEvent` (or `nil` if not done) |
 | `action.Completed()` | `true` if the action reached a terminal state |
@@ -71,7 +76,7 @@ Some actions also have `Pause()`, `Resume()`, and `Volume()`.
 
 ## Lifecycle
 
-### `Answer(opts ...CallOption) (map[string]any, error)`
+### `Answer() error`
 
 Answer an inbound call.
 
@@ -79,7 +84,7 @@ Answer an inbound call.
 call.Answer()
 ```
 
-### `Hangup(reason string) (map[string]any, error)`
+### `Hangup(reason string) error`
 
 End the call.
 
@@ -88,7 +93,7 @@ call.Hangup("")
 call.Hangup("busy")
 ```
 
-### `Pass() (map[string]any, error)`
+### `Pass() error`
 
 Decline control, returning the call to routing.
 
@@ -145,7 +150,7 @@ action := call.Record(
 )
 // ... later ...
 action.Stop()
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 fmt.Printf("Recording URL: %v\n", event.Params["url"])
 ```
 
@@ -162,29 +167,31 @@ action := call.PlayAndCollect(
 	},
 	map[string]any{"digits": map[string]any{"max": 1, "digit_timeout": 5.0}},
 )
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 result, _ := event.Params["result"].(map[string]any)
 params, _ := result["params"].(map[string]any)
 digit, _ := params["digits"].(string)
 ```
 
-### `Collect(collect map[string]any) *StandaloneCollectAction`
+### `Collect(params *CollectParams) *StandaloneCollectAction`
 
-Collect input without playing audio. Pass a collect-config map describing
-the digit and/or speech recognition to perform.
+Collect input without playing audio. Pass a `*CollectParams` describing
+the digit and/or speech recognition to perform (pass `nil` for an empty
+collect body).
 
 ```go
-action := call.Collect(map[string]any{
-	"digits":          map[string]any{"max": 4, "terminators": "#"},
-	"speech":          map[string]any{"language": "en-US"},
-	"partial_results": true,
+partial := true
+action := call.Collect(&relay.CollectParams{
+	Digits:         map[string]any{"max": 4, "terminators": "#"},
+	Speech:         map[string]any{"language": "en-US"},
+	PartialResults: &partial,
 })
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 ```
 
 ## Bridging
 
-### `Connect(devices [][]map[string]any, opts ...ConnectOption) (map[string]any, error)`
+### `Connect(devices [][]map[string]any, opts ...ConnectOption) error`
 
 Bridge the call to another destination.
 
@@ -197,7 +204,7 @@ call.Connect(
 )
 ```
 
-### `Disconnect() (map[string]any, error)`
+### `Disconnect() error`
 
 Unbridge a connected call.
 
@@ -207,7 +214,7 @@ call.Disconnect()
 
 ## DTMF
 
-### `SendDigits(digits string, opts ...DigitOption) (map[string]any, error)`
+### `SendDigits(digits string) error`
 
 Send DTMF tones.
 
@@ -217,32 +224,42 @@ call.SendDigits("1234#")
 
 ## Detection
 
-### `Detect(detect map[string]any, timeout int) *DetectAction`
+### `Detect(detect map[string]any, timeout *float64, controlID ...string) *DetectAction`
 
-Detect machine, fax, or digits. `timeout` is in seconds; pass `0` for the
-server default.
+Detect machine, fax, or digits. `timeout` is a `*float64` (seconds); pass
+`nil` for the server default. The optional `controlID` overrides the
+auto-generated control identifier.
 
 ```go
+timeout := 30.0
 action := call.Detect(
 	map[string]any{"type": "machine"},
-	30, // seconds
+	&timeout,
 )
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
+```
+
+Typed helpers cover the common cases with functional options:
+
+```go
+call.DetectAnsweringMachine(relay.WithAMDInitialTimeout(4.5)) // *DetectAction
+call.DetectDigit()                                            // *DetectAction
+call.DetectFax()                                              // *DetectAction
 ```
 
 ## SIP Refer
 
-### `Refer(device map[string]any, opts ...ReferOption) (map[string]any, error)`
+### `Refer(device map[string]any, statusURL string) error`
 
-Transfer via SIP REFER.
+Transfer via SIP REFER. Pass an empty `statusURL` for no status callback.
 
 ```go
-call.Refer(map[string]any{"type": "sip", "params": map[string]any{"to": "sip:user@example.com"}})
+call.Refer(map[string]any{"type": "sip", "params": map[string]any{"to": "sip:user@example.com"}}, "")
 ```
 
 ## Transfer
 
-### `Transfer(dest string) (map[string]any, error)`
+### `Transfer(dest string) error`
 
 Transfer call control to another RELAY app or SWML script.
 
@@ -252,21 +269,21 @@ call.Transfer("https://example.com/swml-endpoint")
 
 ## Fax
 
-### `SendFax(document, identity string) *FaxAction`
+### `SendFax(document, identity string, opts ...FaxOption) *FaxAction`
 
 ```go
 action := call.SendFax(
 	"https://example.com/document.pdf",
 	"+15551234567", // caller identity
 )
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 ```
 
 ### `ReceiveFax(opts ...FaxOption) *FaxAction`
 
 ```go
 action := call.ReceiveFax()
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 ```
 
 ## Tap (Media Interception)
@@ -299,22 +316,23 @@ action.Stop()
 
 ## Payment
 
-### `Pay(connectorURL, amount, currency string) *PayAction`
+### `Pay(connectorURL string, opts ...PayOption) *PayAction`
 
-Collect a payment via DTMF.
+Collect a payment via DTMF. Amount, currency, prompts, etc. are supplied
+through functional options.
 
 ```go
 action := call.Pay(
 	"https://pay.example.com",
-	"25.99",
-	"usd",
+	relay.WithPayChargeAmount("25.99"),
+	relay.WithPayCurrency("usd"),
 )
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 ```
 
 ## Conference
 
-### `JoinConference(name string, opts ...ConferenceOption) (map[string]any, error)`
+### `JoinConference(name string, opts ...ConferenceOption) error`
 
 ```go
 call.JoinConference("my_conference",
@@ -323,7 +341,7 @@ call.JoinConference("my_conference",
 )
 ```
 
-### `LeaveConference(conferenceID string) (map[string]any, error)`
+### `LeaveConference(confID string) error`
 
 ```go
 call.LeaveConference("conf-123")
@@ -331,7 +349,7 @@ call.LeaveConference("conf-123")
 
 ## Hold
 
-### `Hold() (map[string]any, error)` / `Unhold() (map[string]any, error)`
+### `Hold() error` / `Unhold() error`
 
 ```go
 call.Hold()
@@ -341,7 +359,7 @@ call.Unhold()
 
 ## Denoise
 
-### `Denoise() (map[string]any, error)` / `DenoiseStop() (map[string]any, error)`
+### `Denoise() error` / `DenoiseStop() error`
 
 ```go
 call.Denoise()
@@ -361,27 +379,29 @@ action.Stop()
 
 ## Live Transcribe / Translate
 
-### `LiveTranscribe(actionObj map[string]any) (map[string]any, error)`
+### `LiveTranscribe(action map[string]any) error`
 
 ```go
 call.LiveTranscribe(map[string]any{"start": map[string]any{"language": "en-US"}})
 ```
 
-### `LiveTranslate(actionObj map[string]any, opts ...TranslateOption) (map[string]any, error)`
+### `LiveTranslate(action map[string]any, statusURL string) error`
 
 ```go
-call.LiveTranslate(map[string]any{"start": map[string]any{"source": "en-US", "target": "es"}})
+call.LiveTranslate(map[string]any{"start": map[string]any{"source": "en-US", "target": "es"}}, "")
 ```
 
 ## Echo
 
-### `Echo(timeout int) (map[string]any, error)`
+### `Echo(timeout *float64, statusURL string) error`
 
-Echo audio back to the caller (useful for testing). `timeout` is in seconds
-(pass `0` for the server default).
+Echo audio back to the caller (useful for testing). `timeout` is a
+`*float64` (seconds); pass `nil` for the server default. Pass an empty
+`statusURL` for no status callback.
 
 ```go
-call.Echo(30)
+timeout := 30.0
+call.Echo(&timeout, "")
 ```
 
 ## AI Agent
@@ -395,30 +415,39 @@ action := call.AI(
 	relay.WithAIPrompt(map[string]any{"text": "You are a helpful support agent."}),
 	relay.WithAIParams(map[string]any{"end_of_speech_timeout": 3000}),
 )
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 ```
 
-### `AmazonBedrock(opts ...AIOption) (map[string]any, error)`
+### `AmazonBedrock(opts ...AIOption) *AIAction`
 
 Connect to an Amazon Bedrock AI agent.
 
-### `AIMessage(opts ...AIMessageOption) (map[string]any, error)`
+### `AIMessage(controlID, text, role string, reset, globalData map[string]any) error`
 
 Send a message to an active AI session.
 
-### `AIHold(opts ...AIHoldOption) (map[string]any, error)` / `AIUnhold(opts ...AIUnholdOption) (map[string]any, error)`
+```go
+call.AIMessage("ai-1", "Transfer me to billing", "user", nil, nil)
+```
+
+### `AIHold(controlID, timeout, prompt string) error` / `AIUnhold(controlID, prompt string) error`
 
 Put an AI session on/off hold.
 
-## Rooms
-
-### `JoinRoom(name string, opts ...RoomOption) (map[string]any, error)`
-
 ```go
-call.JoinRoom("my_room")
+call.AIHold("ai-1", "60", "Please wait while I transfer you.")
+call.AIUnhold("ai-1", "I'm back, how can I help?")
 ```
 
-### `LeaveRoom() (map[string]any, error)`
+## Rooms
+
+### `JoinRoom(name string, statusURL string) error`
+
+```go
+call.JoinRoom("my_room", "")
+```
+
+### `LeaveRoom() error`
 
 ```go
 call.LeaveRoom()
@@ -426,34 +455,35 @@ call.LeaveRoom()
 
 ## Queue
 
-### `QueueEnter(queueName string, opts ...QueueOption) (map[string]any, error)`
+### `QueueEnter(name string, statusURL string) error`
 
 ```go
-call.QueueEnter("support")
+call.QueueEnter("support", "")
 ```
 
-### `QueueLeave(queueName string) (map[string]any, error)`
+### `QueueLeave(name string, queueID string, statusURL string) error`
 
 ```go
-call.QueueLeave("support")
+call.QueueLeave("support", "", "")
 ```
 
 ## Digit Bindings
 
-### `BindDigit(digits, method string, params map[string]any) (map[string]any, error)`
+### `BindDigit(digits, method string, bindParams map[string]any, realm string, maxTriggers int) error`
 
-Bind a DTMF sequence to trigger a RELAY method.
+Bind a DTMF sequence to trigger a RELAY method. Pass an empty `realm` for
+the default and `0` for unlimited triggers.
 
 ```go
 call.BindDigit("*1", "calling.play", map[string]any{
 	"play": []map[string]any{{"type": "tts", "params": map[string]any{"text": "You pressed star-1"}}},
-})
+}, "", 0)
 ```
 
-### `ClearDigitBindings() (map[string]any, error)`
+### `ClearDigitBindings(realm string) error`
 
 ```go
-call.ClearDigitBindings()
+call.ClearDigitBindings("")
 ```
 
 ## User Events
@@ -495,17 +525,32 @@ defer cancel()
 event, err := call.WaitFor(ctx, "calling.call.play", nil)
 ```
 
-### End-of-call event
+### State-change convenience helpers
 
-`Call` only exposes an explicit `WaitFor` helper; to wait for the call to
-end, filter on the state-change event:
+`Call` provides typed helpers for the common state transitions, each
+returning `(*relay.RelayEvent, error)`:
+
+| Helper | Resolves when |
+|--------|---------------|
+| `WaitForRinging(ctx)` | the call starts ringing |
+| `WaitForAnswered(ctx)` | the call is answered |
+| `WaitForEnding(ctx)` | the call begins ending |
+| `WaitForEnded(ctx)` | the call has ended |
 
 ```go
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 defer cancel()
+event, err := call.WaitForEnded(ctx)
+if err == nil {
+	fmt.Printf("End reason: %v\n", event.Params["end_reason"])
+}
+```
+
+You can also filter the raw state-change event yourself with `WaitFor`:
+
+```go
 event, err := call.WaitFor(ctx, "calling.call.state", func(e *relay.RelayEvent) bool {
 	state, _ := e.Params["call_state"].(string)
 	return state == "ended"
 })
-fmt.Printf("End reason: %v\n", event.Params["end_reason"])
 ```

--- a/relay/docs/client-reference.md
+++ b/relay/docs/client-reference.md
@@ -13,7 +13,7 @@ client := relay.NewRelayClient(opts ...ClientOption)
 | `WithProject(id)` | `SIGNALWIRE_PROJECT_ID` | Project ID for authentication |
 | `WithToken(token)` | `SIGNALWIRE_API_TOKEN` | API token for authentication |
 | `WithJWT(jwt)` | `SIGNALWIRE_JWT_TOKEN` | JWT token (alternative to project/token) |
-| `WithSpace(host)` | `SIGNALWIRE_SPACE` | Space hostname (default: `relay.signalwire.com`) |
+| `WithSpace(host)` | `SIGNALWIRE_SPACE` | Space hostname (e.g. `example.signalwire.com`; a bare name has `.signalwire.com` appended) |
 | `WithContexts(ctx...)` | -- | Topics to subscribe to |
 | `WithMaxActiveCalls(n)` | `RELAY_MAX_ACTIVE_CALLS` | Max concurrent calls (default: 1000) |
 
@@ -123,9 +123,7 @@ to change.
 
 ## Concurrency
 
-Each inbound call handler runs in its own goroutine, so multiple calls are handled concurrently. The `WithMaxActiveCalls()` option (default: 1000) caps concurrent calls to prevent unbounded goroutine growth.
-
-For multiple WebSocket connections in one process, set `RELAY_MAX_CONNECTIONS` (default: 1).
+Each inbound call handler runs in its own goroutine, so multiple calls are handled concurrently. The `WithMaxActiveCalls()` option (default: 1000, or the `RELAY_MAX_ACTIVE_CALLS` env var) caps concurrent calls to prevent unbounded goroutine growth.
 
 ## Error Handling
 
@@ -141,7 +139,11 @@ if err != nil {
 }
 ```
 
-`RelayError` is returned when the server returns a non-2xx response code. Errors 404 and 410 (call gone) are silently swallowed by Call methods since the call no longer exists.
+`RelayError` carries the numeric `Code` and `Message` the RELAY server
+returned for a failed command (its `Error()` string is formatted as
+`RELAY error {code}: {message}`). A `RelayError` may also wrap a sentinel
+(such as `relay.ErrDialTimeout`) so the same value satisfies both
+`errors.As(err, &relayErr)` and `errors.Is(err, relay.ErrDialTimeout)`.
 
 ## Graceful Shutdown
 

--- a/relay/docs/events.md
+++ b/relay/docs/events.md
@@ -36,7 +36,7 @@ Actions returned by `Play()`, `Record()`, etc. have a `Wait()` method that resol
 action := call.Play([]map[string]any{
 	{"type": "tts", "params": map[string]any{"text": "Hello"}},
 })
-event := action.Wait(context.Background())
+event, _ := action.Wait(context.Background())
 // event is a *RelayEvent with the terminal state
 ```
 
@@ -46,26 +46,28 @@ All event type constants are defined in the `relay` package:
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `EventCallState` | `calling.call.state` | Call state changes (created, ringing, answered, ending, ended) |
-| `EventCallReceive` | `calling.call.receive` | Inbound call notification |
-| `EventCallPlay` | `calling.call.play` | Play operation state changes |
-| `EventCallRecord` | `calling.call.record` | Record operation state changes |
-| `EventCallCollect` | `calling.call.collect` | Input collection results |
-| `EventCallConnect` | `calling.call.connect` | Bridge/connect state changes |
-| `EventCallDetect` | `calling.call.detect` | Detection results |
-| `EventCallFax` | `calling.call.fax` | Fax operation state changes |
-| `EventCallTap` | `calling.call.tap` | Tap operation state changes |
-| `EventCallStream` | `calling.call.stream` | Stream operation state changes |
-| `EventCallSendDigits` | `calling.call.send_digits` | DTMF send completion |
-| `EventCallDial` | `calling.call.dial` | Outbound dial progress |
-| `EventCallRefer` | `calling.call.refer` | SIP REFER results |
-| `EventCallDenoise` | `calling.call.denoise` | Denoise state changes |
-| `EventCallPay` | `calling.call.pay` | Payment state changes |
-| `EventCallQueue` | `calling.call.queue` | Queue state changes |
-| `EventCallEcho` | `calling.call.echo` | Echo state changes |
-| `EventCallTranscribe` | `calling.call.transcribe` | Transcription state changes |
-| `EventConference` | `calling.conference` | Conference state changes |
-| `EventCallingError` | `calling.error` | Error events |
+| `EventCallingCallState` | `calling.call.state` | Call state changes (created, ringing, answered, ending, ended) |
+| `EventCallingCallReceive` | `calling.call.receive` | Inbound call notification |
+| `EventCallingCallPlay` | `calling.call.play` | Play operation state changes |
+| `EventCallingCallRecord` | `calling.call.record` | Record operation state changes |
+| `EventCallingCallCollect` | `calling.call.collect` | Input collection results |
+| `EventCallingCallConnect` | `calling.call.connect` | Bridge/connect state changes |
+| `EventCallingCallDetect` | `calling.call.detect` | Detection results |
+| `EventCallingCallFax` | `calling.call.fax` | Fax operation state changes |
+| `EventCallingCallTap` | `calling.call.tap` | Tap operation state changes |
+| `EventCallingCallStream` | `calling.call.stream` | Stream operation state changes |
+| `EventCallingCallSendDigits` | `calling.call.send_digits` | DTMF send completion |
+| `EventCallingCallDial` | `calling.call.dial` | Outbound dial progress |
+| `EventCallingCallRefer` | `calling.call.refer` | SIP REFER results |
+| `EventCallingCallDenoise` | `calling.call.denoise` | Denoise state changes |
+| `EventCallingCallPay` | `calling.call.pay` | Payment state changes |
+| `EventCallingCallQueue` | `calling.call.queue` | Queue state changes |
+| `EventCallingCallEcho` | `calling.call.echo` | Echo state changes |
+| `EventCallingCallTranscribe` | `calling.call.transcribe` | Transcription state changes |
+| `EventCallingCallHold` | `calling.call.hold` | Hold/unhold state changes |
+| `EventCallingCallAI` | `calling.call.ai` | AI agent session events |
+| `EventCallingCallConference` | `calling.conference` | Conference state changes |
+| `EventCallingCallError` | `calling.error` | Error events |
 | `EventMessagingReceive` | `messaging.receive` | Inbound message received |
 | `EventMessagingState` | `messaging.state` | Outbound message state change |
 
@@ -77,7 +79,7 @@ Raw events are always `*RelayEvent` with a `Params` map. For convenience, typed 
 import "github.com/signalwire/signalwire-go/pkg/relay"
 
 // The event arrives as a *RelayEvent with an EventType and Params map.
-if event.EventType == relay.EventCallState {
+if event.EventType == relay.EventCallingCallState {
 	// Promote the generic event to its typed struct by passing the
 	// Params map to the matching New<EventName> factory.
 	stateEvent := relay.NewCallStateEvent(event.Params)
@@ -156,7 +158,7 @@ client.OnCall(func(call *relay.Call) {
 	go func() {
 		for {
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-			event, err := call.WaitFor(ctx, relay.EventCallState, nil)
+			event, err := call.WaitFor(ctx, relay.EventCallingCallState, nil)
 			cancel()
 			if err != nil {
 				return // timeout or call ended
@@ -183,15 +185,15 @@ client.OnCall(func(call *relay.Call) {
 client.OnCall(func(call *relay.Call) {
 	call.Answer()
 
-	call.On(relay.EventCallPlay, func(event *relay.RelayEvent) {
+	call.On(relay.EventCallingCallPlay, func(event *relay.RelayEvent) {
 		fmt.Printf("Play state: %v\n", event.Params["state"])
 	})
 
-	call.On(relay.EventCallRecord, func(event *relay.RelayEvent) {
+	call.On(relay.EventCallingCallRecord, func(event *relay.RelayEvent) {
 		fmt.Printf("Record state: %v\n", event.Params["state"])
 	})
 
-	call.On(relay.EventCallingError, func(event *relay.RelayEvent) {
+	call.On(relay.EventCallingCallError, func(event *relay.RelayEvent) {
 		fmt.Printf("Error: %v\n", event.Params["message"])
 	})
 

--- a/relay/docs/getting-started.md
+++ b/relay/docs/getting-started.md
@@ -24,7 +24,7 @@ Alternatively, you can authenticate with a JWT token:
 
 | Parameter | Env Var | Description |
 |-----------|---------|-------------|
-| `WithJWTToken()` | `SIGNALWIRE_JWT_TOKEN` | A SignalWire JWT auth token |
+| `WithJWT()` | `SIGNALWIRE_JWT_TOKEN` | A SignalWire JWT auth token |
 
 ## Minimal Example
 

--- a/relay/docs/messaging.md
+++ b/relay/docs/messaging.md
@@ -32,7 +32,7 @@ if err != nil {
 	fmt.Printf("Send failed: %v\n", err)
 	return
 }
-event := message.Wait(context.Background()) // blocks until delivered/failed
+message.Wait(context.Background()) // blocks until delivered/failed
 fmt.Printf("Final state: %s\n", message.State())
 if message.Reason() != "" {
 	fmt.Printf("Reason: %s\n", message.Reason())
@@ -64,7 +64,7 @@ if err != nil {
 }
 
 go func() {
-	event := message.Wait(context.Background())
+	event, _ := message.Wait(context.Background())
 	state, _ := event.Params["message_state"].(string)
 	fmt.Printf("Delivery: %s\n", state)
 }()
@@ -117,18 +117,18 @@ func main() {
 	)
 
 	client.OnMessage(func(message *relay.Message) {
-		fmt.Printf("From: %s\n", message.FromNumber)
-		fmt.Printf("To: %s\n", message.ToNumber)
-		fmt.Printf("Body: %s\n", message.Body)
-		if len(message.Media) > 0 {
-			fmt.Printf("Media: %v\n", message.Media)
+		fmt.Printf("From: %s\n", message.FromNumber())
+		fmt.Printf("To: %s\n", message.ToNumber())
+		fmt.Printf("Body: %s\n", message.Body())
+		if len(message.Media()) > 0 {
+			fmt.Printf("Media: %v\n", message.Media())
 		}
 
 		// Reply back
 		client.SendMessage(
-			message.FromNumber,
-			message.ToNumber,
-			fmt.Sprintf("You said: %s", message.Body),
+			message.FromNumber(),
+			message.ToNumber(),
+			fmt.Sprintf("You said: %s", message.Body()),
 		)
 	})
 
@@ -138,25 +138,28 @@ func main() {
 
 ## Message Object
 
-### Properties
+### Accessors
 
-| Property | Type | Description |
+These are methods (not fields) -- call them with `()`:
+
+| Accessor | Type | Description |
 |----------|------|-------------|
-| `MessageID` | `string` | Unique message identifier |
-| `Context` | `string` | Context the message belongs to |
-| `Direction` | `string` | `inbound` or `outbound` |
-| `FromNumber` | `string` | Sender phone number (E.164) |
-| `ToNumber` | `string` | Recipient phone number (E.164) |
-| `Body` | `string` | Text body of the message |
-| `Media` | `[]string` | Media URLs (MMS) |
-| `Segments` | `int` | Number of message segments |
-| `Tags` | `[]string` | Tags attached to the message |
+| `MessageID()` | `string` | Unique message identifier |
+| `Context()` | `string` | Context the message belongs to |
+| `Direction()` | `string` | `inbound` or `outbound` |
+| `FromNumber()` | `string` | Sender phone number (E.164) |
+| `ToNumber()` | `string` | Recipient phone number (E.164) |
+| `Body()` | `string` | Text body of the message |
+| `Media()` | `[]string` | Media URLs (MMS) |
+| `Segments()` | `int` | Number of message segments |
+| `Tags()` | `[]string` | Tags attached to the message |
+| `MessageState()` | `MessageState` | State as a typed `MessageState` value |
 
 ### Methods
 
 | Method | Description |
 |--------|-------------|
-| `message.Wait(ctx)` | Block until terminal state. Returns the terminal `*RelayEvent`. |
+| `message.Wait(ctx)` | Block until terminal state. Returns `(*RelayEvent, error)`. |
 | `message.State()` | Current message state as a string. |
 | `message.Reason()` | Failure reason (on `undelivered` or `failed`). |
 | `message.IsDone()` | `true` if message reached a terminal state. |

--- a/rest/docs/README.md
+++ b/rest/docs/README.md
@@ -1,15 +1,15 @@
 # REST Client Documentation
 
-Detailed documentation for the SignalWire REST client lives alongside the Go source code in the `pkg/rest/docs/` directory.
+Detailed documentation for the SignalWire REST client.
 
 ## Available Guides
 
-- [Getting Started](../../pkg/rest/docs/getting-started.md) -- installation, environment variables, first API call
-- [Client Reference](../../pkg/rest/docs/client-reference.md) -- `NewRestClient` constructor, namespace layout, error handling
-- [Fabric Resources](../../pkg/rest/docs/fabric.md) -- managing AI agents, SWML scripts, subscribers, call flows, and more
-- [Calling Commands](../../pkg/rest/docs/calling.md) -- REST-based call control (dial, play, record, collect, AI, etc.)
-- [Compatibility API](../../pkg/rest/docs/compat.md) -- Twilio-compatible LAML endpoints
-- [All Namespaces](../../pkg/rest/docs/namespaces.md) -- phone numbers, video, datasphere, logs, registry, and more
+- [Getting Started](getting-started.md) -- installation, environment variables, first API call
+- [Client Reference](client-reference.md) -- `NewRestClient` constructor, namespace layout, error handling
+- [Fabric Resources](fabric.md) -- managing AI agents, SWML scripts, subscribers, call flows, and more
+- [Calling Commands](calling.md) -- REST-based call control (dial, play, record, collect, AI, etc.)
+- [Compatibility API](compat.md) -- Twilio-compatible LAML endpoints
+- [All Namespaces](namespaces.md) -- phone numbers, video, datasphere, logs, registry, and more
 
 ## Quick Links
 

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -59,12 +59,13 @@ Transfer a call to a new destination.
 client.Calling.Transfer(callID, map[string]any{"dest": "sip:agent@example.com"})
 ```
 
-### `Disconnect(callID string) (map[string]any, error)`
+### `Disconnect(callID string, params map[string]any) (map[string]any, error)`
 
-Disconnect bridged calls without hanging up either leg.
+Disconnect bridged calls without hanging up either leg. Pass `nil` for
+`params` when no extra fields are needed.
 
 ```go
-client.Calling.Disconnect(callID)
+client.Calling.Disconnect(callID, nil)
 ```
 
 ## Audio Playback
@@ -174,8 +175,8 @@ client.Calling.StreamStop(callID, map[string]any{"control_id": "str-1"})
 ### `Denoise` / `DenoiseStop`
 
 ```go
-client.Calling.Denoise(callID)
-client.Calling.DenoiseStop(callID)
+client.Calling.Denoise(callID, nil)
+client.Calling.DenoiseStop(callID, nil)
 ```
 
 ## Transcription
@@ -257,7 +258,7 @@ client.Calling.UserEvent(callID, map[string]any{
 | `Update(params)` | `update` | No |
 | `End(callID, params)` | `calling.end` | Yes |
 | `Transfer(callID, params)` | `calling.transfer` | Yes |
-| `Disconnect(callID)` | `calling.disconnect` | Yes |
+| `Disconnect(callID, params)` | `calling.disconnect` | Yes |
 | `Play(callID, params)` | `calling.play` | Yes |
 | `PlayPause(callID, params)` | `calling.play.pause` | Yes |
 | `PlayResume(callID, params)` | `calling.play.resume` | Yes |
@@ -276,8 +277,8 @@ client.Calling.UserEvent(callID, map[string]any{
 | `TapStop(callID, params)` | `calling.tap.stop` | Yes |
 | `Stream(callID, params)` | `calling.stream` | Yes |
 | `StreamStop(callID, params)` | `calling.stream.stop` | Yes |
-| `Denoise(callID)` | `calling.denoise` | Yes |
-| `DenoiseStop(callID)` | `calling.denoise.stop` | Yes |
+| `Denoise(callID, params)` | `calling.denoise` | Yes |
+| `DenoiseStop(callID, params)` | `calling.denoise.stop` | Yes |
 | `Transcribe(callID, params)` | `calling.transcribe` | Yes |
 | `TranscribeStop(callID, params)` | `calling.transcribe.stop` | Yes |
 | `AIMessage(callID, params)` | `calling.ai_message` | Yes |

--- a/rest/docs/client-reference.md
+++ b/rest/docs/client-reference.md
@@ -32,7 +32,7 @@ Every API surface is available as a namespace attribute on the client:
 | `client.Fabric.RelayApplications` | Relay application resources |
 | `client.Fabric.CallFlows` | Call flow resources (+ versions) |
 | `client.Fabric.ConferenceRooms` | Conference room resources |
-| `client.Fabric.FreeSWITCHConnectors` | FreeSWITCH connector resources |
+| `client.Fabric.FreeSwitchConnectors` | FreeSWITCH connector resources |
 | `client.Fabric.Subscribers` | Subscriber resources (+ SIP endpoints) |
 | `client.Fabric.SIPEndpoints` | SIP endpoint resources |
 | `client.Fabric.SIPGateways` | SIP gateway resources |
@@ -93,7 +93,7 @@ if err != nil {
 	var restErr *rest.SignalWireRestError
 	if errors.As(err, &restErr) {
 		fmt.Println(restErr.StatusCode) // 404
-		fmt.Println(restErr.Body)       // map[error:not found]
+		fmt.Println(restErr.Body)       // `{"error":"not found"}` (raw response body)
 		fmt.Println(restErr.URL)        // "/api/fabric/resources/ai_agents/bad-id"
 		fmt.Println(restErr.Method)     // "GET"
 	}
@@ -107,7 +107,7 @@ if err != nil {
 | Field | Type | Description |
 |-------|------|-------------|
 | `StatusCode` | `int` | HTTP status code |
-| `Body` | `any` | Response body (parsed JSON map or raw string) |
+| `Body` | `string` | Raw response body |
 | `URL` | `string` | Request path |
 | `Method` | `string` | HTTP method |
 

--- a/rest/docs/getting-started.md
+++ b/rest/docs/getting-started.md
@@ -124,8 +124,8 @@ agent, err := client.Fabric.AIAgents.Get("nonexistent-id")
 if err != nil {
 	var restErr *rest.SignalWireRestError
 	if errors.As(err, &restErr) {
-		fmt.Printf("HTTP %d: %v\n", restErr.StatusCode, restErr.Body)
-		// HTTP 404: map[error:not found]
+		fmt.Printf("HTTP %d: %s\n", restErr.StatusCode, restErr.Body)
+		// HTTP 404: {"error":"not found"}
 	}
 }
 ```


### PR DESCRIPTION
## Summary

Content/consistency audit of the top-level `README.md` against the actual `pkg/` surface (post PR #229 behavior bundle), using the Python SDK README as the reference structure. No new gate added.

## Findings & fixes

**Fixed (real defects):**
- **Stale Go version** — README said "Requires Go 1.22 or later"; `go.mod` declares `go 1.25.0`. Corrected to "1.25 or later".
- **REST example would not compile** — `client.PhoneNumbers.Search(map[string]string{...})` but the real signature is `Search(params map[string]any)`. Corrected the snippet to `map[string]any`.

**Verified accurate — left unchanged (counts re-counted in `pkg/`):**
- "21 namespaced API surfaces" — `RestClient` has exactly 21 namespace fields.
- Fabric "13 resource types" — consistent with `rest/README.md` (13 CRUD resources + addresses/tokens/generic helpers).
- Calling "37 commands" — exactly 37 exported methods on `CallingNamespace`.
- RELAY "57+ methods" — `Call` has 66; the conservative lower bound is fine.
- Every example identifier exists: `NewAgentBase`/`WithName`/`WithRoute`, `AddLanguage`, `SetPromptText`, `DefineTool`/`ToolDefinition`/`ToolHandler`, `swaig.NewFunctionResult`, `AddSkill`, `PromptAddSection`, `AsRouter`, `relay.NewRelayClient` (returns `*Client`) `.OnCall`/`.Run`, `Call.Answer`/`Play` (`*PlayAction` embeds `*Action`) `.Wait(ctx)`/`.Hangup`, `rest.NewRestClient`, `Fabric.AIAgents.Create`, `Calling.Dial`.
- All relative links resolve (`docs/*.md`, `relay/README.md`, `rest/README.md`, `examples/README.md`, `LICENSE`); all example dirs in the table exist; `swaig-test` flags (`--list-tools`/`--dump-swml`/`--exec`) are real. No dead links found.

## Python-only sections deliberately omitted (Go lacks the feature — accuracy over symmetry)
- **Search System** docs section + the **Local search** feature bullet + the `pip install [search-*]` block. Go's `native_vector_search` skill queries a **remote** search server; the Go port has no local `.swsearch` index building, so the offline-search surface does not apply.
- **Tutorials** section — no `tutorial/` directory exists in the Go port.

## DOC-AUDIT result
`porting-sdk/scripts/audit_docs.py` vs `port_surface_go.json`: **PASS**.
- `docs/`+`examples/` scope: 1029 symbols resolved, 0 drift.
- README's own fenced code blocks (scoped in for this audit): 13 resolved, no phantom symbols. (The top-level README is not in DOC-AUDIT's default `DEFAULT_DOC_DIRS`, so README claims were additionally verified by hand against `pkg/`.)

**Do NOT merge** — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)