### PR TITLE
chore(lint): enable gosec/bodyclose/nilerr/nilnil/exhaustive bug-finders; fix Slowloris DoS on both HTTP servers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,18 +44,31 @@ linters:
     - reassign         # reassigning stdlib/pkg-level vars
     - recvcheck        # mixed value/pointer receivers on one type
     - wastedassign     # assignments whose value is never read (clean today)
+    # Bug-finder tier — adopted after a SECOND measured survey (the "lint
+    # bug-finders" sweep) of 7 not-yet-enabled bug-finders, at a LOW keep
+    # threshold: keep a linter if it could plausibly catch even ONE real bug
+    # someday (the //nolint noise tax is acceptable); drop only pure noise.
+    # gosec found a GENUINE prod bug — the Slowloris/ReadHeaderTimeout gap on
+    # BOTH HTTP servers (now fixed); the rest are clean-today regression guards.
+    - gosec            # security: caught G112 Slowloris (no ReadHeaderTimeout) on both servers — FIXED; guards SSRF/weak-crypto/path-traversal. Test+codegen paths excluded below; genuine prod FPs carry //nolint:gosec with the G-code reason.
+    - bodyclose        # leaked HTTP response bodies — clean after 1 //nolint on the gorilla/websocket dial (lib closes the handshake body) + 3 expect-failure TLS tests (resp is nil on the error path)
+    - nilerr           # `if err != nil { return nil }` — the real swallowed-error bug class; the 5 sites are the filepath.Walk continue idiom + a CLI raw-output fallback (//nolint'd)
+    - nilnil           # `return nil, nil` ambiguity — the 3 sites are intentional "absent, not an error" (no-result SWAIG handler / selector matched nothing) //nolint'd
+    - exhaustive       # missing enum switch arm (the "added a value, forgot the case" bug) — default-signifies-exhaustive (below) + one //exhaustive:ignore cover the by-design subset switches
   # DELIBERATELY NOT ADOPTED (measured + sampled — they fire on idiomatic Go in
   # this codebase, 0 real issues; adopting would mean //nolint on correct code):
-  #   nilerr        — flags the filepath.Walk continue-on-error idiom + graceful
-  #                   fallbacks (return nil to keep walking is correct).
   #   contextcheck  — flags the defensive `if ctx == nil { ctx = Background() }`
-  #                   guard on RunContext/DialContext, which DO honor the caller's ctx.
-  #   nilnil        — flags `return nil, nil` meaning "absent, and not an error"
-  #                   (a tool with no output / a selector matching nothing).
+  #                   guard on RunContext/DialContext (+ the deliberate Background()
+  #                   drain that must outlive a cancelled ctx), which DO honor the
+  #                   caller's ctx. Re-probed in the bug-finder sweep: 6 findings,
+  #                   all that idiom, 0 real ctx-drop — no realistic true positive.
+  #   noctx         — would force NewRequestWithContext everywhere, but the
+  #                   SWAIG/skill handler API (func(args, rawData) any) is
+  #                   context-free by Python parity, so the prod call sites can
+  #                   NEVER thread a caller ctx. Re-probed: 103 findings (88 tests,
+  #                   15 structurally-unfixable prod), 0 real bugs — pure noise here.
   #   unparam       — flags test-helper params that are constant because the
   #                   helper has one caller; not a real defect.
-  #   bodyclose     — all sites are expect-failure TLS tests (untrusted.Get that
-  #                   must error) where there is no response body to close.
   #   goprintffuncname — would rename logger.Debug/Info/Warn/Error to *f; those
   #                   are public API named to mirror Python's logger.debug/info,
   #                   so renaming both breaks the API and diverges from parity.
@@ -83,3 +96,31 @@ linters:
         #     embedded `Service` qualifier is a readability downgrade, not a fix.
         - -QF1001
         - -QF1008
+    exhaustive:
+      # A switch with a `default:` is treated as exhaustive. Every flagged
+      # switch here deliberately handles a SUBSET of its enum and routes the
+      # rest through `default` (math.go's calculator over go/token.Token,
+      # route-registry over reflect.Kind, platformBaseURL over ExecutionMode) —
+      # so a `default` is the correct, intentional shape, not a missing arm.
+      # The one default-less subset switch (MessageState.IsTerminal) carries an
+      # //exhaustive:ignore with its rationale. exhaustive still fires on a
+      # genuinely missing arm in a default-less switch — the bug we want caught.
+      default-signifies-exhaustive: true
+  exclusions:
+    rules:
+      # gosec on TEST files: hardcoded test credentials (G101), and the
+      # subprocess / file-inclusion / file-perm patterns in test + mock
+      # harnesses (G204/G304/G306/G705) are test-only and not production attack
+      # surface. Scoped here rather than scattering ~40 //nolint across tests.
+      - path: _test\.go
+        linters:
+          - gosec
+      # gosec on DEV/CODEGEN tooling and internal mock harnesses — not shipped,
+      # not production attack surface. `cmd/*`: signature/surface enumerators,
+      # swaig-test CLI, emit-skills, route-registry. `internal/*`: top-level
+      # internal/surface (the doc-symbol mapping tables that trip G101 on
+      # method-name strings) AND pkg/{relay,rest}/internal/mocktest (test mock
+      # servers — those internal dirs contain only the mocktest harness).
+      - path: (^|/)(cmd|internal)/
+        linters:
+          - gosec

--- a/cmd/swaig-test/main.go
+++ b/cmd/swaig-test/main.go
@@ -503,9 +503,10 @@ func doExec(baseURL, user, pass string, cfg config) error {
 
 	output, err := formatJSON(body, cfg.raw)
 	if err != nil {
-		// If JSON formatting fails, print the raw response
+		// CLI graceful fallback: if pretty-printing fails, emit the raw response
+		// body (still useful to the user) and exit success.
 		fmt.Println(string(body))
-		return nil
+		return nil //nolint:nilerr // intentional: raw body already emitted above
 	}
 
 	fmt.Println(output)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/signalwire/signalwire-go/pkg/contexts"
 	"github.com/signalwire/signalwire-go/pkg/logging"
@@ -1074,6 +1075,8 @@ func (a *AgentBase) OnFunctionCall(name string, args map[string]any, rawData map
 	}
 	result := tool.Handler(args, rawData)
 	if result == nil {
+		//nolint:nilnil // a SWAIG handler legitimately produces no result and no
+		// error (mirrors Python's handler returning None); not an error condition.
 		return nil, nil
 	}
 	return result.ToMap(), nil
@@ -3117,6 +3120,11 @@ func (a *AgentBase) buildAndServe() error {
 	server := &http.Server{
 		Addr:    addr,
 		Handler: mux,
+		// Bound the request-header read so a slow/incomplete header write
+		// (Slowloris) cannot pin a connection open indefinitely. net/http
+		// applies no header-read deadline by default, so this must be set
+		// explicitly. 20s is generous for a well-behaved SignalWire client.
+		ReadHeaderTimeout: 20 * time.Second,
 	}
 
 	// If SetupGracefulShutdown is active, spin a goroutine that waits for
@@ -3124,7 +3132,9 @@ func (a *AgentBase) buildAndServe() error {
 	go func() {
 		<-ch
 		a.Logger.Info("graceful shutdown: stopping HTTP server")
-		server.Shutdown(context.Background()) //nolint:errcheck
+		if err := server.Shutdown(context.Background()); err != nil {
+			a.Logger.Warn("graceful shutdown: server.Shutdown returned: %s", err)
+		}
 	}()
 
 	err := server.ListenAndServe()

--- a/pkg/livewire/livewire.go
+++ b/pkg/livewire/livewire.go
@@ -59,6 +59,8 @@ var tips = []string{
 }
 
 func printTip() {
+	//nolint:gosec // G404: math/rand is fine here — picking a cosmetic "did you
+	// know" tip to print, no security/crypto context.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	tip := tips[r.Intn(len(tips))]
 	fmt.Fprintf(os.Stderr, "\n\U0001f4a1 Did you know?  %s\n\n", tip)

--- a/pkg/relay/client.go
+++ b/pkg/relay/client.go
@@ -595,6 +595,9 @@ func (c *Client) connect() error {
 	}
 
 	header := http.Header{}
+	//nolint:bodyclose // gorilla/websocket: on a successful dial it closes the
+	// handshake response body itself; on failure (err != nil, handled below) the
+	// *http.Response body need not be closed per the DialContext contract.
 	conn, _, err := dialer.DialContext(c.ctx, url, header)
 	if err != nil {
 		return fmt.Errorf("websocket dial %s: %w", url, err)
@@ -617,6 +620,8 @@ func caPoolFromEnv(envVar string) *x509.CertPool {
 	if path == "" {
 		return nil
 	}
+	//nolint:gosec // G304: path is the operator-supplied CA-file env var, not
+	// attacker input — reading the configured CA bundle is the intended behavior.
 	pem, err := os.ReadFile(path)
 	if err != nil {
 		panic(fmt.Sprintf("read %s %q: %v", envVar, path, err))

--- a/pkg/relay/states.go
+++ b/pkg/relay/states.go
@@ -164,6 +164,10 @@ func (s MessageState) IsKnown() bool {
 // separate, behavior-only concern and is deliberately not folded into this
 // grounded predicate.
 func (s MessageState) IsTerminal() bool {
+	//exhaustive:ignore // only the three outbound-terminal states return true by
+	// design (mirrors Python's MESSAGE_TERMINAL_STATES); all other states —
+	// including any future additions — are correctly non-terminal via the
+	// trailing `return false`.
 	switch s {
 	case MsgDelivered, MsgUndelivered, MsgFailed:
 		return true

--- a/pkg/relay/tls_wss_mock_test.go
+++ b/pkg/relay/tls_wss_mock_test.go
@@ -88,6 +88,8 @@ func TestTLS_RelayClient_WSS(t *testing.T) {
 			TLSClientConfig:  &tls.Config{RootCAs: x509.NewCertPool()}, // empty pool
 		}
 		url := fmt.Sprintf("wss://127.0.0.1:%d/api/relay/ws", mock.wsPort)
+		//nolint:bodyclose // expect-failure test: the dial MUST fail (empty trust
+		// pool), so conn/resp are nil on the error path — nothing to close.
 		conn, _, err := dialer.Dial(url, http.Header{})
 		if err == nil {
 			_ = conn.Close()

--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -110,6 +110,8 @@ func caPoolFromEnv(envVar string) *x509.CertPool {
 	if path == "" {
 		return nil
 	}
+	//nolint:gosec // G304: path is the operator-supplied CA-file env var, not
+	// attacker input — reading the configured CA bundle is the intended behavior.
 	pem, err := os.ReadFile(path)
 	if err != nil {
 		panic(fmt.Sprintf("read %s %q: %v", envVar, path, err))

--- a/pkg/rest/namespaces/tls_https_mock_test.go
+++ b/pkg/rest/namespaces/tls_https_mock_test.go
@@ -72,6 +72,8 @@ func TestTLS_RestClient_HTTPS(t *testing.T) {
 				TLSClientConfig: &tls.Config{RootCAs: x509.NewCertPool()}, // empty pool
 			},
 		}
+		//nolint:bodyclose // expect-failure test: the request MUST fail (empty
+		// trust pool), so the response is nil on the error path — nothing to close.
 		_, err := untrusted.Get(baseURL + "/__mock__/health")
 		if err == nil {
 			t.Fatal("HTTPS GET with empty trust store unexpectedly succeeded")

--- a/pkg/security/webhook.go
+++ b/pkg/security/webhook.go
@@ -19,7 +19,7 @@ package security
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // G505: HMAC-SHA1 is mandated by the cross-SDK webhook signature contract (Compat/Twilio compatibility); used inside HMAC, not as a bare digest.
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -404,6 +404,9 @@ func (s *AgentServer) RunContext(ctx context.Context, opts ...RunOption) error {
 	// soon as serving ends (serveDone) so it never leaks past this call.
 	serveDone := make(chan struct{})
 	defer close(serveDone)
+	//nolint:gosec // G118: context.Background() in the drain goroutine below is
+	// deliberate (see comment) — using the already-cancelled ctx would abort
+	// in-flight requests instead of draining them gracefully.
 	go func() {
 		select {
 		case <-ctx.Done():

--- a/pkg/skills/builtin/api_ninjas_trivia.go
+++ b/pkg/skills/builtin/api_ninjas_trivia.go
@@ -190,6 +190,8 @@ func (s *APINinjasTriviaSkill) handleGetTrivia(args map[string]any, _ map[string
 	base = strings.TrimRight(base, "/")
 	apiURL := fmt.Sprintf("%s/v1/trivia?category=%s", base, category)
 
+	//nolint:gosec // G704: not SSRF — fixed operator-configured base host; only
+	// the category value is user-supplied. The user cannot redirect the host.
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return swaig.NewFunctionResult("Error creating trivia request.")
@@ -197,6 +199,7 @@ func (s *APINinjasTriviaSkill) handleGetTrivia(args map[string]any, _ map[string
 	req.Header.Set("X-Api-Key", s.apiKey)
 
 	client := &http.Client{Timeout: 10 * time.Second}
+	//nolint:gosec // G704: not SSRF — see request construction above (fixed host).
 	resp, err := client.Do(req)
 	if err != nil {
 		return swaig.NewFunctionResult("Sorry, I cannot get trivia questions right now.")

--- a/pkg/skills/builtin/claude_skills.go
+++ b/pkg/skills/builtin/claude_skills.go
@@ -257,6 +257,8 @@ func (s *ClaudeSkillsSkill) discoverSections(skillDir string) map[string]string 
 
 	err := filepath.Walk(skillDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			//nolint:nilerr // filepath.Walk idiom: skip this unreadable entry and
+			// keep walking — returning err would abort the whole traversal.
 			return nil
 		}
 		if info.IsDir() {
@@ -272,6 +274,8 @@ func (s *ClaudeSkillsSkill) discoverSections(skillDir string) map[string]string 
 		// Relative path from skillDir.
 		rel, err := filepath.Rel(skillDir, path)
 		if err != nil {
+			//nolint:nilerr // skip an entry whose relative path can't be computed;
+			// continue the walk rather than aborting it.
 			return nil
 		}
 
@@ -304,6 +308,8 @@ func (s *ClaudeSkillsSkill) discoverAllFiles(skillDir string) map[string][]strin
 
 	err := filepath.Walk(skillDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			//nolint:nilerr // filepath.Walk idiom: skip this unreadable entry and
+			// keep walking — returning err would abort the whole traversal.
 			return nil
 		}
 		if info.IsDir() {
@@ -315,6 +321,8 @@ func (s *ClaudeSkillsSkill) discoverAllFiles(skillDir string) map[string][]strin
 
 		rel, err := filepath.Rel(skillDir, path)
 		if err != nil {
+			//nolint:nilerr // skip an entry whose relative path can't be computed;
+			// continue the walk rather than aborting it.
 			return nil
 		}
 		parts := strings.Split(filepath.ToSlash(rel), "/")
@@ -364,6 +372,8 @@ func (s *ClaudeSkillsSkill) matchesPatterns(name string) bool {
 
 // parseSkillMD reads and parses a SKILL.md file with optional YAML frontmatter.
 func (s *ClaudeSkillsSkill) parseSkillMD(path string) (*skillEntry, error) {
+	//nolint:gosec // G304: path is a SKILL.md discovered under the operator's
+	// configured skills directory, not attacker input — reading it is the intent.
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", path, err)
@@ -518,6 +528,9 @@ func (s *ClaudeSkillsSkill) executeShellInjection(content, skillDir string, time
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 		defer cancel()
 
+		//nolint:gosec // G204: command is a !`...` macro authored inside the
+		// operator-installed SKILL.md (a trusted skill-author file, like a build
+		// script), not remote/end-user input — executing it is the feature.
 		cmd := exec.CommandContext(ctx, "sh", "-c", command)
 		cmd.Dir = skillDir
 		out, err := cmd.Output()
@@ -676,6 +689,9 @@ func (s *ClaudeSkillsSkill) RegisterTools() []skills.ToolRegistration {
 			var content string
 			if section != "" {
 				if sectionPath, ok := capturedSkill.sections[section]; ok {
+					//nolint:gosec // G304: sectionPath is looked up from the
+					// pre-discovered sections map (built by walking the operator's
+					// skill dir); the user only selects a known key, not a raw path.
 					data, err := os.ReadFile(sectionPath)
 					if err != nil {
 						slog.Error("claude_skills: failed to read section", "section", section, "error", err)

--- a/pkg/skills/builtin/joke.go
+++ b/pkg/skills/builtin/joke.go
@@ -72,6 +72,8 @@ func (s *JokeSkill) RegisterTools() []skills.ToolRegistration {
 }
 
 func (s *JokeSkill) handleTellJoke(_ map[string]any, _ map[string]any) *swaig.FunctionResult {
+	//nolint:gosec // G404: math/rand is fine here — picking a random joke to
+	// tell, no security/crypto context.
 	joke := builtinJokes[rand.Intn(len(builtinJokes))]
 	return swaig.NewFunctionResult("Here's a joke: " + joke)
 }

--- a/pkg/skills/builtin/spider/spider.go
+++ b/pkg/skills/builtin/spider/spider.go
@@ -642,6 +642,8 @@ func applySelector(doc *goquery.Document, xpathRoot *html.Node, selector string)
 		}
 		switch len(texts) {
 		case 0:
+			//nolint:nilnil // "selector matched nothing" is a valid, non-error
+			// result (documented above); callers distinguish nil from an error.
 			return nil, nil
 		case 1:
 			return texts[0], nil
@@ -652,6 +654,8 @@ func applySelector(doc *goquery.Document, xpathRoot *html.Node, selector string)
 
 	sel := doc.Find(selector)
 	if sel.Length() == 0 {
+		//nolint:nilnil // "selector matched nothing" is a valid, non-error
+		// result (documented above); callers distinguish nil from an error.
 		return nil, nil
 	}
 	if sel.Length() == 1 {

--- a/pkg/skills/builtin/weather_api.go
+++ b/pkg/skills/builtin/weather_api.go
@@ -158,6 +158,9 @@ func (s *WeatherAPISkill) handleGetWeather(args map[string]any, _ map[string]any
 	)
 
 	client := &http.Client{Timeout: 15 * time.Second}
+	//nolint:gosec // G704: not SSRF — the host/scheme come from a fixed,
+	// operator-configured base URL; only the query value is user-supplied and it
+	// is url.QueryEscape'd. The user cannot redirect the request to another host.
 	resp, err := client.Get(apiURL)
 	if err != nil {
 		return swaig.NewFunctionResult("Sorry, I cannot get weather information right now. Please try again later.")

--- a/pkg/skills/builtin/web_search.go
+++ b/pkg/skills/builtin/web_search.go
@@ -177,6 +177,9 @@ func (s *WebSearchSkill) searchGoogle(query string, numResults int) ([]searchRes
 	)
 
 	client := &http.Client{Timeout: 15 * time.Second}
+	//nolint:gosec // G704: not SSRF — the host/scheme come from a fixed,
+	// operator-configured base URL; only the query value is user-supplied and it
+	// is url.QueryEscape'd. The user cannot redirect the request to another host.
 	resp, err := client.Get(apiURL)
 	if err != nil {
 		return nil, err

--- a/pkg/skills/builtin/wikipedia_search.go
+++ b/pkg/skills/builtin/wikipedia_search.go
@@ -107,6 +107,9 @@ func (s *WikipediaSearchSkill) handleSearch(args map[string]any, _ map[string]an
 		s.numResults,
 	)
 
+	//nolint:gosec // G704: not SSRF — the host/scheme come from a fixed,
+	// operator-configured base URL; only the search term is user-supplied and it
+	// is url.QueryEscape'd. The user cannot redirect the request to another host.
 	resp, err := client.Get(searchURL)
 	if err != nil {
 		return swaig.NewFunctionResult(fmt.Sprintf("Error accessing Wikipedia: %v", err))
@@ -145,6 +148,8 @@ func (s *WikipediaSearchSkill) handleSearch(args map[string]any, _ map[string]an
 			url.QueryEscape(title),
 		)
 
+		//nolint:gosec // G704: not SSRF — fixed operator-configured base host; the
+		// title is server-derived (from the prior search) and url.QueryEscape'd.
 		extractResp, err := client.Get(extractURL)
 		if err != nil {
 			continue

--- a/pkg/swml/config_file.go
+++ b/pkg/swml/config_file.go
@@ -38,6 +38,8 @@ type configFileSchema struct {
 // which executes during NewService. At that point s.Logger is not yet
 // allocated, so warnings are written to stderr via fmt.Fprintf.
 func applyConfigFile(s *Service, path string) {
+	//nolint:gosec // G304: path is the operator-supplied WithConfigFile argument,
+	// not attacker input — reading the configured file is the intended behavior.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr,

--- a/pkg/swml/schema.go
+++ b/pkg/swml/schema.go
@@ -161,6 +161,8 @@ func (s *Schema) VerbCount() int {
 // LoadSchemaFromFile loads a SWML schema from the given file path instead of
 // the embedded schema.json. Mirrors Python's schema_path constructor param.
 func LoadSchemaFromFile(path string) (*Schema, error) {
+	//nolint:gosec // G304: path is the operator-supplied schema_path argument,
+	// not attacker input — reading the configured schema file is the intent.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read schema file %q: %w", path, err)

--- a/pkg/swml/schema_utils.go
+++ b/pkg/swml/schema_utils.go
@@ -127,6 +127,8 @@ func (s *SchemaUtils) LoadSchema() map[string]any {
 }
 
 func (s *SchemaUtils) loadFromPath(path string) map[string]any {
+	//nolint:gosec // G304: path is an operator-supplied schema path, not attacker
+	// input — reading the configured schema file is the intended behavior.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return map[string]any{}

--- a/pkg/swml/service.go
+++ b/pkg/swml/service.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/signalwire/signalwire-go/pkg/logging"
 )
@@ -1188,6 +1189,11 @@ func (s *Service) Serve() error {
 	s.server = &http.Server{
 		Addr:    addr,
 		Handler: mux,
+		// Bound the request-header read so a slow/incomplete header write
+		// (Slowloris) cannot pin a connection open indefinitely. net/http
+		// applies no header-read deadline by default, so this must be set
+		// explicitly. 20s is generous for a well-behaved SignalWire client.
+		ReadHeaderTimeout: 20 * time.Second,
 	}
 	if s.TLSEnabled() {
 		// Require TLS 1.2+ (mirrors Python's CERT_REQUIRED ssl_verify_mode default).

--- a/pkg/swml/tls_server_test.go
+++ b/pkg/swml/tls_server_test.go
@@ -133,6 +133,8 @@ func TestTLS_Server_HTTPS(t *testing.T) {
 				TLSClientConfig: &tls.Config{RootCAs: x509.NewCertPool()}, // empty pool
 			},
 		}
+		//nolint:bodyclose // expect-failure test: the request MUST fail (empty
+		// trust pool), so the response is nil on the error path — nothing to close.
 		_, err := untrusted.Get(baseURL + "/health")
 		if err == nil {
 			t.Fatal("https /health with empty trust store unexpectedly succeeded")


### PR DESCRIPTION
## Summary

A second measured **bug-finder sweep** of 7 not-yet-enabled golangci-lint linters (`nilerr`, `bodyclose`, `contextcheck`, `nilnil`, `exhaustive`, `gosec`, `noctx`), at a **low keep-threshold** (keep a linter if it could plausibly catch even one real bug someday; drop only pure noise). Every finding was triaged for a genuine defect, real bugs fixed, the high-value linters enabled, and the gate driven to **0 issues**.

## Genuine bugs found + fixed

- **Slowloris DoS — `gosec G112` on BOTH HTTP servers** (`pkg/agent/agent.go:3117`, `pkg/swml/service.go:1188`). Both `http.Server`s were constructed with **no `ReadHeaderTimeout`**, and `net/http` applies **no header-read deadline by default** — a slow/incomplete header write can pin a connection open indefinitely. Set a conservative `ReadHeaderTimeout: 20 * time.Second` on both. (The third server, `pkg/server/server.go`, was already hardened with `ReadHeaderTimeout`/`IdleTimeout`.) The Python reference runs under uvicorn, which sets its own header timeout; the raw-`net/http` Go port had no equivalent until now. **This is a real prod hardening gap.**
- **Unhandled graceful-shutdown error — `gosec G104`** (`pkg/agent/agent.go:3127`). `server.Shutdown(...)` was discarded with `//nolint:errcheck`. Now logged at `Warn` — a failed drain is genuine operational signal — which also legitimately resolves the finding (no suppression needed).

## Per-linter decision

**ENABLED (5)** — each guards a real bug class; current findings are by-design and carry a specific `//nolint`, or are scoped out via config:

| Linter | Decision rationale |
|---|---|
| **gosec** | Caught the Slowloris; guards SSRF/weak-crypto/path-traversal. Test + `cmd/*` + `internal/*` (codegen tables, mocktest harnesses) paths excluded via `.golangci.yml` (not prod attack surface). 18 prod `//nolint:gosec` with G-code reasons. |
| **bodyclose** | Real response-body leak guard. 4 `//nolint`: gorilla/websocket dial (lib closes the handshake body per its contract) + 3 expect-failure TLS tests (resp is `nil` on the error path). |
| **nilerr** | Real swallowed-error class. 5 `//nolint`: the `filepath.Walk` continue-on-error idiom (4) + a CLI raw-output fallback (1). |
| **nilnil** | Ambiguous `(nil, nil)`. 3 `//nolint`: no-result SWAIG handler (mirrors Python returning `None`) + selector-matched-nothing (documented contract). |
| **exhaustive** | Missing-enum-arm bug. `default-signifies-exhaustive: true` covers the by-design subset switches (`go/token.Token` calculator, `reflect.Kind`, `ExecutionMode`); 1 `//exhaustive:ignore` on `MessageState.IsTerminal` (default-less subset switch). Still fires on a genuinely missing arm. |

**DROPPED (2)** — pure noise here, ~zero realistic true positive (documented in `.golangci.yml`):

- **contextcheck** — 6 findings, all the defensive `if ctx == nil { ctx = context.Background() }` guard on `RunContext`/`DialContext` + the deliberate `Background()` drain that must outlive a cancelled ctx; the port threads ctx correctly. 0 real ctx-drops.
- **noctx** — 103 findings (88 tests, 15 prod). The SWAIG/skill handler API `func(args, rawData) any` is **context-free by Python parity**, so the prod call sites can never thread a caller ctx — structurally unfixable, no future-bug potential.

## Suppressions

**30 `//nolint`** (18 gosec, 5 nilerr, 4 bodyclose, 3 nilnil) **+ 1 `//exhaustive:ignore`**, each with a specific one-line rationale matching the repo's existing nolint style. No blanket disables; no correct code rewritten to dodge a linter. gosec test/codegen noise (~36 sites) handled via scoped `.golangci.yml` `exclusions.rules` rather than scattering nolints, per maintainer guidance.

## CI

Full `scripts/run-ci.sh` → **`==> CI PASS`** (all 13 gates green, including **LINT** with the new linters and the DRIFT/SURFACE-FRESH/EMISSION gates — confirming the edits introduced **no surface drift**). `go test ./...`, `go vet ./...`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
